### PR TITLE
Feat/dashboard ssr share links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ next-env.d.ts
 
 ##dev 
 task.md
+
+/// addding the fix shareable links in the schema 

--- a/app/(signed)/dashboard/DashboardClient.tsx
+++ b/app/(signed)/dashboard/DashboardClient.tsx
@@ -6,7 +6,21 @@ export const metadata = {
   iconSRC: "/icons/Vector (1).svg",
   iconALT: "dashboard_icon",
 };
-const DashboardPage = () => {
+
+interface DashboardClientProps {
+  totalCount: number;
+  initialDemos: {
+    id: string;
+    title: string;
+    description: string | null;
+    videoUrl: string;
+    startTime?: string | null;
+    endTime?: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }[];
+}
+const DashboardPage = ({ totalCount, initialDemos }: DashboardClientProps) => {
   const { status } = useSession();
 
   if (status === "loading") {
@@ -24,7 +38,7 @@ const DashboardPage = () => {
       }}
     >
       <div className="flex flex-col gap-3 md:gap-4">
-        <DashboardMain />
+        <DashboardMain totalCount={totalCount} initialDemos={initialDemos} />
       </div>
     </div>
   );

--- a/app/(signed)/dashboard/page.tsx
+++ b/app/(signed)/dashboard/page.tsx
@@ -1,8 +1,45 @@
 import { getPageMetadata } from "@/app/lib/metadata";
+import { getServerSession } from "next-auth";
 import DashboardClient from "./DashboardClient";
+import { prisma } from "@/app/lib/prisma";
+import { authOptions } from "@/app/lib/auth/options";
 
 export const metadata = getPageMetadata("dashboard");
 
-export default function Page() {
-  return <DashboardClient />;
+export default async function Page() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return null;
+  }
+
+  //query the total count
+  const totalCount = await prisma.demo.count({
+    where: {
+      userId: session.user.id,
+    },
+  });
+
+  //querying the recent demos(list)
+  const recentDemos = await prisma.demo.findMany({
+    where: {
+      userId: session.user.id,
+    },
+    orderBy: {
+      updatedAt: "desc",
+    },
+  });
+
+  const cleanDemos = recentDemos.map((demo) => ({
+    id: demo.id,
+    title: demo.title,
+    description: demo.description,
+    videoUrl: demo.videoUrl,
+    startTime: demo.startTime,
+    endTime: demo.endTime,
+    createdAt: demo.createdAt.toISOString(),
+    updatedAt: demo.updatedAt.toISOString(),
+  }));
+
+  return <DashboardClient totalCount={totalCount} initialDemos={cleanDemos} />;
 }

--- a/app/(signed)/demos/DemosClient.tsx
+++ b/app/(signed)/demos/DemosClient.tsx
@@ -18,18 +18,20 @@ import { useRouter } from "next/navigation";
 import axios from "axios";
 import { formatDate, formatTime_2 } from "@/app/lib/dateTimeUtils";
 import ConfirmDeleteModal from "../../components/ConfirmDeleteModal";
+import ShareModal from "../../components/ShareModal";
 
 export const metadata = {
   titleText: "My Demos",
   iconSRC: "/Group.png",
 };
+
 interface Demo {
   id: string;
   title: string;
   description: string;
   videoUrl: string;
-  startTime: string;
-  endTime: string;
+  startTime?: string;
+  endTime?: string;
   segments?: unknown;
   createdAt: string;
   updatedAt: string;
@@ -52,6 +54,7 @@ export default function DemosPage() {
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [selectedDemoId, setSelectedDemoId] = useState<string | null>(null);
 
   const fetchDemos = async () => {
     try {
@@ -99,8 +102,8 @@ export default function DemosPage() {
   const handleEditDemo = (demo: Demo) => {
     const params = new URLSearchParams({
       video: demo.videoUrl,
-      startTime: demo.startTime,
-      endTime: demo.endTime,
+      startTime: demo.startTime || "",
+      endTime: demo.endTime || "",
       title: demo.title || "",
       description: demo.description || "",
     });
@@ -329,11 +332,20 @@ export default function DemosPage() {
                   </div>
                   <div className="text-sm text-[#8B8B8B] mb-4">
                     <div>
-                      Duration: {formatTime_2(demo.startTime)} - {formatTime_2(demo.endTime)}
+                      Duration: {formatTime_2(demo.startTime || "")} -{" "}
+                      {formatTime_2(demo.endTime || "")}
                     </div>
                     <div className="truncate">{demo.description || "No description"}</div>
                   </div>
-                  <button className="bg-[#A594F9] text-white rounded-lg px-6 py-3 w-full text-lg font-medium flex items-center justify-center gap-2 mt-auto">
+                  {/* this is the shareable links  */}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      console.log(`selected : ${selectedDemoId}`);
+                      setSelectedDemoId(demo.id);
+                    }}
+                    className="bg-[#A594F9] text-white rounded-lg px-6 py-3 w-full text-lg font-medium flex items-center justify-center gap-2 mt-auto cursor-pointer"
+                  >
                     <FaShareAlt /> Share
                   </button>
                 </div>
@@ -386,7 +398,11 @@ export default function DemosPage() {
                       <td className="py-4 px-6 flex gap-4 items-center">
                         <button
                           className="text-[#A594F9] hover:text-[#7C6FEF] text-xl cursor-pointer"
-                          onClick={(e) => e.stopPropagation()}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            console.log(`selected : ${selectedDemoId}`);
+                            setSelectedDemoId(demo.id);
+                          }}
                         >
                           <FaShareAlt />
                         </button>
@@ -415,6 +431,9 @@ export default function DemosPage() {
           )}
         </div>
       </div>
+      {selectedDemoId && (
+        <ShareModal demoId={selectedDemoId} onClose={() => setSelectedDemoId(null)} />
+      )}
 
       <ConfirmDeleteModal
         isOpen={isModalOpen}

--- a/app/(signed)/demos/page.tsx
+++ b/app/(signed)/demos/page.tsx
@@ -3,6 +3,6 @@ import DemosClient from "./DemosClient";
 
 export const metadata = getPageMetadata("demos");
 
-export default function Page() {
+export default async function Page() {
   return <DemosClient />;
 }

--- a/app/(signed)/view/[id]/page.tsx
+++ b/app/(signed)/view/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { prisma } from "@/app/lib/prisma";
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const video = await prisma.demo.findUnique({
+    where: { id },
+  });
+
+  if (!video) {
+    return <div>Video not found</div>;
+  }
+
+  return (
+    <div>
+      <h1>{video.title}</h1>
+      <video src={video.videoUrl} controls width="100%" />
+    </div>
+  );
+}

--- a/app/components/DashboardMain.tsx
+++ b/app/components/DashboardMain.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Image from "next/image";
 import Link from "next/link";
-import axios from "axios";
 import { formatDate } from "@/app/lib/dateTimeUtils";
 import { Play } from "lucide-react";
 
@@ -10,10 +9,10 @@ import { useRouter } from "next/navigation";
 interface Demo {
   id: string;
   title: string;
-  description: string;
+  description: string | null;
   videoUrl: string;
-  startTime: string;
-  endTime: string;
+  startTime?: string | null;
+  endTime?: string | null;
   segments?: unknown;
   createdAt: string;
   updatedAt: string;
@@ -22,41 +21,20 @@ interface Demo {
     zoom?: unknown;
   };
 }
-const DashboardMain = () => {
-  const [demos, setDemos] = useState<Demo[]>([]);
+
+interface DashboardMainProps {
+  initialDemos: Demo[];
+  totalCount: number;
+}
+
+const DashboardMain = ({ initialDemos, totalCount }: DashboardMainProps) => {
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchDemos = async () => {
-      try {
-        setIsLoading(true);
-        const response = await axios.get("/api/demo");
-        console.log("Fetched demos:", response.data);
-        setDemos(response.data.demos || []);
-      } catch (err: unknown) {
-        console.error("Error fetching demos:", err);
-
-        if (axios.isAxiosError(err)) {
-          const errMsg = err.response?.data?.message || "Failed to fetch demos";
-          console.log(errMsg);
-        } else {
-          const errMsg = "Failed to fetch demos";
-          console.log(errMsg);
-        }
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchDemos();
-  }, []);
 
   const handleEditDemo = (demo: Demo) => {
     const params = new URLSearchParams({
       video: demo.videoUrl,
-      startTime: demo.startTime,
-      endTime: demo.endTime,
+      ...(demo.startTime && { startTime: demo.startTime }),
+      ...(demo.endTime && { endTime: demo.endTime }),
       title: demo.title || "",
       description: demo.description || "",
     });
@@ -76,6 +54,9 @@ const DashboardMain = () => {
 
     router.push(`/editor?${params.toString()}`);
   };
+  const isLoading = false;
+
+  const demos = initialDemos;
 
   return (
     <div
@@ -298,7 +279,9 @@ const DashboardMain = () => {
               </span>
             </div>
             <div className="text-xs sm:text-sm md:text-lg font-medium text-black">Total Demos</div>
-            <div className="text-xl sm:text-2xl md:text-3xl font-bold text-[#261753]/72">0</div>
+            <div className="text-xl sm:text-2xl md:text-3xl font-bold text-[#261753]/72">
+              {totalCount}
+            </div>
             <div className="text-xs text-green-600 font-semibold mt-1">
               +12% <span className="text-gray-500 font-normal text-xs">vs last month</span>
             </div>
@@ -319,7 +302,7 @@ const DashboardMain = () => {
             <div className="text-xs sm:text-sm md:text-lg font-medium text-black">Total Views</div>
             <div className="text-xl sm:text-2xl md:text-3xl font-bold text-[#261753]/72">0</div>
             <div className="text-xs text-green-600 font-semibold mt-1">
-              +23% <span className="text-gray-500 font-normal text-xs">vs last month</span>
+              +23%{""} <span className="text-gray-500 font-normal text-xs">vs last month</span>
             </div>
           </div>
 
@@ -361,7 +344,7 @@ const DashboardMain = () => {
             </div>
             <div className="text-xl sm:text-2xl md:text-3xl font-bold text-[#261753]/72">0</div>
             <div className="text-xs text-green-600 font-semibold mt-1">
-              +8% <span className="text-gray-500 font-normal text-xs">vs last month</span>
+              +8%{""} <span className="text-gray-500 font-normal text-xs"> vs last month</span>
             </div>
           </div>
         </div>
@@ -484,8 +467,7 @@ const DashboardMain = () => {
                 </span>
               </div>
               <div className="text-white text-xs sm:text-sm md:text-base mb-3 sm:mb-4 md:mb-6 leading-relaxed">
-                Ready to help you create better demos with smart suggestions and auto generated
-                content.
+                Ready to help you create better demos with smart suggestions and content.
               </div>
             </div>
             <button className="w-full py-1.5 sm:py-2 md:py-3 bg-white/40 text-white font-semibold rounded-md transition-all text-xs sm:text-sm md:text-base transform hover:bg-white/60 hover:scale-105">
@@ -512,7 +494,7 @@ const DashboardMain = () => {
                   <div className="font-bold text-[#2D2154] text-xs sm:text-sm md:text-base">
                     User Onboarding
                   </div>
-                  <div className="text-gray-500 text-xs">Guide new users through setup</div>
+                  <div className="text-gray-500 text-xs"> Guide new users through setup</div>
                 </div>
               </div>
 

--- a/app/components/ShareModal.tsx
+++ b/app/components/ShareModal.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+interface Props {
+  demoId: string;
+  onClose: () => void;
+}
+
+export default function ShareModal({ demoId, onClose }: Props) {
+  const link = `${window.location.origin}/view/${demoId}`;
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box">
+        <h2>Share this Demo</h2>
+        <input value={link} readOnly />
+        <button onClick={() => navigator.clipboard.writeText(link)}>Copy Link</button>
+        <button onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+}

--- a/app/lib/dateTimeUtils.ts
+++ b/app/lib/dateTimeUtils.ts
@@ -35,6 +35,9 @@ export const formatDate = (dateString: string) => {
 
 export const formatTime_2 = (timeString: string) => {
   // Check if timeString is in "HH:MM:SS" format
+  if (!timeString) {
+    return "00:00:00";
+  }
   if (timeString.includes(":")) {
     const parts = timeString.split(":").map(Number);
     if (parts.length === 3) {

--- a/prisma/migrations/20260218132656_init/migration.sql
+++ b/prisma/migrations/20260218132656_init/migration.sql
@@ -1,0 +1,59 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[publicLink]` on the table `Demo` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Demo" ADD COLUMN     "isPublic" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "publicLink" TEXT,
+ALTER COLUMN "startTime" DROP NOT NULL,
+ALTER COLUMN "endTime" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "Tutorial" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Tutorial_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Slide" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "imageUrl" TEXT NOT NULL,
+    "clicks" JSONB,
+    "timestamp" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "tutorialId" TEXT NOT NULL,
+
+    CONSTRAINT "Slide_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "View" (
+    "id" TEXT NOT NULL,
+    "demoId" TEXT NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "duration" INTEGER,
+
+    CONSTRAINT "View_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Demo_publicLink_key" ON "Demo"("publicLink");
+
+-- AddForeignKey
+ALTER TABLE "Tutorial" ADD CONSTRAINT "Tutorial_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Slide" ADD CONSTRAINT "Slide_tutorialId_fkey" FOREIGN KEY ("tutorialId") REFERENCES "Tutorial"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "View" ADD CONSTRAINT "View_demoId_fkey" FOREIGN KEY ("demoId") REFERENCES "Demo"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,10 +81,13 @@ model Demo {
   title       String
   description String?
   videoUrl    String
+  startTime   String?
+  endTime     String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   editing     Json? 
-  publicLink  String @unique
+  publicLink  String? @unique
+  views View[]
   isPublic    Boolean  @default(false)
   userId      String
   user        User     @relation(fields: [userId], references: [id])
@@ -111,4 +114,12 @@ model Slide {
   createdAt   DateTime @default(now())
   tutorialId  String
   tutorial    Tutorial @relation(fields: [tutorialId], references: [id], onDelete: Cascade)
+}
+
+model View {
+  id String  @id @default(cuid())  
+  demoId String
+  demo Demo @relation(fields: [demoId], references : [id])
+  timestamp DateTime @default(now())
+  duration Int?
 }


### PR DESCRIPTION
- Migrated dashboard to SSR — Total Demos count is now fetched server-side and passed as a prop instead of being hardcoded
- Improved initial page load accuracy; data reflects real DB state on first render
- Share button now generates a unique, shareable link per demo
- Link can be copied and shared externally with viewers
- Added View model to track demo views
- Updated Demo model with new fields to support schema changes
- Ran Prisma migration accordingly