### PR TITLE
fix: prevent PRO upgrade via client-controlled payment amount

### DIFF
--- a/app/(signed)/payment-gateway/page.tsx
+++ b/app/(signed)/payment-gateway/page.tsx
@@ -23,7 +23,7 @@ function PaymentGatewayContent() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ amount }),
+        body: JSON.stringify({ plan: "pro" }),
       });
       const data = await res.json();
       console.log("Order Data:", data);

--- a/app/api/create-order/route.ts
+++ b/app/api/create-order/route.ts
@@ -1,18 +1,33 @@
 import Razorpay from "razorpay";
 import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/lib/auth/options";
+import { PAYMENT_CURRENCY, PLANS, isPlanId } from "@/app/lib/plans";
 
 export async function POST(req: Request) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { plan } = await req.json();
+    if (!isPlanId(plan)) {
+      return NextResponse.json({ error: "Invalid plan" }, { status: 400 });
+    }
+
+    const { amount } = PLANS[plan];
+
     const razorpay = new Razorpay({
       key_id: process.env.NEXT_PUBLIC_RAZORPAY_KEY_ID as string,
       key_secret: process.env.RAZORPAY_KEY_SECRET as string,
     });
 
-    const { amount } = await req.json();
     const order = await razorpay.orders.create({
       amount: amount * 100, // In cents (e.g. 4900 cents = 49 USD)
-      currency: "USD",
-      receipt: "receipt_order_7",
+      currency: PAYMENT_CURRENCY,
+      receipt: `receipt_${plan}_${Date.now()}`,
+      notes: { plan },
     });
     return NextResponse.json(order);
   } catch (error) {

--- a/app/api/verify-payment/route.ts
+++ b/app/api/verify-payment/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from "next/server";
 import crypto from "crypto";
+import Razorpay from "razorpay";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/lib/auth/options";
 import { prisma } from "@/app/lib/prisma";
+import { PAYMENT_CURRENCY, PLANS } from "@/app/lib/plans";
 
 export async function POST(req: Request) {
   try {
@@ -22,22 +24,47 @@ export async function POST(req: Request) {
 
     const isAuthentic = expectedSignature === razorpay_signature;
 
-    if (isAuthentic) {
-      // Update user's plan to PRO
-      await prisma.user.update({
-        where: { email: session.user.email },
-        data: { plan: "PRO" },
-      });
-      return NextResponse.json({
-        success: true,
-        message: "Payment verified successfully",
-      });
-    } else {
+    if (!isAuthentic) {
       return NextResponse.json(
         { success: false, message: "Invalid payment signature" },
         { status: 400 }
       );
     }
+
+    // The signature only proves the order/payment pair is genuine — it says
+    // nothing about how much was paid. Re-fetch the order from Razorpay and
+    // assert it matches the server-defined PRO price before upgrading.
+    const razorpay = new Razorpay({
+      key_id: process.env.NEXT_PUBLIC_RAZORPAY_KEY_ID as string,
+      key_secret: process.env.RAZORPAY_KEY_SECRET!,
+    });
+
+    const order = await razorpay.orders.fetch(razorpay_order_id);
+    const expectedAmount = PLANS.pro.amount * 100;
+    const orderAmount = Number(order.amount);
+
+    const isValidOrder =
+      order.status === "paid" &&
+      order.currency === PAYMENT_CURRENCY &&
+      orderAmount === expectedAmount &&
+      order.notes?.plan === PLANS.pro.id;
+
+    if (!isValidOrder) {
+      return NextResponse.json(
+        { success: false, message: "Payment does not match the PRO plan" },
+        { status: 400 }
+      );
+    }
+
+    // Update user's plan to PRO
+    await prisma.user.update({
+      where: { email: session.user.email },
+      data: { plan: "PRO" },
+    });
+    return NextResponse.json({
+      success: true,
+      message: "Payment verified successfully",
+    });
   } catch (error) {
     console.error("Payment verification failed:", error);
     return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });

--- a/app/components/Pricing.tsx
+++ b/app/components/Pricing.tsx
@@ -49,7 +49,7 @@ const Pricing: React.FC = () => {
       const res = await fetch("/api/create-order", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ amount }),
+        body: JSON.stringify({ plan }),
       });
       const data = await res.json();
 

--- a/app/lib/plans.ts
+++ b/app/lib/plans.ts
@@ -1,0 +1,19 @@
+// Server-side source of truth for plan pricing.
+// Never trust amounts sent by the client — derive them from the plan id here.
+
+export const PAYMENT_CURRENCY = "USD";
+
+export const PLANS = {
+  pro: {
+    id: "pro" as const,
+    // Price in whole currency units (USD). Razorpay expects the smallest unit
+    // (cents), so multiply by 100 when creating an order.
+    amount: 49,
+  },
+} as const;
+
+export type PlanId = keyof typeof PLANS;
+
+export function isPlanId(value: unknown): value is PlanId {
+  return typeof value === "string" && value in PLANS;
+}


### PR DESCRIPTION
Fixes #182
## Summary

The payment amount was client-controlled end-to-end, allowing any user to pay
$1 (or $0.01) and still get upgraded to PRO.

- The amount originated from a `?amount=` URL param and was sent verbatim to
  `create-order`, which created a Razorpay order for whatever it received.
- `verify-payment` validated the HMAC signature (correctly) but never checked
  the order amount, currency, or that it was a PRO purchase before upgrading.
- The amount was also unvalidated (`undefined`/`"abc"` → `NaN`, negatives, etc.).

There was no server-side source of truth for the price.

## Changes

- **New `app/lib/plans.ts`** : server-side source of truth for plan pricing
  (`PLANS.pro.amount = 49`, `PAYMENT_CURRENCY = "USD"`) with an `isPlanId` guard.
- **`create-order`** : now requires auth and a valid `plan` id, derives the
  amount server-side from the plan table, and tags the order with
  `notes: { plan }`. The client-sent `amount` is no longer trusted.
- **`verify-payment`** : after the HMAC check, re-fetches the order from
  Razorpay and asserts `status === "paid"`, currency, `amount`, and
  `notes.plan` all match the server-defined PRO price before upgrading.
  Any mismatch returns 400 with no upgrade.
- **Clients** (`Pricing.tsx`, `payment-gateway/page.tsx`) : send `{ plan }`
  instead of `{ amount }`.

## Why this is safe

The signature still proves the order/payment pair is genuine; the new order
re-fetch proves *what* was actually paid. Since the price comes only from the
server plan table, tampering with the client amount no longer affects the
charge or the upgrade.

## Notes

The standalone `payment-gateway` page is hardcoded to `plan: "pro"` since PRO
is the only paid plan. If more paid plans are added later, that page will need
a real plan selector.
