### PR TITLE
refactor: reduce oversized functions below 150 lines (#196) : 1/13

### DIFF
--- a/app/(signed)/editor/hooks/useURLParams.ts
+++ b/app/(signed)/editor/hooks/useURLParams.ts
@@ -50,6 +50,201 @@ function normalizeBrowserFrameMode(value: string | null): BrowserFrameMode | nul
   return null;
 }
 
+// Resolves a gs:// video URL to a playable URL (or sets the URL directly).
+async function resolvePlayableVideoUrl(
+  urlVideo: string,
+  setVideoUrl: (url: string | null) => void
+): Promise<void> {
+  try {
+    if (!urlVideo.startsWith("gs://")) {
+      setVideoUrl(urlVideo);
+      return;
+    }
+
+    const response = await fetch(`/api/gcs/resolve?url=${encodeURIComponent(urlVideo)}`, {
+      cache: "no-store",
+    });
+    const data = (await response.json().catch(() => ({}))) as {
+      ok?: boolean;
+      playableUrl?: string;
+    };
+    if (response.ok && data.ok && data.playableUrl) {
+      setVideoUrl(data.playableUrl);
+      return;
+    }
+    // Fallback to public URL so we still surface an explicit load failure in UI if resolve fails, but without throwing a scheme error.
+    setVideoUrl(urlVideo.replace("gs://", "https://storage.googleapis.com/"));
+  } catch {
+    setVideoUrl(urlVideo.replace("gs://", "https://storage.googleapis.com/"));
+  }
+}
+
+interface BrowserFrameHandlers {
+  setBrowserFrameMode: (mode: BrowserFrameMode) => void;
+  setBrowserFrameDrawShadow: (enabled: boolean) => void;
+  setBrowserFrameDrawBorder: (enabled: boolean) => void;
+}
+
+function applyBrowserFrameParam(urlBrowserFrame: string, handlers: BrowserFrameHandlers): void {
+  const { setBrowserFrameMode, setBrowserFrameDrawShadow, setBrowserFrameDrawBorder } = handlers;
+  try {
+    const parsed = JSON.parse(urlBrowserFrame) as {
+      mode?: string;
+      drawShadow?: boolean;
+      drawBorder?: boolean;
+    };
+    const mode = normalizeBrowserFrameMode(parsed.mode ?? null);
+    if (mode) {
+      setBrowserFrameMode(mode);
+    }
+    if (typeof parsed.drawShadow === "boolean") {
+      setBrowserFrameDrawShadow(parsed.drawShadow);
+    }
+    if (typeof parsed.drawBorder === "boolean") {
+      setBrowserFrameDrawBorder(parsed.drawBorder);
+    }
+  } catch {
+    const mode = normalizeBrowserFrameMode(urlBrowserFrame);
+    if (mode) {
+      setBrowserFrameMode(mode);
+    }
+  }
+}
+
+// Reads all editor params from the URL and pushes them into editor state.
+function applyEditorUrlParams({
+  params,
+  setVideoUrl,
+  setInputStartTime,
+  setInputEndTime,
+  setTimelineEndTime,
+  setSidebarTitle,
+  setSidebarDescription,
+  setLoadedSegments,
+  setCurrentSegments,
+  setZoomEffects,
+  setSubtitles,
+  setSavedDemoId,
+  setSelectedBackground,
+  setBackgroundType,
+  setTextOverlays,
+  setAspectRatio,
+  setBrowserFrameMode,
+  setBrowserFrameDrawShadow,
+  setBrowserFrameDrawBorder,
+  formatTimeForInput,
+}: UseURLParamsProps): void {
+  if (!params) {
+    return;
+  }
+
+  const urlVideo = params.get("video");
+  const urlStartTime = params.get("startTime");
+  const urlEndTime = params.get("endTime");
+  const urlSegments = params.get("segments");
+  const urlZoom = params.get("zoom");
+  const urlSubtitles = params.get("subtitles");
+  const urlTitle = params.get("title");
+  const urlDescription = params.get("description");
+  const urlDemoId = params.get("demoId");
+  const urlAspectRatio = params.get("aspectRatio");
+  const urlBrowserFrame = params.get("browserFrame");
+  const urlBackground = params.get("background");
+  const urlBackgroundType = params.get("backgroundType");
+  const urlTextOverlays = params.get("textOverlays");
+
+  // These should restore even if the video URL isn't set yet (prevents TDZ/ordering issues).
+  if (urlDemoId) {
+    setSavedDemoId(urlDemoId);
+  }
+  if (urlTitle) {
+    setSidebarTitle(urlTitle);
+  }
+  if (urlDescription) {
+    setSidebarDescription(urlDescription);
+  }
+  if (urlBackground && setSelectedBackground) {
+    setSelectedBackground(urlBackground);
+  }
+  if (urlBackgroundType && setBackgroundType) {
+    setBackgroundType(urlBackgroundType);
+  }
+  if (urlTextOverlays && setTextOverlays) {
+    try {
+      setTextOverlays(JSON.parse(urlTextOverlays));
+    } catch {
+      // ignore
+    }
+  }
+
+  if (!urlVideo) {
+    return;
+  }
+
+  resolvePlayableVideoUrl(urlVideo, setVideoUrl);
+
+  // Set timeline values if provided
+  if (urlStartTime && urlEndTime) {
+    const startSeconds = parseInt(urlStartTime);
+    const endSeconds = parseInt(urlEndTime);
+
+    if (!isNaN(startSeconds) && !isNaN(endSeconds)) {
+      setInputStartTime(formatTimeForInput(startSeconds));
+      setInputEndTime(formatTimeForInput(endSeconds));
+      setTimelineEndTime(endSeconds);
+    }
+  }
+
+  const normalizedAspectRatio = normalizeAspectRatio(urlAspectRatio);
+  if (normalizedAspectRatio) {
+    setAspectRatio(normalizedAspectRatio);
+  }
+  if (urlBrowserFrame) {
+    applyBrowserFrameParam(urlBrowserFrame, {
+      setBrowserFrameMode,
+      setBrowserFrameDrawShadow,
+      setBrowserFrameDrawBorder,
+    });
+  }
+
+  // Load segments if provided
+  if (urlSegments) {
+    try {
+      const segments = JSON.parse(urlSegments);
+      console.log("Loaded segments from URL:", segments);
+      const convertedSegments = segments.map((seg: { start: string; end: string }) => ({
+        start: seg.start,
+        end: seg.end,
+      }));
+      setLoadedSegments(convertedSegments);
+      setCurrentSegments(convertedSegments);
+    } catch (error) {
+      console.error("Error parsing segments from URL:", error);
+    }
+  }
+
+  // Load zoom effects if provided
+  if (urlZoom) {
+    try {
+      const zoom = JSON.parse(urlZoom);
+      console.log("Loaded zoom effects from URL:", zoom);
+      setZoomEffects(zoom);
+    } catch (error) {
+      console.error("Error parsing zoom from URL:", error);
+    }
+  }
+
+  // Load subtitles if provided
+  if (urlSubtitles && setSubtitles) {
+    try {
+      const subs = JSON.parse(urlSubtitles);
+      setSubtitles(subs);
+    } catch (error) {
+      console.error("Error parsing subtitles from URL:", error);
+    }
+  }
+}
+
 export function useURLParams({
   params,
   setVideoUrl,
@@ -73,155 +268,28 @@ export function useURLParams({
   formatTimeForInput,
 }: UseURLParamsProps) {
   useEffect(() => {
-    if (!params) {
-      return;
-    }
-
-    const urlVideo = params.get("video");
-    const urlStartTime = params.get("startTime");
-    const urlEndTime = params.get("endTime");
-    const urlSegments = params.get("segments");
-    const urlZoom = params.get("zoom");
-    const urlSubtitles = params.get("subtitles");
-    const urlTitle = params.get("title");
-    const urlDescription = params.get("description");
-    const urlDemoId = params.get("demoId");
-    const urlAspectRatio = params.get("aspectRatio");
-    const urlBrowserFrame = params.get("browserFrame");
-    const urlBackground = params.get("background");
-    const urlBackgroundType = params.get("backgroundType");
-    const urlTextOverlays = params.get("textOverlays");
-
-    // These should restore even if the video URL isn't set yet (prevents TDZ/ordering issues).
-    if (urlDemoId) {
-      setSavedDemoId(urlDemoId);
-    }
-    if (urlTitle) {
-      setSidebarTitle(urlTitle);
-    }
-    if (urlDescription) {
-      setSidebarDescription(urlDescription);
-    }
-    if (urlBackground && setSelectedBackground) {
-      setSelectedBackground(urlBackground);
-    }
-    if (urlBackgroundType && setBackgroundType) {
-      setBackgroundType(urlBackgroundType);
-    }
-    if (urlTextOverlays && setTextOverlays) {
-      try {
-        setTextOverlays(JSON.parse(urlTextOverlays));
-      } catch {
-        // ignore
-      }
-    }
-
-    if (urlVideo) {
-      const resolvePlayableUrl = async () => {
-        try {
-          if (!urlVideo.startsWith("gs://")) {
-            setVideoUrl(urlVideo);
-            return;
-          }
-
-          const response = await fetch(`/api/gcs/resolve?url=${encodeURIComponent(urlVideo)}`, {
-            cache: "no-store",
-          });
-          const data = (await response.json().catch(() => ({}))) as {
-            ok?: boolean;
-            playableUrl?: string;
-          };
-          if (response.ok && data.ok && data.playableUrl) {
-            setVideoUrl(data.playableUrl);
-            return;
-          }
-          // Fallback to public URL so we still surface an explicit load failure in UI if resolve fails, but without throwing a scheme error.
-          setVideoUrl(urlVideo.replace("gs://", "https://storage.googleapis.com/"));
-        } catch {
-          setVideoUrl(urlVideo.replace("gs://", "https://storage.googleapis.com/"));
-        }
-      };
-
-      resolvePlayableUrl();
-
-      // Set timeline values if provided
-      if (urlStartTime && urlEndTime) {
-        const startSeconds = parseInt(urlStartTime);
-        const endSeconds = parseInt(urlEndTime);
-
-        if (!isNaN(startSeconds) && !isNaN(endSeconds)) {
-          setInputStartTime(formatTimeForInput(startSeconds));
-          setInputEndTime(formatTimeForInput(endSeconds));
-          setTimelineEndTime(endSeconds);
-        }
-      }
-
-      const normalizedAspectRatio = normalizeAspectRatio(urlAspectRatio);
-      if (normalizedAspectRatio) {
-        setAspectRatio(normalizedAspectRatio);
-      }
-      if (urlBrowserFrame) {
-        try {
-          const parsed = JSON.parse(urlBrowserFrame) as {
-            mode?: string;
-            drawShadow?: boolean;
-            drawBorder?: boolean;
-          };
-          const mode = normalizeBrowserFrameMode(parsed.mode ?? null);
-          if (mode) {
-            setBrowserFrameMode(mode);
-          }
-          if (typeof parsed.drawShadow === "boolean") {
-            setBrowserFrameDrawShadow(parsed.drawShadow);
-          }
-          if (typeof parsed.drawBorder === "boolean") {
-            setBrowserFrameDrawBorder(parsed.drawBorder);
-          }
-        } catch {
-          const mode = normalizeBrowserFrameMode(urlBrowserFrame);
-          if (mode) {
-            setBrowserFrameMode(mode);
-          }
-        }
-      }
-
-      // Load segments if provided
-      if (urlSegments) {
-        try {
-          const segments = JSON.parse(urlSegments);
-          console.log("Loaded segments from URL:", segments);
-          const convertedSegments = segments.map((seg: { start: string; end: string }) => ({
-            start: seg.start,
-            end: seg.end,
-          }));
-          setLoadedSegments(convertedSegments);
-          setCurrentSegments(convertedSegments);
-        } catch (error) {
-          console.error("Error parsing segments from URL:", error);
-        }
-      }
-
-      // Load zoom effects if provided
-      if (urlZoom) {
-        try {
-          const zoom = JSON.parse(urlZoom);
-          console.log("Loaded zoom effects from URL:", zoom);
-          setZoomEffects(zoom);
-        } catch (error) {
-          console.error("Error parsing zoom from URL:", error);
-        }
-      }
-
-      // Load subtitles if provided
-      if (urlSubtitles && setSubtitles) {
-        try {
-          const subs = JSON.parse(urlSubtitles);
-          setSubtitles(subs);
-        } catch (error) {
-          console.error("Error parsing subtitles from URL:", error);
-        }
-      }
-    }
+    applyEditorUrlParams({
+      params,
+      setVideoUrl,
+      setInputStartTime,
+      setInputEndTime,
+      setTimelineEndTime,
+      setSidebarTitle,
+      setSidebarDescription,
+      setLoadedSegments,
+      setCurrentSegments,
+      setZoomEffects,
+      setSubtitles,
+      setSavedDemoId,
+      setSelectedBackground,
+      setBackgroundType,
+      setTextOverlays,
+      setAspectRatio,
+      setBrowserFrameMode,
+      setBrowserFrameDrawShadow,
+      setBrowserFrameDrawBorder,
+      formatTimeForInput,
+    });
   }, [
     params,
     setVideoUrl,

--- a/app/(signed)/editor/utils/videoHandlers.ts
+++ b/app/(signed)/editor/utils/videoHandlers.ts
@@ -70,6 +70,103 @@ interface SaveDemoParams {
   onSaveSuccess?: () => void;
 }
 
+async function uploadDemoSourceVideo(videoUrl: string): Promise<string | null> {
+  try {
+    const response = await fetch(videoUrl);
+    if (!response.ok) {
+      throw new Error("Failed to fetch video blob");
+    }
+    const videoBlob = await response.blob();
+    const fixedVideoBlob = await fixWebmDurationIfNeeded(videoBlob);
+
+    console.log("Uploading source video to GCS...");
+    const upload = await uploadBlobToGcs({
+      blob: fixedVideoBlob,
+      filename: "video.webm",
+      kind: "demo-source",
+    });
+    return upload.url;
+  } catch (cloudError) {
+    console.error("Error uploading source video to GCS:", cloudError);
+    toast.dismiss();
+    toast.error("Failed to upload source video");
+    return null;
+  }
+}
+
+interface DemoConflictParams {
+  data: { title: string; description: string };
+  editingToSave: Record<string, unknown>;
+  conflictData: unknown;
+  setSidebarTitle: (title: string) => void;
+  setSidebarDescription: (description: string) => void;
+  setShowSaveDemoModal: (show: boolean) => void;
+  setDemoSaved?: (saved: boolean) => void;
+  setSavedDemoId?: (id: string | null) => void;
+  onSaveSuccess?: () => void;
+}
+
+async function handleDemoConflict({
+  data,
+  editingToSave,
+  conflictData,
+  setSidebarTitle,
+  setSidebarDescription,
+  setShowSaveDemoModal,
+  setDemoSaved,
+  setSavedDemoId,
+  onSaveSuccess,
+}: DemoConflictParams): Promise<void> {
+  console.log("Demo already saved:", conflictData);
+  const existingId = getDemoIdFromApiResponse(conflictData) || undefined;
+  if (existingId) {
+    try {
+      const patchRes = await axios.patch("/api/demo", {
+        id: existingId,
+        title: data.title,
+        description: data.description,
+        editing: editingToSave,
+      });
+      if (setDemoSaved) {
+        setDemoSaved(true);
+      }
+      if (setSavedDemoId) {
+        setSavedDemoId(existingId);
+      }
+      if (onSaveSuccess) {
+        onSaveSuccess();
+      }
+      toast.dismiss();
+      toast.success("Demo updated successfully!");
+      // Ensure sidebar reflects the saved text immediately.
+      setSidebarTitle(data.title);
+      setSidebarDescription(data.description);
+      setShowSaveDemoModal(false);
+      console.log("Demo updated after 409:", patchRes.data);
+      return;
+    } catch (patchErr) {
+      console.error("Failed to update existing demo after 409:", patchErr);
+      toast.dismiss();
+      toast.error("Failed to update demo");
+      throw patchErr;
+    }
+  }
+
+  if (setDemoSaved) {
+    setDemoSaved(true);
+  }
+  const conflictDemoId = getDemoIdFromApiResponse(conflictData);
+  if (setSavedDemoId && conflictDemoId) {
+    setSavedDemoId(conflictDemoId);
+  }
+  if (onSaveSuccess) {
+    onSaveSuccess();
+  }
+  toast.dismiss();
+  toast.warning("This demo has already been saved!");
+  setShowSaveDemoModal(false);
+}
+
 export async function handleSaveDemo(
   data: { title: string; description: string },
   params: SaveDemoParams
@@ -119,28 +216,11 @@ export async function handleSaveDemo(
     // First, upload source video to GCS if it's a blob URL
     let sourceVideoUrl = videoUrl;
     if (!existingDemoId && videoUrl.startsWith("blob:")) {
-      try {
-        // Get the video blob
-        const response = await fetch(videoUrl);
-        if (!response.ok) {
-          throw new Error("Failed to fetch video blob");
-        }
-        const videoBlob = await response.blob();
-        const fixedVideoBlob = await fixWebmDurationIfNeeded(videoBlob);
-
-        console.log("Uploading source video to GCS...");
-        const upload = await uploadBlobToGcs({
-          blob: fixedVideoBlob,
-          filename: "video.webm",
-          kind: "demo-source",
-        });
-        sourceVideoUrl = upload.url;
-      } catch (cloudError) {
-        console.error("Error uploading source video to GCS:", cloudError);
-        toast.dismiss();
-        toast.error("Failed to upload source video");
+      const uploadedUrl = await uploadDemoSourceVideo(videoUrl);
+      if (!uploadedUrl) {
         return;
       }
+      sourceVideoUrl = uploadedUrl;
     }
 
     // Use current segments from the timeline
@@ -197,53 +277,17 @@ export async function handleSaveDemo(
       if (axios.isAxiosError(error)) {
         if (error.response) {
           if (error.response.status === 409) {
-            // Demo already exists
-            console.log("Demo already saved:", error.response.data);
-            const existingId = getDemoIdFromApiResponse(error.response.data) || undefined;
-            if (existingId) {
-              try {
-                const patchRes = await axios.patch("/api/demo", {
-                  id: existingId,
-                  title: data.title,
-                  description: data.description,
-                  editing: editingToSave,
-                });
-                if (setDemoSaved) {
-                  setDemoSaved(true);
-                }
-                if (setSavedDemoId) {
-                  setSavedDemoId(existingId);
-                }
-                if (onSaveSuccess) {
-                  onSaveSuccess();
-                }
-                toast.dismiss();
-                toast.success("Demo updated successfully!");
-                // Ensure sidebar reflects the saved text immediately.
-                setSidebarTitle(data.title);
-                setSidebarDescription(data.description);
-                setShowSaveDemoModal(false);
-                console.log("Demo updated after 409:", patchRes.data);
-                return;
-              } catch (patchErr) {
-                console.error("Failed to update existing demo after 409:", patchErr);
-                toast.dismiss();
-                toast.error("Failed to update demo");
-                throw patchErr;
-              }
-            }
-            if (setDemoSaved) {
-              setDemoSaved(true);
-            }
-            if (setSavedDemoId && error.response.data.demo?.id) {
-              setSavedDemoId(error.response.data.demo.id);
-            }
-            if (onSaveSuccess) {
-              onSaveSuccess();
-            }
-            toast.dismiss();
-            toast.warning("This demo has already been saved!");
-            setShowSaveDemoModal(false);
+            await handleDemoConflict({
+              data,
+              editingToSave,
+              conflictData: error.response.data,
+              setSidebarTitle,
+              setSidebarDescription,
+              setShowSaveDemoModal,
+              setDemoSaved,
+              setSavedDemoId,
+              onSaveSuccess,
+            });
             return;
           }
           console.error(
@@ -551,6 +595,163 @@ async function fetchPublicAssetAsBlob(assetPathOrUrl: string): Promise<Blob> {
   return await resp.blob();
 }
 
+interface ResolveExportBackgroundParams {
+  selectedBackground: string;
+  customBackgroundUrl: string | null;
+  imageMap: Record<string, string>;
+  toastId: string | number;
+}
+
+async function resolveExportBackground({
+  selectedBackground,
+  customBackgroundUrl,
+  imageMap,
+  toastId,
+}: ResolveExportBackgroundParams): Promise<{
+  backgroundToUse: string;
+  resolvedCustomBackgroundUrl: string | null;
+}> {
+  let backgroundToUse = "transparent";
+  let resolvedCustomBackgroundUrl: string | null = null;
+  if (selectedBackground === "custom" && customBackgroundUrl) {
+    try {
+      toast.loading("Uploading custom background...", { id: toastId });
+      const response = await fetch(customBackgroundUrl);
+      if (!response.ok) {
+        throw new Error("Failed to read custom background");
+      }
+      const bgBlob = await response.blob();
+      resolvedCustomBackgroundUrl = await uploadImageBlobToGcs(bgBlob);
+      backgroundToUse = "custom";
+    } catch (bgError) {
+      console.error("Custom background upload failed:", bgError);
+      backgroundToUse = "transparent";
+    }
+  } else if (
+    selectedBackground &&
+    selectedBackground !== "none" &&
+    selectedBackground !== "transparent"
+  ) {
+    // For built-in backgrounds, ensure backend FFmpeg gets a real image input matching frontend selection.
+    const mappedValue = imageMap[selectedBackground];
+    if (mappedValue) {
+      try {
+        toast.loading("Preparing selected background...", { id: toastId });
+        if (mappedValue.toLowerCase().endsWith(".svg")) {
+          const pngBlob = await rasterizeSvgToPngBlob(mappedValue, 1920, 1080);
+          resolvedCustomBackgroundUrl = await uploadImageBlobToGcs(pngBlob);
+        } else {
+          // Public-root images like /staticbackground.jpg etc.
+          const blob = await fetchPublicAssetAsBlob(mappedValue);
+          resolvedCustomBackgroundUrl = await uploadImageBlobToGcs(blob);
+        }
+        backgroundToUse = "custom";
+      } catch (svgBgError) {
+        console.error("Failed to rasterize/upload selected SVG background:", svgBgError);
+        // Fallback to key so worker still applies a deterministic style.
+        backgroundToUse = selectedBackground;
+      }
+    } else {
+      // gradient:* / color:* paths
+      backgroundToUse = selectedBackground;
+    }
+  }
+  return { backgroundToUse, resolvedCustomBackgroundUrl };
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function createMp4Downloader(jobId: string, sidebarTitle: string) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return async (_url: string) => {
+    const safeName = (sidebarTitle || "Exported_Demo")
+      .replace(/[^\w\s-]/g, "")
+      .trim()
+      .replace(/\s+/g, "_");
+    const filename = `${safeName || "Exported_Demo"}.mp4`;
+    const downloadUrl = `/api/jobs/${jobId}/download?title=${encodeURIComponent(
+      sidebarTitle || "Exported_Demo"
+    )}`;
+
+    try {
+      const response = await fetch(downloadUrl, { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(`Download failed: ${response.status}`);
+      }
+      const blob = await response.blob();
+      const localUrl = URL.createObjectURL(new Blob([blob], { type: "video/mp4" }));
+      const link = document.createElement("a");
+      link.href = localUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(localUrl);
+    } catch (err) {
+      console.error("Blob download failed, falling back to direct link:", err);
+      const link = document.createElement("a");
+      link.href = downloadUrl;
+      link.download = filename;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  };
+}
+
+interface PollExportJobParams {
+  jobId: string;
+  setProgress: (p: number) => void;
+  toastId: string | number;
+}
+
+async function pollExportJob({
+  jobId,
+  setProgress,
+  toastId,
+}: PollExportJobParams): Promise<string | null> {
+  // Poll for job status every 5s
+  const MAX_POLLS = 180; // 15 minutes max (180 × 5s)
+  for (let pollCount = 0; pollCount < MAX_POLLS; pollCount++) {
+    try {
+      const statusRes = await axios.get(`/api/jobs/${jobId}`);
+      const { state, progress, exportedUrl, error } = statusRes.data;
+
+      if (state === "active" || state === "waiting" || state === "delayed") {
+        setProgress(progress || 0);
+        toast.loading(`Processing... ${progress || 0}%`, { id: toastId });
+        await sleep(5000);
+        continue;
+      }
+
+      if (state === "completed") {
+        if (!exportedUrl) {
+          throw new Error("Export completed but no output URL was returned");
+        }
+        setProgress(100);
+        toast.success("Export complete!", { id: toastId });
+        return exportedUrl;
+      }
+
+      if (state === "failed") {
+        throw new Error(error || "Unknown error");
+      }
+    } catch (err) {
+      console.error("Error polling job status", err);
+      const message = err instanceof Error ? err.message : "Lost connection to processing server";
+      toast.error(`Export failed: ${message}`, { id: toastId });
+      return null;
+    }
+
+    await sleep(5000);
+  }
+
+  toast.error("Export timed out after 15 minutes", { id: toastId });
+  return null;
+}
+
 export const exportVideo = async ({
   videoUrl,
   selectedBackground,
@@ -579,51 +780,12 @@ export const exportVideo = async ({
 
   try {
     let uploadedSourceVideo = false;
-    let backgroundToUse = "transparent";
-    let resolvedCustomBackgroundUrl: string | null = null;
-    if (selectedBackground === "custom" && customBackgroundUrl) {
-      try {
-        toast.loading("Uploading custom background...", { id: toastId });
-        const response = await fetch(customBackgroundUrl);
-        if (!response.ok) {
-          throw new Error("Failed to read custom background");
-        }
-        const bgBlob = await response.blob();
-        resolvedCustomBackgroundUrl = await uploadImageBlobToGcs(bgBlob);
-        backgroundToUse = "custom";
-      } catch (bgError) {
-        console.error("Custom background upload failed:", bgError);
-        backgroundToUse = "transparent";
-      }
-    } else if (
-      selectedBackground &&
-      selectedBackground !== "none" &&
-      selectedBackground !== "transparent"
-    ) {
-      // For built-in backgrounds, ensure backend FFmpeg gets a real image input matching frontend selection.
-      const mappedValue = imageMap[selectedBackground];
-      if (mappedValue) {
-        try {
-          toast.loading("Preparing selected background...", { id: toastId });
-          if (mappedValue.toLowerCase().endsWith(".svg")) {
-            const pngBlob = await rasterizeSvgToPngBlob(mappedValue, 1920, 1080);
-            resolvedCustomBackgroundUrl = await uploadImageBlobToGcs(pngBlob);
-          } else {
-            // Public-root images like /staticbackground.jpg etc.
-            const blob = await fetchPublicAssetAsBlob(mappedValue);
-            resolvedCustomBackgroundUrl = await uploadImageBlobToGcs(blob);
-          }
-          backgroundToUse = "custom";
-        } catch (svgBgError) {
-          console.error("Failed to rasterize/upload selected SVG background:", svgBgError);
-          // Fallback to key so worker still applies a deterministic style.
-          backgroundToUse = selectedBackground;
-        }
-      } else {
-        // gradient:* / color:* paths
-        backgroundToUse = selectedBackground;
-      }
-    }
+    const { backgroundToUse, resolvedCustomBackgroundUrl } = await resolveExportBackground({
+      selectedBackground,
+      customBackgroundUrl,
+      imageMap,
+      toastId,
+    });
 
     toast.loading("Preparing video for backend...", { id: toastId });
 
@@ -683,91 +845,19 @@ export const exportVideo = async ({
     }
 
     toast.loading("Processing video...", { id: toastId });
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const downloadAsMp4 = async (_url: string) => {
-      const safeName = (sidebarTitle || "Exported_Demo")
-        .replace(/[^\w\s-]/g, "")
-        .trim()
-        .replace(/\s+/g, "_");
-      const filename = `${safeName || "Exported_Demo"}.mp4`;
-      const downloadUrl = `/api/jobs/${jobId}/download?title=${encodeURIComponent(
-        sidebarTitle || "Exported_Demo"
-      )}`;
+    const downloadAsMp4 = createMp4Downloader(jobId, sidebarTitle);
 
-      try {
-        const response = await fetch(downloadUrl, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(`Download failed: ${response.status}`);
-        }
-        const blob = await response.blob();
-        const localUrl = URL.createObjectURL(new Blob([blob], { type: "video/mp4" }));
-        const link = document.createElement("a");
-        link.href = localUrl;
-        link.download = filename;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(localUrl);
-      } catch (err) {
-        console.error("Blob download failed, falling back to direct link:", err);
-        const link = document.createElement("a");
-        link.href = downloadUrl;
-        link.download = filename;
-        link.target = "_blank";
-        link.rel = "noopener noreferrer";
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-      }
-    };
-
-    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-    // 2. Poll for job status every 5s
-    const MAX_POLLS = 180; // 15 minutes max (180 × 5s)
-    for (let pollCount = 0; pollCount < MAX_POLLS; pollCount++) {
-      try {
-        const statusRes = await axios.get(`/api/jobs/${jobId}`);
-        const { state, progress, exportedUrl, error } = statusRes.data;
-
-        if (state === "active" || state === "waiting" || state === "delayed") {
-          setProgress(progress || 0);
-          toast.loading(`Processing... ${progress || 0}%`, { id: toastId });
-          await sleep(5000);
-          continue;
-        }
-
-        if (state === "completed") {
-          if (!exportedUrl) {
-            throw new Error("Export completed but no output URL was returned");
-          }
-
-          setProgress(100);
-          toast.success("Export complete!", { id: toastId });
-
-          return {
-            exportedUrl,
-            sourceVideoUrl,
-            downloadAsMp4,
-            uploadedSourceVideo,
-          };
-        }
-
-        if (state === "failed") {
-          throw new Error(error || "Unknown error");
-        }
-      } catch (err) {
-        console.error("Error polling job status", err);
-        const message = err instanceof Error ? err.message : "Lost connection to processing server";
-        toast.error(`Export failed: ${message}`, { id: toastId });
-        return null;
-      }
-
-      await sleep(5000);
+    const exportedUrl = await pollExportJob({ jobId, setProgress, toastId });
+    if (!exportedUrl) {
+      return null;
     }
 
-    toast.error("Export timed out after 15 minutes", { id: toastId });
-    return null;
+    return {
+      exportedUrl,
+      sourceVideoUrl,
+      downloadAsMp4,
+      uploadedSourceVideo,
+    };
   } catch (error) {
     console.error("Export error:", error);
     toast.error("Failed to start export", { id: toastId });

--- a/app/api/jobs/create/route.ts
+++ b/app/api/jobs/create/route.ts
@@ -5,6 +5,144 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/lib/auth/options";
 export const maxDuration = 300;
 
+const EXEMPT_EMAILS = [
+  "aryaanandpathak30@gmail.com",
+  "sarthakbehera10@gmail.com",
+  "ashishmishra19122000@gmail.com",
+  "sandipsubham.32@gmail.com",
+  "kanupriya2052017@gmail.com",
+  "rathourrahul21@gmail.com",
+  "ajitkumarshankhwar25@gmail.com",
+  "somyanayak281@gmail.com",
+  "manushichillar412@gmail.com",
+];
+
+// Returns true when the user is allowed to start another export.
+async function isExportAllowed(
+  userId: string,
+  email: string | null | undefined,
+  plan: string | null
+): Promise<boolean> {
+  const isExempt =
+    (email && EXEMPT_EMAILS.includes(email)) || plan === "PRO" || plan === "ENTERPRISE";
+  if (isExempt) {
+    return true;
+  }
+
+  const jobCount = await prisma.videoJob.count({
+    where: { userId, status: "COMPLETED" },
+  });
+  const savedCount = await prisma.exportedVideo.count({
+    where: { userId },
+  });
+  const exportCount = Math.max(jobCount, savedCount);
+
+  return exportCount < 3;
+}
+
+// Dispatches chunked processing to GCP Cloud Run workers and merges the result.
+async function dispatchVideoJob(
+  jobId: string,
+  videoUrl: string,
+  duration: number,
+  normalizedPayload: Record<string, unknown>
+): Promise<void> {
+  try {
+    await prisma.videoJob.update({
+      where: { id: jobId },
+      data: {
+        status: "PROCESSING",
+        progress: 25,
+      },
+    });
+
+    const chunkDuration = 10;
+    const chunksCount = Math.ceil(duration / chunkDuration);
+    const chunkFilenames: string[] = [];
+    const fetchTasks = [];
+
+    for (let i = 0; i < chunksCount; i++) {
+      const startTime = i * chunkDuration;
+      const currentChunkDuration = Math.min(chunkDuration, duration - startTime);
+      const chunkId = `${jobId}_chunk_${String(i).padStart(3, "0")}`;
+      const outputObject = `${chunkId}.mp4`;
+
+      chunkFilenames.push(outputObject);
+
+      // Store a function that RETURNS the promise, but don't call it yet!
+      fetchTasks.push(() =>
+        invokeGcpWorker(
+          {
+            chunkId,
+            recipeId: jobId,
+            outputObject,
+            videoUrl,
+            recipe: normalizedPayload,
+            startTime,
+            duration: currentChunkDuration,
+          },
+          "/process"
+        )
+      );
+    }
+
+    // True Concurrency Queue Logic (Actual Deferred Execution)
+    const MAX_CONCURRENT_CHUNKS = 5;
+    const executing = new Set<Promise<unknown>>();
+    const results = [];
+
+    for (const task of fetchTasks) {
+      const promise = task().finally(() => executing.delete(promise));
+      executing.add(promise);
+      results.push(promise);
+      if (executing.size >= MAX_CONCURRENT_CHUNKS) {
+        await Promise.race(executing);
+      }
+    }
+
+    const completedTasks = await Promise.all(results);
+
+    const validChunkFilenames = (
+      completedTasks as { result?: { skipped?: boolean; processedObject?: string } }[]
+    )
+      .filter((res) => res && res.result && !res.result.skipped)
+      .map((res) => res.result!.processedObject!);
+
+    await prisma.videoJob.update({
+      where: { id: jobId },
+      data: { progress: 80 },
+    });
+
+    const mergeResp = await invokeGcpWorker(
+      {
+        recipeId: jobId,
+        chunkFilenames: validChunkFilenames,
+      },
+      "/merge"
+    );
+
+    const exportedUrl = mergeResp.result?.exportedUrl || null;
+
+    await prisma.videoJob.update({
+      where: { id: jobId },
+      data: {
+        status: "COMPLETED",
+        progress: 100,
+        exportedUrl,
+      },
+    });
+  } catch (dispatchError) {
+    console.error("Job dispatch failed:", dispatchError);
+    await prisma.videoJob.update({
+      where: { id: jobId },
+      data: {
+        status: "FAILED",
+        error: dispatchError instanceof Error ? dispatchError.message : "Dispatch failed",
+      },
+    });
+  }
+}
+
 export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
@@ -65,39 +203,14 @@ export async function POST(req: NextRequest) {
 
     const userId = user.id;
 
-    const EXEMPT_EMAILS = [
-      "aryaanandpathak30@gmail.com",
-      "sarthakbehera10@gmail.com",
-      "ashishmishra19122000@gmail.com",
-      "sandipsubham.32@gmail.com",
-      "kanupriya2052017@gmail.com",
-      "rathourrahul21@gmail.com",
-      "ajitkumarshankhwar25@gmail.com",
-      "somyanayak281@gmail.com",
-      "manushichillar412@gmail.com",
-    ];
-
-    const isExempt =
-      (session.user.email && EXEMPT_EMAILS.includes(session.user.email)) ||
-      user.plan === "PRO" ||
-      user.plan === "ENTERPRISE";
-    if (!isExempt) {
-      const jobCount = await prisma.videoJob.count({
-        where: { userId, status: "COMPLETED" },
-      });
-      const savedCount = await prisma.exportedVideo.count({
-        where: { userId },
-      });
-      const exportCount = Math.max(jobCount, savedCount);
-
-      if (exportCount >= 3) {
-        return NextResponse.json(
-          {
-            error: "Free trial limit of 3 exports reached. Please upgrade your plan.",
-          },
-          { status: 403 }
-        );
-      }
+    const exportAllowed = await isExportAllowed(userId, session.user.email, user.plan);
+    if (!exportAllowed) {
+      return NextResponse.json(
+        {
+          error: "Free trial limit of 3 exports reached. Please upgrade your plan.",
+        },
+        { status: 403 }
+      );
     }
 
     // 1. Create a job record in the database
@@ -148,102 +261,7 @@ export async function POST(req: NextRequest) {
     };
 
     // 2. Dispatch to GCP Cloud Run workers (Scatter-Gather)
-    after(async () => {
-      try {
-        await prisma.videoJob.update({
-          where: { id: jobRecord.id },
-          data: {
-            status: "PROCESSING",
-            progress: 25,
-          },
-        });
-
-        const chunkDuration = 10;
-        const chunksCount = Math.ceil(duration / chunkDuration);
-        const chunkFilenames: string[] = [];
-        const fetchTasks = [];
-
-        for (let i = 0; i < chunksCount; i++) {
-          const startTime = i * chunkDuration;
-          const currentChunkDuration = Math.min(chunkDuration, duration - startTime);
-          const chunkId = `${jobRecord.id}_chunk_${String(i).padStart(3, "0")}`;
-          const outputObject = `${chunkId}.mp4`;
-
-          chunkFilenames.push(outputObject);
-
-          // Store a function that RETURNS the promise, but don't call it yet!
-          fetchTasks.push(() =>
-            invokeGcpWorker(
-              {
-                chunkId,
-                recipeId: jobRecord.id,
-                outputObject,
-                videoUrl,
-                recipe: normalizedPayload as unknown as Record<string, unknown>,
-                startTime,
-                duration: currentChunkDuration,
-              },
-              "/process"
-            )
-          );
-        }
-
-        // True Concurrency Queue Logic (Actual Deferred Execution)
-        const MAX_CONCURRENT_CHUNKS = 5;
-        const executing = new Set<Promise<unknown>>();
-        const results = [];
-
-        for (const task of fetchTasks) {
-          const promise = task().finally(() => executing.delete(promise));
-          executing.add(promise);
-          results.push(promise);
-          if (executing.size >= MAX_CONCURRENT_CHUNKS) {
-            await Promise.race(executing);
-          }
-        }
-
-        const completedTasks = await Promise.all(results);
-
-        const validChunkFilenames = (
-          completedTasks as { result?: { skipped?: boolean; processedObject?: string } }[]
-        )
-          .filter((res) => res && res.result && !res.result.skipped)
-          .map((res) => res.result!.processedObject!);
-
-        await prisma.videoJob.update({
-          where: { id: jobRecord.id },
-          data: { progress: 80 },
-        });
-
-        const mergeResp = await invokeGcpWorker(
-          {
-            recipeId: jobRecord.id,
-            chunkFilenames: validChunkFilenames,
-          },
-          "/merge"
-        );
-
-        const exportedUrl = mergeResp.result?.exportedUrl || null;
-
-        await prisma.videoJob.update({
-          where: { id: jobRecord.id },
-          data: {
-            status: "COMPLETED",
-            progress: 100,
-            exportedUrl,
-          },
-        });
-      } catch (dispatchError) {
-        console.error("Job dispatch failed:", dispatchError);
-        await prisma.videoJob.update({
-          where: { id: jobRecord.id },
-          data: {
-            status: "FAILED",
-            error: dispatchError instanceof Error ? dispatchError.message : "Dispatch failed",
-          },
-        });
-      }
-    });
+    after(() => dispatchVideoJob(jobRecord.id, videoUrl, duration, normalizedPayload));
 
     // 3. Return the job ID to the client instantly
     return NextResponse.json({

--- a/app/lib/ffmpeg.ts
+++ b/app/lib/ffmpeg.ts
@@ -5,77 +5,65 @@ type Overlay =
   | { type: "arrow"; x: number; y: number; x2: number; y2: number }
   | { type: "text"; x: number; y: number; text: string };
 
-export const videoTrimmer = async (inputBlob: Blob, start: string, end: string): Promise<Blob> => {
-  const { createFFmpeg } = await import("@ffmpeg/ffmpeg");
-  const ffmpeg = createFFmpeg({
-    log: true,
-    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/dist/ffmpeg-core.js",
-  });
-  if (!ffmpeg.isLoaded()) {
-    await ffmpeg.load();
+type FFmpegModule = typeof import("@ffmpeg/ffmpeg");
+type FFmpegInstance = ReturnType<FFmpegModule["createFFmpeg"]>;
+
+// Convert "HH:MM:SS[.mmm]" or a number into a float count of seconds.
+function toSeconds(t: string | number): number {
+  if (typeof t === "number") {
+    return t;
   }
-
-  const inputName = "input.webm";
-  const outputName = "output.webm";
-
-  // Helper to format time as seconds (float)
-  function toSeconds(t: string | number): number {
-    if (typeof t === "number") {
-      return t;
+  if (t.includes(":")) {
+    // HH:MM:SS[.mmm]
+    const parts = t.split(":").map(Number);
+    if (parts.length === 3) {
+      return parts[0] * 3600 + parts[1] * 60 + parts[2];
+    } else if (parts.length === 2) {
+      return parts[0] * 60 + parts[1];
+    } else {
+      return Number(t);
     }
-    if (t.includes(":")) {
-      // HH:MM:SS[.mmm]
-      const parts = t.split(":").map(Number);
-      if (parts.length === 3) {
-        return parts[0] * 3600 + parts[1] * 60 + parts[2];
-      } else if (parts.length === 2) {
-        return parts[0] * 60 + parts[1];
-      } else {
-        return Number(t);
-      }
-    }
-    return parseFloat(t);
   }
+  return parseFloat(t);
+}
 
-  // Helper: get file size in ffmpeg FS (returns 0 if file doesn't exist)
-  function getFileSize(name: string): number {
+// Get file size in the ffmpeg FS (returns 0 if file doesn't exist).
+function getFFmpegFileSize(ffmpeg: FFmpegInstance, name: string): number {
+  try {
+    const d = ffmpeg.FS("readFile", name);
+    return d.length;
+  } catch {
+    return 0;
+  }
+}
+
+// Check that a file exists and has a reasonable size in the ffmpeg FS.
+function ffmpegFileValid(ffmpeg: FFmpegInstance, name: string, minBytes = 1000): boolean {
+  return getFFmpegFileSize(ffmpeg, name) >= minBytes;
+}
+
+// Clean up intermediate files (ignore errors).
+function cleanupFFmpegFiles(ffmpeg: FFmpegInstance, ...names: string[]): void {
+  for (const n of names) {
     try {
-      const d = ffmpeg.FS("readFile", name);
-      return d.length;
+      ffmpeg.FS("unlink", n);
     } catch {
-      return 0;
+      /* ignore */
     }
   }
+}
 
-  // Helper: check if a file exists and has reasonable size in ffmpeg FS
-  function fileExistsAndValid(name: string, minBytes = 1000): boolean {
-    return getFileSize(name) >= minBytes;
-  }
-
-  // Helper: clean up intermediate files (ignore errors)
-  function cleanupFiles(...names: string[]) {
-    for (const n of names) {
-      try {
-        ffmpeg.FS("unlink", n);
-      } catch {
-        /* ignore */
-      }
-    }
-  }
-
-  const inputData = new Uint8Array(await inputBlob.arrayBuffer());
-  const inputSize = inputData.length;
-  ffmpeg.FS("writeFile", inputName, inputData);
-
-  const startSec = toSeconds(start);
-  const endSec = toSeconds(end);
-
-  // ── Strategy 1: Stream-copy (fast, no quality loss) ──────────────────
-  // This works when recording has proper audio (mic on / tab audio).
-  // It may fail with synthetic silent audio (mic off) because webm/opus
-  // timestamps from a silent oscillator don't split cleanly with -c copy.
-  let streamCopySuccess = false;
-
+// Strategy 1: Stream-copy (fast, no quality loss). Works when the recording has
+// proper audio. May fail with synthetic silent audio (mic off) because webm/opus
+// timestamps don't split cleanly with -c copy. Returns true on success.
+async function trimByStreamCopy(
+  ffmpeg: FFmpegInstance,
+  inputName: string,
+  outputName: string,
+  startSec: number,
+  endSec: number,
+  inputSize: number
+): Promise<boolean> {
   try {
     const parts: string[] = [];
 
@@ -93,7 +81,7 @@ export const videoTrimmer = async (inputBlob: Blob, start: string, end: string):
           "copy",
           part1Name
         );
-        if (fileExistsAndValid(part1Name)) {
+        if (ffmpegFileValid(ffmpeg, part1Name)) {
           parts.push(part1Name);
         }
       } catch {
@@ -104,7 +92,7 @@ export const videoTrimmer = async (inputBlob: Blob, start: string, end: string):
     const part2Name = "part2.webm";
     try {
       await ffmpeg.run("-i", inputName, "-ss", String(endSec), "-c", "copy", part2Name);
-      if (fileExistsAndValid(part2Name)) {
+      if (ffmpegFileValid(ffmpeg, part2Name)) {
         parts.push(part2Name);
       }
     } catch {
@@ -117,12 +105,12 @@ export const videoTrimmer = async (inputBlob: Blob, start: string, end: string):
 
       await ffmpeg.run("-f", "concat", "-safe", "0", "-i", "concat.txt", "-c", "copy", outputName);
 
-      const outSize = getFileSize(outputName);
+      const outSize = getFFmpegFileSize(ffmpeg, outputName);
       // Trim should ALWAYS produce a smaller file — if output is bigger
       // than input, the stream-copy produced corrupt/inflated output
       if (outSize >= 1000 && outSize < inputSize) {
-        streamCopySuccess = true;
         console.log("Trim succeeded with stream-copy", { inputSize, outSize });
+        return true;
       } else if (outSize > 0) {
         console.warn("Stream-copy output looks wrong (size mismatch)", {
           inputSize,
@@ -133,53 +121,35 @@ export const videoTrimmer = async (inputBlob: Blob, start: string, end: string):
   } catch (err) {
     console.warn("Stream-copy trim failed, will try re-encode fallback:", err);
   }
+  return false;
+}
 
-  // ── Strategy 2: Re-encode fallback (handles mic-off / silent audio) ──
-  // When stream-copy fails or produces a corrupt file, re-encode to fix
-  // audio timestamps. Uses libvpx for video and libopus for audio.
-  if (!streamCopySuccess) {
-    console.log("Falling back to re-encode trim...");
+// Strategy 2: Re-encode fallback (handles mic-off / silent audio). Re-encodes to
+// fix audio timestamps using libvpx for video and libopus for audio.
+async function trimByReencode(
+  ffmpeg: FFmpegInstance,
+  inputName: string,
+  outputName: string,
+  startSec: number,
+  endSec: number
+): Promise<void> {
+  console.log("Falling back to re-encode trim...");
 
-    // Clean up any leftover files from strategy 1
-    cleanupFiles("part1.webm", "part2.webm", "concat.txt", outputName);
+  // Clean up any leftover files from strategy 1
+  cleanupFFmpegFiles(ffmpeg, "part1.webm", "part2.webm", "concat.txt", outputName);
 
-    const parts: string[] = [];
+  const parts: string[] = [];
 
-    if (startSec > 0) {
-      const part1Name = "re_part1.webm";
-      try {
-        await ffmpeg.run(
-          "-i",
-          inputName,
-          "-ss",
-          "0",
-          "-to",
-          String(startSec),
-          "-c:v",
-          "libvpx",
-          "-crf",
-          "10",
-          "-b:v",
-          "0",
-          "-c:a",
-          "libopus",
-          part1Name
-        );
-        if (fileExistsAndValid(part1Name)) {
-          parts.push(part1Name);
-        }
-      } catch {
-        console.warn("Re-encode: Part 1 extraction failed");
-      }
-    }
-
-    const part2Name = "re_part2.webm";
+  if (startSec > 0) {
+    const part1Name = "re_part1.webm";
     try {
       await ffmpeg.run(
         "-i",
         inputName,
         "-ss",
-        String(endSec),
+        "0",
+        "-to",
+        String(startSec),
         "-c:v",
         "libvpx",
         "-crf",
@@ -188,44 +158,92 @@ export const videoTrimmer = async (inputBlob: Blob, start: string, end: string):
         "0",
         "-c:a",
         "libopus",
-        part2Name
+        part1Name
       );
-      if (fileExistsAndValid(part2Name)) {
-        parts.push(part2Name);
+      if (ffmpegFileValid(ffmpeg, part1Name)) {
+        parts.push(part1Name);
       }
     } catch {
-      console.warn("Re-encode: Part 2 extraction failed");
+      console.warn("Re-encode: Part 1 extraction failed");
     }
+  }
 
-    if (parts.length === 0) {
-      throw new Error("Failed to extract any video segments for trimming");
+  const part2Name = "re_part2.webm";
+  try {
+    await ffmpeg.run(
+      "-i",
+      inputName,
+      "-ss",
+      String(endSec),
+      "-c:v",
+      "libvpx",
+      "-crf",
+      "10",
+      "-b:v",
+      "0",
+      "-c:a",
+      "libopus",
+      part2Name
+    );
+    if (ffmpegFileValid(ffmpeg, part2Name)) {
+      parts.push(part2Name);
     }
+  } catch {
+    console.warn("Re-encode: Part 2 extraction failed");
+  }
 
-    const concatList = parts.map((p) => `file '${p}'`).join("\n");
-    ffmpeg.FS("writeFile", "re_concat.txt", new TextEncoder().encode(concatList));
+  if (parts.length === 0) {
+    throw new Error("Failed to extract any video segments for trimming");
+  }
 
-    try {
-      await ffmpeg.run(
-        "-f",
-        "concat",
-        "-safe",
-        "0",
-        "-i",
-        "re_concat.txt",
-        "-c",
-        "copy",
-        outputName
-      );
-    } catch (err) {
-      console.error("Re-encode concat failed:", err);
-      throw new Error("Failed to trim and concatenate video segments");
-    }
+  const concatList = parts.map((p) => `file '${p}'`).join("\n");
+  ffmpeg.FS("writeFile", "re_concat.txt", new TextEncoder().encode(concatList));
 
-    if (!fileExistsAndValid(outputName)) {
-      throw new Error("Re-encode trim produced no valid output");
-    }
+  try {
+    await ffmpeg.run("-f", "concat", "-safe", "0", "-i", "re_concat.txt", "-c", "copy", outputName);
+  } catch (err) {
+    console.error("Re-encode concat failed:", err);
+    throw new Error("Failed to trim and concatenate video segments");
+  }
 
-    console.log("Trim succeeded with re-encode fallback");
+  if (!ffmpegFileValid(ffmpeg, outputName)) {
+    throw new Error("Re-encode trim produced no valid output");
+  }
+
+  console.log("Trim succeeded with re-encode fallback");
+}
+
+export const videoTrimmer = async (inputBlob: Blob, start: string, end: string): Promise<Blob> => {
+  const { createFFmpeg } = await import("@ffmpeg/ffmpeg");
+  const ffmpeg = createFFmpeg({
+    log: true,
+    corePath: "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/dist/ffmpeg-core.js",
+  });
+  if (!ffmpeg.isLoaded()) {
+    await ffmpeg.load();
+  }
+
+  const inputName = "input.webm";
+  const outputName = "output.webm";
+
+  const inputData = new Uint8Array(await inputBlob.arrayBuffer());
+  const inputSize = inputData.length;
+  ffmpeg.FS("writeFile", inputName, inputData);
+
+  const startSec = toSeconds(start);
+  const endSec = toSeconds(end);
+
+  const streamCopySuccess = await trimByStreamCopy(
+    ffmpeg,
+    inputName,
+    outputName,
+    startSec,
+    endSec,
+    inputSize
+  );
+
+  if (!streamCopySuccess) {
+    await trimByReencode(ffmpeg, inputName, outputName, startSec, endSec);
   }
 
   try {


### PR DESCRIPTION
fixes part  of #196 
Extracts helpers (to module scope) so each target function drops under the 150-line max-lines-per-function limit. Behavior-preserving, no UI/logic/prop/type changes.

Functions fixed:

videoHandlers.ts — handleSaveDemo (186), exportVideo (198)
api/jobs/create/route.ts — POST (216)
lib/ffmpeg.ts — videoTrimmer (190)
editor/hooks/useURLParams.ts — useURLParams (177)
Lint max-lines-per-function warnings: 40 → 35. useURLParams dependency array unchanged (no new exhaustive-deps warning).

Note: a pre-existing project-wide tsc build failure (implicit-any in analytics/page.tsx, dashboard/page.tsx, demos/page.tsx, api/jobs/[id]/route.ts) exists on master and is out of scope here.