### PR TITLE
fix: prevent cross-tenant Cloudinary asset deletion in exported-videos/cleanup

### DIFF
--- a/app/api/exported-videos/cleanup/route.ts
+++ b/app/api/exported-videos/cleanup/route.ts
@@ -46,6 +46,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "exportedUrl is required" }, { status: 400 });
     }
 
+    // Ownership gate: the exportedUrl must belong to the caller. The only server-side
+    // record that ties a freshly-exported (unsaved) Cloudinary URL to a user is the
+    // VideoJob created at /api/jobs/create, so verify against the caller's jobs.
+    const ownedJob = await prisma.videoJob.findFirst({
+      where: { userId, exportedUrl },
+      select: { id: true },
+    });
+
+    if (!ownedJob) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
     if (demoId) {
       const demo = await prisma.demo.findUnique({
         where: { id: demoId },
@@ -64,8 +76,33 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    await deleteCloudinaryVideoByUrl(exportedUrl);
-    await deleteCloudinaryVideoByUrl(sourceVideoUrl || null);
+    // Never destroy an asset that a persisted (saved) ExportedVideo still references.
+    const savedReferencingExport = await prisma.exportedVideo.findFirst({
+      where: { exportedUrl },
+      select: { id: true },
+    });
+
+    if (!savedReferencingExport) {
+      await deleteCloudinaryVideoByUrl(exportedUrl);
+    }
+
+    // Only delete the source video if it is also owned by the caller (i.e. it was the
+    // input to one of their jobs) and is not still referenced by a saved export.
+    if (sourceVideoUrl) {
+      const ownsSource = await prisma.videoJob.findFirst({
+        where: { userId, videoUrl: sourceVideoUrl },
+        select: { id: true },
+      });
+      const sourceStillReferenced = await prisma.exportedVideo.findFirst({
+        where: { sourceVideoUrl },
+        select: { id: true },
+      });
+
+      if (ownsSource && !sourceStillReferenced) {
+        await deleteCloudinaryVideoByUrl(sourceVideoUrl);
+      }
+    }
+
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Failed to cleanup exported video:", error);


### PR DESCRIPTION
Fixes #184 
## Summary

Fixes a cross-tenant data-destruction vulnerability in `POST /api/exported-videos/cleanup`. The endpoint deleted Cloudinary assets using a URL taken directly from the request body, with no check that the URL belonged to the caller. The `demoId` ownership branch was the only gate, and it was optional — by omitting `demoId`, **any authenticated user could permanently delete any other tenant's exported or source video** by passing its (public, discoverable) Cloudinary URL.

## Root cause

`deleteCloudinaryVideoByUrl(exportedUrl)` ran regardless of ownership. `deleteCloudinaryVideoByUrl` extracts the `public_id` from the URL and calls `cloudinary.uploader.destroy`, so a discoverable URL was enough to destroy someone else's asset.

## Fix

Added a server-side ownership gate before any deletion. An exported URL is produced by a `VideoJob` (created in `/api/jobs/create`), which stores both `userId` and `exportedUrl` plus the source `videoUrl` — the authoritative owner record for an unsaved export.

The route now:
1. **Requires a `VideoJob` owned by the caller** matching the `exportedUrl` (`userId === caller`). No match → `404`, nothing deleted. *(core fix)*
2. **Skips assets still referenced by a saved `ExportedVideo`**, so abandoning a temp export never destroys an asset backing a saved share link.
3. **Scopes source-video deletion to the caller** — only deletes `sourceVideoUrl` if it was the input to one of their own jobs and isn't referenced by a saved export.

Existing `demoId` ownership/clearing logic is preserved. Returns `404` (not `403`) on a non-owned URL to avoid leaking whether a URL exists in another account.
