### PR TITLE
feat(schema): add Cta and CtaClick models

### DIFF
--- a/prisma/migrations/20260615000000_add_cta_and_cta_click/migration.sql
+++ b/prisma/migrations/20260615000000_add_cta_and_cta_click/migration.sql
@@ -1,0 +1,46 @@
+-- CreateTable
+CREATE TABLE "Cta" (
+    "id" TEXT NOT NULL,
+    "demoId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "placement" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Cta_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CtaClick" (
+    "id" TEXT NOT NULL,
+    "ctaId" TEXT NOT NULL,
+    "demoId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "pageType" TEXT NOT NULL DEFAULT 'demo',
+    "sessionId" TEXT,
+    "userId" TEXT,
+    "referrer" TEXT,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CtaClick_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Cta_demoId_idx" ON "Cta"("demoId");
+
+-- CreateIndex
+CREATE INDEX "CtaClick_demoId_timestamp_idx" ON "CtaClick"("demoId", "timestamp");
+
+-- CreateIndex
+CREATE INDEX "CtaClick_ctaId_idx" ON "CtaClick"("ctaId");
+
+-- AddForeignKey
+ALTER TABLE "Cta" ADD CONSTRAINT "Cta_demoId_fkey" FOREIGN KEY ("demoId") REFERENCES "Demo"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CtaClick" ADD CONSTRAINT "CtaClick_ctaId_fkey" FOREIGN KEY ("ctaId") REFERENCES "Cta"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CtaClick" ADD CONSTRAINT "CtaClick_demoId_fkey" FOREIGN KEY ("demoId") REFERENCES "Demo"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,8 @@ model Demo {
   exportedVideo ExportedVideo?
   videoJobs     VideoJob[]
   views         View[]
+  ctas          Cta[]
+  ctaClicks     CtaClick[]
 }
 
 model Tutorial {
@@ -179,4 +181,36 @@ model Review {
   content   String
   createdAt DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id])
+}
+
+model Cta {
+  id        String     @id @default(cuid())
+  demoId    String
+  label     String
+  url       String
+  placement String?
+  order     Int        @default(0)
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+  demo      Demo       @relation(fields: [demoId], references: [id], onDelete: Cascade)
+  clicks    CtaClick[]
+
+  @@index([demoId])
+}
+
+model CtaClick {
+  id        String   @id @default(cuid())
+  ctaId     String
+  demoId    String
+  label     String
+  pageType  String   @default("demo")
+  sessionId String?
+  userId    String?
+  referrer  String?
+  timestamp DateTime @default(now())
+  cta       Cta      @relation(fields: [ctaId], references: [id], onDelete: Cascade)
+  demo      Demo     @relation(fields: [demoId], references: [id])
+
+  @@index([demoId, timestamp])
+  @@index([ctaId])
 }


### PR DESCRIPTION
Fixes #194
Add a dedicated Cta table for CTA definitions on a demo and a CtaClick event table for click aggregation, mirroring the existing View model.

- Cta: label, url, optional placement, order; cascade-deletes with Demo
- CtaClick: denormalized demoId, label snapshot, pageType, sessionId, userId, referrer, timestamp for total/unique-click aggregation
- Demo gains ctas and ctaClicks relations
- Indexes on CtaClick(demoId, timestamp) and CtaClick(ctaId)

Additive migration only; existing tables and queries are unaffected.