### PR TITLE
fix: require auth and scope DELETE /api/demo to owner

### DIFF
--- a/app/api/demo/route.ts
+++ b/app/api/demo/route.ts
@@ -40,9 +40,20 @@ export async function DELETE(req: NextRequest) {
   }
 
   try {
-    await prisma.demo.delete({
-      where: { id },
+    const session = await getServerSession(authOptions);
+
+    if (!session || !session.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Scope the delete to the logged-in user so a demo can only be deleted by its owner.
+    const result = await prisma.demo.deleteMany({
+      where: { id, userId: session.user.id },
     });
+
+    if (result.count === 0) {
+      return NextResponse.json({ error: "Demo not found" }, { status: 404 });
+    }
 
     return NextResponse.json({ message: "Demo deleted successfully" });
   } catch (error) {

--- a/app/api/demo/route.ts
+++ b/app/api/demo/route.ts
@@ -33,17 +33,17 @@ export async function GET() {
 
 //Current session strategy is set to use jwt, entry in the Session table will only be created when set to "database"
 export async function DELETE(req: NextRequest) {
-  const id = req.nextUrl.searchParams.get("id");
-
-  if (!id) {
-    return NextResponse.json({ message: "Demo Id could not be found." }, { status: 404 });
-  }
-
   try {
     const session = await getServerSession(authOptions);
 
     if (!session || !session.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const id = req.nextUrl.searchParams.get("id");
+
+    if (!id) {
+      return NextResponse.json({ message: "Demo Id could not be found." }, { status: 400 });
     }
 
     // Scope the delete to the logged-in user so a demo can only be deleted by its owner.


### PR DESCRIPTION
Fixes  #178
## Summary

`DELETE /api/demo` had no authentication and no ownership check, anyone could delete any demo by id.

Unlike every sibling handler in `app/api/demo/route.ts`, `DELETE` never called `getServerSession` and never scoped the query by `userId`. Since middleware only covers `/dashboard` (not `/api/*`), the route was reachable unauthenticated. Demo ids are publicly exposed via `app/share/[slug]` and `app/(signed)/view/[id]`, so anyone opening a share link could delete that demo (and brute-force others).

## Changes

- Require an authenticated session; return `401 Unauthorized` when there's no `session.user.id`.
- Scope the delete to the owner using `deleteMany({ where: { id, userId: session.user.id } })`.
- Return `404 Not found` when `result.count === 0`, covering both non-existent ids and demos owned by another user (without leaking which).

This mirrors the existing ownership pattern already used by the `PATCH` handler in the same file.
