### PR TITLE
feat: client-side video trimming, audio mixing, and editor improvements

### DIFF
--- a/app/(signed)/editor/EditorClient.tsx
+++ b/app/(signed)/editor/EditorClient.tsx
@@ -8,6 +8,7 @@ import { Toaster, toast } from "react-hot-toast";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import ReactPlayer from "react-player";
+import { videoTrimmer } from "@/app/lib/ffmpeg";
 //import Image from "next/image";
 
 // Components
@@ -244,6 +245,43 @@ export default function EditorPage() {
 
   const toggleDashboardMenu = () => {
     setIsDashboardMenuOpen(!isDashboardMenuOpen);
+  };
+
+  // Delete Trim handler
+  const onDeleteTrimmedDemo = async (segmentToDelete: { start: number; end: number }) => {
+    if (!videoUrl) {
+      return;
+    }
+
+    //convert seconds to hh:mm:ss
+    const secondsToTime = (sec: number): string => {
+      const h = Math.floor(sec / 3600);
+      const m = Math.floor((sec % 3600) / 60);
+      const s = Math.floor(sec % 60);
+      return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+    };
+
+    const response = await fetch(videoUrl);
+    let currentBlob = await response.blob();
+
+    //getting all the segments
+    const sortedSegments = [...segments]
+      .filter((seg) =>
+        seg.start === segmentToDelete.start && seg.end === segmentToDelete.end ? true : true
+      )
+      .sort((a, b) => b.start - a.start);
+
+    for (const seg of sortedSegments) {
+      const start = secondsToTime(seg.start);
+      const end = secondsToTime(seg.end);
+      currentBlob = await videoTrimmer(currentBlob, start, end);
+    }
+
+    const newUrl = URL.createObjectURL(currentBlob);
+    setVideoUrl(newUrl);
+    setDuration(0);
+
+    setSegments([]);
   };
 
   // Save demo handler
@@ -601,7 +639,7 @@ export default function EditorPage() {
               </button>
             </div>
           )}
-          {videoUrl && (
+          {/* {videoUrl && (
             <div className="flex justify-center mt-6 mb-6 ml-">
               <button
                 onClick={() => setShowSaveDemoModal(true)}
@@ -611,7 +649,8 @@ export default function EditorPage() {
                 {savingDemo ? "Saving..." : demoSaved ? "Saved" : "Save Demo"}
               </button>
             </div>
-          )}
+          )} */}
+          <div className="mt-5"></div>
           {/* Video Wrapper */}
           <div
             className={
@@ -622,7 +661,7 @@ export default function EditorPage() {
             {/* Video container */}
             <div
               ref={videoContainerRef}
-              className={`relative w-[900px] sm:h-auto sm:aspect-video rounded-2xl border ${
+              className={`relative w-[1000px] sm:h-auto sm:aspect-video rounded-2xl border ${
                 isFullscreen ? "border-[#7C5CFC] shadow-lg" : "border-[#E6E1FA]"
               } flex flex-col items-center justify-center mb-1 transition-all duration-300`}
               style={{
@@ -806,6 +845,7 @@ export default function EditorPage() {
             <div className="mr-2 mt-8 mb-5 pr-8 sm:mr-0 mx-4 sm:mx-8">
               {duration > 0 ? (
                 <TimelineRuler
+                  onDeleteSegment={onDeleteTrimmedDemo}
                   minValue={0}
                   maxValue={duration}
                   currentValue={Math.max(0, currentTime)}

--- a/app/(signed)/editor/utils/videoHandlers.ts
+++ b/app/(signed)/editor/utils/videoHandlers.ts
@@ -284,7 +284,7 @@ export async function videoTrimHandler(
 
     // 5. Convert back to HH:MM:SS for your existing ffmpeg code
     const newNormalizedSegments = keepSegments.map((seg) => {
-      console.log("dgfg", seg);
+      console.log("newNormalizedSegments", seg);
       return {
         start: secondsToTime(seg.start),
         end: secondsToTime(seg.end),

--- a/app/api/trim/route.ts
+++ b/app/api/trim/route.ts
@@ -8,7 +8,7 @@ export async function POST() {
   return NextResponse.json(
     {
       error:
-        "Video trimming has been moved to client-side processing. Use the videoTrimmer function from app/lib/ffmpeg.ts instead.",
+        "Video trimming has been moved to client-side processing.   Use the videoTrimmer function from app/lib/ffmpeg.ts instead.",
     },
     { status: 501 }
   );

--- a/app/components/EditorSidebar.tsx
+++ b/app/components/EditorSidebar.tsx
@@ -274,7 +274,7 @@ const EditorSidebar: React.FC<EditorSidebarProps> = ({
         </button>
       </div>
 
-      {/* BACKGROUND TAB */}
+      {/* cd  TAB */}
       {activeTab === "background" && (
         <div className="space-y-4">
           <div className="flex items-center justify-between">

--- a/app/components/TimeLine.tsx
+++ b/app/components/TimeLine.tsx
@@ -28,6 +28,8 @@ interface TimelineRulerProps {
   playing: boolean;
   isFullscreen: boolean;
   handleFullscreen: () => void;
+  //to handle the trimmed video part
+  onDeleteSegment: (segment: { start: number; end: number }) => void;
   //videourl: string;
   //setVideoUrl: React.Dispatch<React.SetStateAction<string | null>>;
   mode: "main" | "trim" | "zoom";
@@ -68,6 +70,7 @@ export default function TimelineRuler({
   mode,
   setMode,
   playerRef,
+  onDeleteSegment,
   setChildHandleProgress,
   //onZoomChange,
   zoomSegments,
@@ -451,8 +454,10 @@ export default function TimelineRuler({
   // };
 
   const removeSegment = (idx: number) => {
+    onDeleteSegment(segments[idx]);
     const newSegments = segments.filter((_, i) => i !== idx);
     setSegments(newSegments);
+
     const newActiveSegment = Math.min(activeSegment, newSegments.length - 1);
     setActiveSegment(-1);
     if (newSegments[newActiveSegment]) {
@@ -960,6 +965,7 @@ export default function TimelineRuler({
   };
   // const [open, setOpen] = useState(false);
   return (
+    //this is to handle zoom click
     <div className="w-full max-w-6xl mx-auto">
       <div className="flex flex-row items-center justify-between w-full mb-6 gap-3 sm:gap-6 ">
         <div className="flex gap-3 sm:gap-4 items-center">
@@ -984,7 +990,7 @@ export default function TimelineRuler({
             />
             Add Segment
           </button> */}
-
+          {/* this is to handle the trim */}
           <button
             onClick={handleSmartTrim}
             disabled={processing}
@@ -1105,6 +1111,7 @@ export default function TimelineRuler({
           >
             <Image src="/icons/Group 316.svg" alt="fullscreen" width={18.67} height={21} />
           </button>
+          {/* this is delete button */}
           <button
             onClick={() => removeSegment(activeSegment)}
             disabled={segments.length === 0 || activeSegment === -1 || mode === "main"}

--- a/app/hooks/useScreenRecorder.ts
+++ b/app/hooks/useScreenRecorder.ts
@@ -19,6 +19,8 @@ export const useScreenRecorder = () => {
 
   const startRecording = async () => {
     try {
+      const audioContext = new AudioContext();
+      const destination = audioContext.createMediaStreamDestination();
       if (!screenStreamRef.current) {
         return;
       }
@@ -35,10 +37,20 @@ export const useScreenRecorder = () => {
         }
       }
 
+      if (screenStreamRef.current.getAudioTracks().length > 0) {
+        const tabSource = audioContext.createMediaStreamSource(
+          new MediaStream(screenStreamRef.current.getAudioTracks())
+        );
+        tabSource.connect(destination);
+      }
+      if (micStream) {
+        const micSource = audioContext.createMediaStreamSource(micStream);
+        micSource.connect(destination);
+      }
+
       const combinedStream = new MediaStream([
         ...screenStreamRef.current.getVideoTracks(),
-        ...screenStreamRef.current.getAudioTracks(),
-        ...(micStream ? micStream.getAudioTracks() : []),
+        ...destination.stream.getAudioTracks(),
       ]);
 
       const chunks: Blob[] = [];

--- a/app/lib/ffmpeg.ts
+++ b/app/lib/ffmpeg.ts
@@ -9,7 +9,7 @@ export const videoTrimmer = async (inputBlob: Blob, start: string, end: string):
   const { createFFmpeg } = await import("@ffmpeg/ffmpeg");
   const ffmpeg = createFFmpeg({
     log: true,
-    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0",
+    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/dist/ffmpeg-core.js",
   });
   if (!ffmpeg.isLoaded()) {
     await ffmpeg.load();
@@ -40,43 +40,73 @@ export const videoTrimmer = async (inputBlob: Blob, start: string, end: string):
   ffmpeg.FS("writeFile", inputName, new Uint8Array(await inputBlob.arrayBuffer()));
 
   // Get video duration
-  let duration = 0;
+
   // Skipping log parsing for duration due to lack of public API in ffmpeg.wasm
   // Instead, fallback to a large number (should be longer than any real video)
-  duration = 999999;
-
   const startSec = toSeconds(start);
   const endSec = toSeconds(end);
 
-  // Compose filter_complex for trim and concat
-  // [0:v]trim=0:start,setpts=PTS-STARTPTS[v0];[0:a]atrim=0:start,asetpts=PTS-STARTPTS[a0];
-  // [0:v]trim=end:duration,setpts=PTS-STARTPTS[v1];[0:a]atrim=end:duration,asetpts=PTS-STARTPTS[a1];
-  // [v0][a0][v1][a1]concat=n=2:v=1:a=1[outv][outa]
-  const filter =
-    `[0:v]trim=0:${startSec},setpts=PTS-STARTPTS[v0];` +
-    `[0:a]atrim=0:${startSec},asetpts=PTS-STARTPTS[a0];` +
-    `[0:v]trim=${endSec}:${duration},setpts=PTS-STARTPTS[v1];` +
-    `[0:a]atrim=${endSec}:${duration},asetpts=PTS-STARTPTS[a1];` +
-    "[v0][a0][v1][a1]concat=n=2:v=1:a=1[outv][outa]";
+  // // Audio+Video filter (works when recording has audio)
+  // const filterWithAudio =
+  //   `[0:v]trim=0:${startSec},setpts=PTS-STARTPTS[v0];` +
+  //   `[0:a]atrim=0:${startSec},asetpts=PTS-STARTPTS[a0];` +
+  //   `[0:v]trim=${endSec}:${duration},setpts=PTS-STARTPTS[v1];` +
+  //   `[0:a]atrim=${endSec}:${duration},asetpts=PTS-STARTPTS[a1];` +
+  //   "[v0][a0][v1][a1]concat=n=2:v=1:a=1[outv][outa]";
 
+  // // Video-only filter (fallback when no audio stream exists)
+  // const filterVideoOnly =
+  //   `[0:v]trim=0:${startSec},setpts=PTS-STARTPTS[v0];` +
+  //   `[0:v]trim=${endSec}:${duration},setpts=PTS-STARTPTS[v1];` +
+  //   "[v0][v1]concat=n=2:v=1:a=0[outv]";
+
+  // Concat demuxer approach: split into parts → join with stream copy
+  // filter_complex always re-encodes even with -c copy. Concat demuxer is truly instant.
+
+  // Step 1: Extract the parts to KEEP (inverse of the cut segment)
+  // Part 1: 0 → startSec
+  // Part 2: endSec → end of video
+  const parts: string[] = [];
+
+  if (startSec > 0) {
+    const part1Name = "part1.webm";
+    try {
+      await ffmpeg.run(
+        "-i",
+        inputName,
+        "-ss",
+        "0",
+        "-to",
+        String(startSec),
+        "-c",
+        "copy",
+        part1Name
+      );
+      ffmpeg.FS("readFile", part1Name); // verify it exists
+      parts.push(part1Name);
+    } catch {
+      console.warn("Part 1 extraction failed");
+    }
+  }
+
+  const part2Name = "part2.webm";
   try {
-    await ffmpeg.run(
-      "-i",
-      inputName,
-      "-filter_complex",
-      filter,
-      "-map",
-      "[outv]",
-      "-map",
-      "[outa]",
-      "-c:v",
-      "libvpx",
-      "-c:a",
-      "libvorbis",
-      outputName
-    );
+    await ffmpeg.run("-i", inputName, "-ss", String(endSec), "-c", "copy", part2Name);
+    ffmpeg.FS("readFile", part2Name); // verify it exists
+    parts.push(part2Name);
+  } catch {
+    console.warn("Part 2 extraction failed");
+  }
+
+  // Step 2: Write concat list file
+  const concatList = parts.map((p) => `file '${p}'`).join("\n");
+  ffmpeg.FS("writeFile", "concat.txt", new TextEncoder().encode(concatList));
+
+  // Step 3: Join parts with stream copy (instant)
+  try {
+    await ffmpeg.run("-f", "concat", "-safe", "0", "-i", "concat.txt", "-c", "copy", outputName);
   } catch (err) {
-    console.error("FFmpeg filter_complex error", err);
+    console.error("Concat failed:", err);
     throw new Error("Failed to trim and concatenate video segments");
   }
 
@@ -93,7 +123,7 @@ export const videoToMP4 = async (inputBlob: Blob): Promise<Blob> => {
   const { createFFmpeg } = await import("@ffmpeg/ffmpeg");
   const ffmpeg = createFFmpeg({
     log: true,
-    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0",
+    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/dist/ffmpeg-core.js",
   });
   if (!ffmpeg.isLoaded()) {
     await ffmpeg.load();
@@ -122,7 +152,7 @@ export const videoToThumbnail = async (inputBlob: Blob): Promise<Blob> => {
   const { createFFmpeg } = await import("@ffmpeg/ffmpeg");
   const ffmpeg = createFFmpeg({
     log: true,
-    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0",
+    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/dist/ffmpeg-core.js",
   });
   if (!ffmpeg.isLoaded()) {
     await ffmpeg.load();
@@ -144,7 +174,7 @@ export const videoToMP4WithOverlays = async (
   const { createFFmpeg } = await import("@ffmpeg/ffmpeg");
   const ffmpeg = createFFmpeg({
     log: true,
-    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0",
+    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/dist/ffmpeg-core.js",
   });
   if (!ffmpeg.isLoaded()) {
     await ffmpeg.load();
@@ -192,7 +222,7 @@ function generateFFmpegFilters(overlays: Overlay[]): string {
         case "rect":
           return `drawbox=x=${o.x}:y=${o.y}:w=${o.w}:h=${o.h}:color=red@0.6:t=2`;
         case "arrow":
-          return `drawbox=x=${o.x}:y=${o.y}:w=2:h=2:color=yellow@1.0:t=fill`; // Approximation
+          return `drawbox=x=${o.x}:y=${o.y}:w=2:h=2:color=yellow@1.0:t=fill`;
         case "text":
           return `drawtext=text='${o.text}':x=${o.x}:y=${o.y}:fontsize=20:fontcolor=white`;
       }
@@ -204,7 +234,7 @@ export const videoToMP3 = async (inputBlob: Blob): Promise<Blob> => {
   const { createFFmpeg } = await import("@ffmpeg/ffmpeg");
   const ffmpeg = createFFmpeg({
     log: true,
-    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0",
+    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/dist/ffmpeg-core.js",
   });
   if (!ffmpeg.isLoaded()) {
     await ffmpeg.load();

--- a/next.config.ts
+++ b/next.config.ts
@@ -34,7 +34,6 @@ const nextConfig: NextConfig = {
         ...config.externals,
         "fluent-ffmpeg": "fluent-ffmpeg",
         "ffmpeg-static": "ffmpeg-static",
-        "@ffmpeg/ffmpeg": "commonjs @ffmpeg/ffmpeg",
       };
     } else {
       // For server, mark these as external to avoid module resolution issues

--- a/prisma/migrations/20260223183742_latest/migration.sql
+++ b/prisma/migrations/20260223183742_latest/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Demo" ADD COLUMN     "subtitles" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,7 +85,8 @@ model Demo {
   endTime     String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
-  editing     Json? 
+  editing     Json?
+  subtitles   Json?
   shareCount Int @default(0)
   publicLink  String? @unique
   views View[]
@@ -123,4 +124,4 @@ model View {
   demo Demo @relation(fields: [demoId], references : [id])
   timestamp DateTime @default(now())
   duration Int?
-}
+} 


### PR DESCRIPTION
- Implemented client-side video trimming using FFmpeg WASM (concat demuxer, stream copy — near-instant)
- Connected delete button on trim segments to actually modify the video, not just the UI
- Fixed audio recording to capture both tab audio and microphone simultaneously
- Removed duplicate Save Demo button from editor to increase video player display area
- Fixed FFmpeg core CDN path for correct WASM loading