### PR TITLE
fix: require auth and scope /view/[id] to owner (private demo leak)

### DIFF
--- a/app/(signed)/view/[id]/page.tsx
+++ b/app/(signed)/view/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { prisma } from "@/app/lib/prisma";
 import { Storage } from "@google-cloud/storage";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/lib/auth/options";
 
 const storage = new Storage();
 
@@ -45,20 +47,25 @@ async function toPlayableUrl(url: string) {
 
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const video = await prisma.demo.findUnique({
-    where: { id },
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return <div>Video not found</div>;
+  }
+
+  const video = await prisma.demo.findFirst({
+    where: { id, userId: session.user.id },
   });
+
+  if (!video) {
+    return <div>Video not found</div>;
+  }
 
   await prisma.view.create({
     data: {
       demoId: id,
     },
   });
-  console.log(id);
-
-  if (!video) {
-    return <div>Video not found</div>;
-  }
 
   const source = video.exportedUrl || video.videoUrl;
   const playableSource = source ? await toPlayableUrl(source) : "";


### PR DESCRIPTION
Fixes #183 
## Changes

`app/(signed)/view/[id]/page.tsx`:

- **Added a session check** : import `getServerSession` + `authOptions`; if there's no logged-in user, return "Video not found" before any DB work.
- **Scoped the demo lookup to the owner** : changed `prisma.demo.findUnique({ where: { id } })` to `prisma.demo.findFirst({ where: { id, userId: session.user.id } })`, so a demo is only returned to its owner.
- **Reordered side effects** : the `prisma.view.create(...)` write and the signed GCS URL minting now run only *after* the ownership check passes, so a non-owner never triggers a view-count write or gets a signed read URL.
- **Removed** the stray `console.log(id)`.
