### PR TITLE
added / editor route and download locally

### DIFF
--- a/app/(signed)/editor/page.tsx
+++ b/app/(signed)/editor/page.tsx
@@ -16,7 +16,14 @@ const EditorPage = () => {
       Editor Page
       <div className="col-span-2">
         {initialUrl && (
-          <video src={initialUrl} controls className="w-full rounded" />
+          <>
+            <video src={initialUrl} controls className="w-full rounded" />
+            <a href={initialUrl} download="recording.webm">
+              <button className="btn mt-2 bg-blue-500 text-white px-4 py-2 rounded">
+                Download Recording
+              </button>
+            </a>
+          </>
         )}
       </div>
       <div>

--- a/app/(signed)/recorder/page.tsx
+++ b/app/(signed)/recorder/page.tsx
@@ -1,5 +1,7 @@
 "use client";
+import React from "react";
 import { useScreenRecorder } from "@/app/hooks/useScreenRecorder";
+import { useRouter } from "next/navigation";
 
 const RecorderPage = () => {
   const {
@@ -10,6 +12,15 @@ const RecorderPage = () => {
     recording,
     videoUrl,
   } = useScreenRecorder();
+
+  const router = useRouter();
+
+  // Redirect to /editor when videoUrl is set
+  React.useEffect(() => {
+    if (videoUrl) {
+      router.push(`/editor?video=${encodeURIComponent(videoUrl)}`); // Redirected the preview to editor page
+    }
+  }, [videoUrl, router]);
 
   return (
     <div className="p-8">
@@ -41,19 +52,6 @@ const RecorderPage = () => {
         >
           Stop Recording
         </button>
-      )}
-
-      {/* Video Preview */}
-      {videoUrl && (
-        <div className="mt-4">
-          <h2 className="text-lg">Preview:</h2>
-          <video src={videoUrl} controls className="mt-2" width={600} />
-          <a href={videoUrl} download="recording.webm">
-            <button className="btn mt-2 bg-blue-500 text-white px-4 py-2 rounded">
-              Download Recording
-            </button>
-          </a>
-        </div>
       )}
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "next-auth": "^4.24.11",
         "prisma": "^6.7.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1799,7 +1800,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2832,7 +2833,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6912,6 +6913,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }


### PR DESCRIPTION

**Screen Recording Flow Refactor & Bug Fixes**

1. Refactored the screen recording flow:

- The /recorder page now only handles recording controls (start/stop, microphone toggle).

- After recording, users are automatically redirected to the /editor page with the recorded video URL as a query parameter.

2.  Moved the video preview and download button to the /editor page:

- The /editor page now displays the recorded video and provides a download button 

3. Fixed a bug with the "use client" directive by placing it at the top of the file. 
4. Added the missing import React from "react" to resolve a "React is not defined" error.
5. Cleaned up code to ensure proper separation of concerns between recording and editing.
6. General improvements to user experience and code organization.