### PR TITLE
refactor: split landing/marketing components under 150 lines (#196) 2/13

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -267,6 +267,120 @@ const WaitlistSection: React.FC = () => {
   );
 };
 
+const FooterBrandContent: React.FC<{ isInView: boolean }> = ({ isInView }) => (
+  <motion.div
+    initial={{ opacity: 0, y: 60 }}
+    animate={{
+      opacity: isInView ? 1 : 0,
+      y: isInView ? 0 : 60,
+    }}
+    transition={{
+      duration: 0.8,
+      ease: easeOut,
+      delay: 0.2,
+    }}
+  >
+    <div className="flex items-center gap-3 sm:gap-4 mb-3 sm:mb-4">
+      <div className="footer-logo-box flex items-center justify-center w-14 h-14 rounded-[15px] border border-[rgba(139,92,255,0.28)] bg-[rgba(14,16,36,0.7)] shrink-0">
+        <Image
+          src="/images/Logo.png"
+          alt="Marvedge Logo"
+          width={28}
+          height={28}
+          className="w-7 h-7 object-contain dark:hidden"
+        />
+        <Image
+          src="/images/logo_dark.png"
+          alt="Marvedge Logo dark"
+          width={28}
+          height={28}
+          className="w-7 h-7 object-contain hidden dark:block"
+        />
+      </div>
+      <h2
+        className="brand text-white text-lg sm:text-xl md:text-2xl font-semibold flex items-center gap-1.5"
+        style={{ fontFamily: "var(--font-raleway)" }}
+      >
+        MAR <strong className="text-white">VEDGE</strong>
+      </h2>
+    </div>
+    <p
+      className="text-gray-300 text-xs sm:text-sm md:text-base max-w-xs sm:max-w-sm"
+      style={{ fontFamily: "var(--font-raleway)" }}
+    >
+      Transform your product URLs into compelling demo videos with the power of AI. Boost
+      conversations and save time with automated video creation.
+    </p>
+  </motion.div>
+);
+
+const FooterSocials: React.FC<{ isInView: boolean }> = ({ isInView }) => (
+  <motion.div
+    className="sm:shrink-0 sm:ml-auto  flex justify-end shrink-0"
+    initial={{ opacity: 0, y: 60 }}
+    animate={{
+      opacity: isInView ? 1 : 0,
+      y: isInView ? 0 : 60,
+    }}
+    transition={{
+      duration: 0.8,
+      ease: easeOut,
+      delay: 0.6,
+    }}
+  >
+    <motion.div
+      className="flex gap-4 sm:gap-5 md:gap-6"
+      initial={{ opacity: 0, y: 30 }}
+      animate={{
+        opacity: isInView ? 1 : 0,
+        y: isInView ? 0 : 30,
+      }}
+      transition={{
+        duration: 0.8,
+        ease: easeOut,
+        delay: 0.7,
+      }}
+    >
+      {socialIcons.map((icon, index) => (
+        <SocialIcon key={index} image={icon.image} url={icon.url} label={icon.label} />
+      ))}
+    </motion.div>
+  </motion.div>
+);
+
+const FooterCopyright: React.FC<{ isInView: boolean }> = ({ isInView }) => (
+  <motion.footer
+    className="copyright w-full max-w-7xl mx-auto flex flex-col items-center pt-6 pb-8 px-3 sm:px-4 border-t border-[rgba(165,139,255,0.12)] relative z-10 mt-8"
+    initial={{ opacity: 0, y: 60 }}
+    animate={{
+      opacity: isInView ? 1 : 0,
+      y: isInView ? 0 : 60,
+    }}
+    transition={{
+      duration: 0.8,
+      ease: easeOut,
+      delay: 0.8,
+    }}
+  >
+    <motion.p
+      className="text-gray-400 text-xs sm:text-sm font-semibold text-center opacity-70"
+      style={{ fontFamily: "var(--font-raleway)" }}
+      initial={{ opacity: 0, y: 30 }}
+      animate={{
+        opacity: isInView ? 1 : 0,
+        y: isInView ? 0 : 30,
+      }}
+      transition={{
+        duration: 0.8,
+        ease: easeOut,
+        delay: 1.0,
+      }}
+    >
+      Copyright © 2025. All rights reserved. Created with purple heart for better conversation.
+    </motion.p>
+  </motion.footer>
+);
+
 const Footer: React.FC = () => {
   const sectionRef = useRef(null);
   const pathname = usePathname();
@@ -301,50 +415,7 @@ const Footer: React.FC = () => {
             }}
             style={{ y }}
           >
-            <motion.div
-              initial={{ opacity: 0, y: 60 }}
-              animate={{
-                opacity: isInView ? 1 : 0,
-                y: isInView ? 0 : 60,
-              }}
-              transition={{
-                duration: 0.8,
-                ease: easeOut,
-                delay: 0.2,
-              }}
-            >
-              <div className="flex items-center gap-3 sm:gap-4 mb-3 sm:mb-4">
-                <div className="footer-logo-box flex items-center justify-center w-14 h-14 rounded-[15px] border border-[rgba(139,92,255,0.28)] bg-[rgba(14,16,36,0.7)] shrink-0">
-                  <Image
-                    src="/images/Logo.png"
-                    alt="Marvedge Logo"
-                    width={28}
-                    height={28}
-                    className="w-7 h-7 object-contain dark:hidden"
-                  />
-                  <Image
-                    src="/images/logo_dark.png"
-                    alt="Marvedge Logo dark"
-                    width={28}
-                    height={28}
-                    className="w-7 h-7 object-contain hidden dark:block"
-                  />
-                </div>
-                <h2
-                  className="brand text-white text-lg sm:text-xl md:text-2xl font-semibold flex items-center gap-1.5"
-                  style={{ fontFamily: "var(--font-raleway)" }}
-                >
-                  MAR <strong className="text-white">VEDGE</strong>
-                </h2>
-              </div>
-              <p
-                className="text-gray-300 text-xs sm:text-sm md:text-base max-w-xs sm:max-w-sm"
-                style={{ fontFamily: "var(--font-raleway)" }}
-              >
-                Transform your product URLs into compelling demo videos with the power of AI. Boost
-                conversations and save time with automated video creation.
-              </p>
-            </motion.div>
+            <FooterBrandContent isInView={isInView} />
           </motion.div>
 
           <motion.div
@@ -366,70 +437,10 @@ const Footer: React.FC = () => {
             ))}
           </motion.div>
 
-          <motion.div
-            className="sm:shrink-0 sm:ml-auto  flex justify-end shrink-0"
-            initial={{ opacity: 0, y: 60 }}
-            animate={{
-              opacity: isInView ? 1 : 0,
-              y: isInView ? 0 : 60,
-            }}
-            transition={{
-              duration: 0.8,
-              ease: easeOut,
-              delay: 0.6,
-            }}
-          >
-            <motion.div
-              className="flex gap-4 sm:gap-5 md:gap-6"
-              initial={{ opacity: 0, y: 30 }}
-              animate={{
-                opacity: isInView ? 1 : 0,
-                y: isInView ? 0 : 30,
-              }}
-              transition={{
-                duration: 0.8,
-                ease: easeOut,
-                delay: 0.7,
-              }}
-            >
-              {socialIcons.map((icon, index) => (
-                <SocialIcon key={index} image={icon.image} url={icon.url} label={icon.label} />
-              ))}
-            </motion.div>
-          </motion.div>
+          <FooterSocials isInView={isInView} />
         </section>
 
-        <motion.footer
-          className="copyright w-full max-w-7xl mx-auto flex flex-col items-center pt-6 pb-8 px-3 sm:px-4 border-t border-[rgba(165,139,255,0.12)] relative z-10 mt-8"
-          initial={{ opacity: 0, y: 60 }}
-          animate={{
-            opacity: isInView ? 1 : 0,
-            y: isInView ? 0 : 60,
-          }}
-          transition={{
-            duration: 0.8,
-            ease: easeOut,
-            delay: 0.8,
-          }}
-        >
-          <motion.p
-            className="text-gray-400 text-xs sm:text-sm font-semibold text-center opacity-70"
-            style={{ fontFamily: "var(--font-raleway)" }}
-            initial={{ opacity: 0, y: 30 }}
-            animate={{
-              opacity: isInView ? 1 : 0,
-              y: isInView ? 0 : 30,
-            }}
-            transition={{
-              duration: 0.8,
-              ease: easeOut,
-              delay: 1.0,
-            }}
-          >
-            Copyright © 2025. All rights reserved. Created with purple heart for better
-            conversation.
-          </motion.p>
-        </motion.footer>
+        <FooterCopyright isInView={isInView} />
         <ToastContainer position="top-center" autoClose={3000} />
       </div>
     </>

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -6,16 +6,220 @@ import { motion, useInView, useScroll, useTransform, easeOut } from "framer-moti
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 
+const textSegments = [
+  { text: "Turn ", color: "text-[#494369]" },
+  { text: "Clicks", color: "text-[#261753]" },
+  { text: " Into Customers with", color: "text-[#494369]" },
+  { text: "Interactive Demos", color: "text-[#8A76FC]/70" },
+];
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1,
+    },
+  },
+};
+
+const letterVariants = {
+  hidden: { opacity: 0, y: 10 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.2 } },
+};
+
+const fadeInUp = {
+  hidden: { opacity: 0, y: 60, rotateX: -15 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    rotateX: 0,
+    transition: { duration: 0.8, ease: easeOut },
+  },
+};
+
+const fadeInLeft = {
+  hidden: { opacity: 0, x: -60, rotateY: -15 },
+  visible: {
+    opacity: 1,
+    x: 0,
+    rotateY: 0,
+    transition: { duration: 0.8, ease: easeOut },
+  },
+};
+
+const HeroBlobs: React.FC = () => (
+  <>
+    <motion.div
+      className="absolute bottom-40 left-1/4 w-8 sm:w-12 h-8 sm:h-12 bg-green-200 rounded-full opacity-20"
+      animate={{
+        scale: [1, 1.3, 1],
+        x: [0, 40, 0],
+        rotate: [0, 90, 180],
+      }}
+      transition={{
+        duration: 7,
+        repeat: Infinity,
+        ease: "easeInOut",
+      }}
+    />
+
+    <motion.div
+      className="absolute top-[55%] left-[22%] w-48 sm:w-[200px] h-48 sm:h-[200px] rounded-full pointer-events-none"
+      style={{
+        background: "radial-gradient(circle, #8A76FC 0%, transparent 45%)",
+        filter: "blur(60px)",
+        transform: "translate(-50%, -50%)",
+        opacity: 0.57,
+      }}
+      animate={{
+        scale: [1, 1.15, 1],
+        y: [0, 15, 0],
+      }}
+      transition={{
+        duration: 6,
+        repeat: Infinity,
+        ease: "easeInOut",
+      }}
+    />
+  </>
+);
+
+const HeroEllipses: React.FC = () => (
+  <>
+    <div className="absolute top-[-20%] left-1/2 transform -translate-x-1/2 w-full max-w-4xl pointer-events-none z-0">
+      <Image
+        src="/Ellipse 29.png"
+        alt="Background ellipse center"
+        width={600}
+        height={600}
+        className="w-full h-auto"
+      />
+    </div>
+
+    <div className="absolute top-[-10%] left-[-15%] w-full max-w-4xl pointer-events-none z-0">
+      <Image
+        src="/Ellipse 29.png"
+        alt="Background ellipse left"
+        width={600}
+        height={600}
+        className="w-full h-auto"
+      />
+    </div>
+
+    <div className="absolute top-[-30%] right-[-15%] w-full max-w-4xl pointer-events-none z-0">
+      <Image
+        src="/Ellipse 29.png"
+        alt="Background ellipse right"
+        width={600}
+        height={600}
+        className="w-full h-auto"
+      />
+    </div>
+  </>
+);
+
+const HeroHeading: React.FC<{ isInView: boolean }> = ({ isInView }) => (
+  <motion.h1
+    className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight"
+    style={{
+      fontFamily: "var(--font-raleway)",
+      fontWeight: 900,
+      lineHeight: "1.2",
+      letterSpacing: "0%",
+    }}
+    variants={containerVariants}
+    initial="hidden"
+    animate={isInView ? "visible" : "hidden"}
+    aria-label="Hero heading"
+  >
+    {textSegments.map((segment, segmentIndex) => (
+      <span key={segmentIndex} className={segment.color}>
+        {segment.text.split("").map((char, charIndex) => (
+          <motion.span key={`${segmentIndex}-${charIndex}`} variants={letterVariants}>
+            {char === " " ? "\u00A0" : char}
+          </motion.span>
+        ))}
+        {segmentIndex === 2 ? <br /> : null}
+      </span>
+    ))}
+  </motion.h1>
+);
+
+const HeroActions: React.FC<{
+  isInView: boolean;
+  actionButtonText: string;
+  onActionClick: () => void;
+  onExploreClick: () => void;
+}> = ({ isInView, actionButtonText, onActionClick, onExploreClick }) => (
+  <motion.div
+    className="mt-4 sm:mt-10 flex flex-col sm:flex-row gap-4 sm:gap-5 justify-center items-center"
+    variants={fadeInUp}
+    initial="hidden"
+    animate={isInView ? "visible" : "hidden"}
+  >
+    <motion.button
+      onClick={onActionClick}
+      className="flex items-center justify-center cursor-pointer gap-2 bg-[#8A76FC] hover:bg-[#7563E8] text-white px-8 sm:px-12 py-3 sm:py-4 rounded-lg font-semibold text-base sm:text-lg transition whitespace-nowrap"
+      style={{ fontFamily: "var(--font-raleway)", fontWeight: 500 }}
+      whileHover={{ scale: 1.05, y: -2 }}
+      whileTap={{ scale: 0.95 }}
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M4 2L16 10L4 18V2Z" fill="white" />
+      </svg>
+      {actionButtonText}
+    </motion.button>
+    <motion.button
+      onClick={onExploreClick}
+      className="flex items-center justify-center cursor-pointer gap-2 border-2 border-gray-300 bg-white shadow-md px-8 sm:px-12 py-3 sm:py-4 rounded-lg text-[#261753] text-base sm:text-lg font-semibold hover:shadow-lg transition whitespace-nowrap"
+      style={{ fontFamily: "var(--font-raleway)", fontWeight: 500 }}
+      whileHover={{ scale: 1.05, y: -2 }}
+      whileTap={{ scale: 0.95 }}
+      transition={{ duration: 0.1 }}
+    >
+      <Image src="/ri_gemini-fill.png" alt="Explore Examples" width={20} height={20} />
+      Book a Demo
+    </motion.button>
+  </motion.div>
+);
+
+const HeroImage: React.FC<{ isInView: boolean }> = ({ isInView }) => (
+  <motion.div
+    className="w-full mt-2 sm:mt-3 md:mt-4 rounded-4xl overflow-hidden"
+    variants={fadeInUp}
+    initial="hidden"
+    animate={isInView ? "visible" : "hidden"}
+    aria-label="Landing page hero image"
+  >
+    <Image
+      src="/images/landing_image.png"
+      alt="Interactive demo showcase"
+      width={1200}
+      height={600}
+      className="w-full h-auto object-cover dark:hidden"
+      priority
+    />
+    <Image
+      src="/images/landing_image_dark.png"
+      alt="Interactive demo showcase dark"
+      width={1200}
+      height={600}
+      className="w-full h-auto object-cover hidden dark:block"
+      priority
+    />
+  </motion.div>
+);
+
 const Hero: React.FC = () => {
   const router = useRouter();
   const { status } = useSession();
-
-  const textSegments = [
-    { text: "Turn ", color: "text-[#494369]" },
-    { text: "Clicks", color: "text-[#261753]" },
-    { text: " Into Customers with", color: "text-[#494369]" },
-    { text: "Interactive Demos", color: "text-[#8A76FC]/70" },
-  ];
 
   const handleActionButtonClick = () => {
     if (status === "authenticated") {
@@ -43,110 +247,16 @@ const Hero: React.FC = () => {
 
   const y1 = useTransform(scrollYProgress, [0, 1], [0, -100]);
 
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1,
-      },
-    },
-  };
-
-  const letterVariants = {
-    hidden: { opacity: 0, y: 10 },
-    visible: { opacity: 1, y: 0, transition: { duration: 0.2 } },
-  };
-
-  const fadeInUp = {
-    hidden: { opacity: 0, y: 60, rotateX: -15 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      rotateX: 0,
-      transition: { duration: 0.8, ease: easeOut },
-    },
-  };
-
-  const fadeInLeft = {
-    hidden: { opacity: 0, x: -60, rotateY: -15 },
-    visible: {
-      opacity: 1,
-      x: 0,
-      rotateY: 0,
-      transition: { duration: 0.8, ease: easeOut },
-    },
-  };
-
   return (
     <section
       ref={ref}
       className="min-h-screen pt-48 sm:pt-32 md:pt-32 lg:pt-[170px] pb-4 bg-white relative overflow-hidden z-0"
       style={{ zIndex: 0 }}
     >
-      <motion.div
-        className="absolute bottom-40 left-1/4 w-8 sm:w-12 h-8 sm:h-12 bg-green-200 rounded-full opacity-20"
-        animate={{
-          scale: [1, 1.3, 1],
-          x: [0, 40, 0],
-          rotate: [0, 90, 180],
-        }}
-        transition={{
-          duration: 7,
-          repeat: Infinity,
-          ease: "easeInOut",
-        }}
-      />
-
-      <motion.div
-        className="absolute top-[55%] left-[22%] w-48 sm:w-[200px] h-48 sm:h-[200px] rounded-full pointer-events-none"
-        style={{
-          background: "radial-gradient(circle, #8A76FC 0%, transparent 45%)",
-          filter: "blur(60px)",
-          transform: "translate(-50%, -50%)",
-          opacity: 0.57,
-        }}
-        animate={{
-          scale: [1, 1.15, 1],
-          y: [0, 15, 0],
-        }}
-        transition={{
-          duration: 6,
-          repeat: Infinity,
-          ease: "easeInOut",
-        }}
-      />
+      <HeroBlobs />
 
       <div className="w-full px-3 sm:px-4 md:px-6 lg:max-w-6xl lg:mx-auto flex flex-col items-center text-center relative">
-        <div className="absolute top-[-20%] left-1/2 transform -translate-x-1/2 w-full max-w-4xl pointer-events-none z-0">
-          <Image
-            src="/Ellipse 29.png"
-            alt="Background ellipse center"
-            width={600}
-            height={600}
-            className="w-full h-auto"
-          />
-        </div>
-
-        <div className="absolute top-[-10%] left-[-15%] w-full max-w-4xl pointer-events-none z-0">
-          <Image
-            src="/Ellipse 29.png"
-            alt="Background ellipse left"
-            width={600}
-            height={600}
-            className="w-full h-auto"
-          />
-        </div>
-
-        <div className="absolute top-[-30%] right-[-15%] w-full max-w-4xl pointer-events-none z-0">
-          <Image
-            src="/Ellipse 29.png"
-            alt="Background ellipse right"
-            width={600}
-            height={600}
-            className="w-full h-auto"
-          />
-        </div>
+        <HeroEllipses />
 
         <motion.div
           className="w-full relative z-10"
@@ -155,30 +265,7 @@ const Hero: React.FC = () => {
           animate={isInView ? "visible" : "hidden"}
           style={{ y: y1 }}
         >
-          <motion.h1
-            className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight"
-            style={{
-              fontFamily: "var(--font-raleway)",
-              fontWeight: 900,
-              lineHeight: "1.2",
-              letterSpacing: "0%",
-            }}
-            variants={containerVariants}
-            initial="hidden"
-            animate={isInView ? "visible" : "hidden"}
-            aria-label="Hero heading"
-          >
-            {textSegments.map((segment, segmentIndex) => (
-              <span key={segmentIndex} className={segment.color}>
-                {segment.text.split("").map((char, charIndex) => (
-                  <motion.span key={`${segmentIndex}-${charIndex}`} variants={letterVariants}>
-                    {char === " " ? "\u00A0" : char}
-                  </motion.span>
-                ))}
-                {segmentIndex === 2 ? <br /> : null}
-              </span>
-            ))}
-          </motion.h1>
+          <HeroHeading isInView={isInView} />
           <motion.p
             className="mt-1 sm:mt-1 text-gray-600 text-base sm:text-lg max-w-2xl mx-auto"
             style={{ fontFamily: "var(--font-raleway)", fontWeight: 400 }}
@@ -190,68 +277,15 @@ const Hero: React.FC = () => {
             convert.
           </motion.p>
 
-          <motion.div
-            className="mt-4 sm:mt-10 flex flex-col sm:flex-row gap-4 sm:gap-5 justify-center items-center"
-            variants={fadeInUp}
-            initial="hidden"
-            animate={isInView ? "visible" : "hidden"}
-          >
-            <motion.button
-              onClick={handleActionButtonClick}
-              className="flex items-center justify-center cursor-pointer gap-2 bg-[#8A76FC] hover:bg-[#7563E8] text-white px-8 sm:px-12 py-3 sm:py-4 rounded-lg font-semibold text-base sm:text-lg transition whitespace-nowrap"
-              style={{ fontFamily: "var(--font-raleway)", fontWeight: 500 }}
-              whileHover={{ scale: 1.05, y: -2 }}
-              whileTap={{ scale: 0.95 }}
-            >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 20 20"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M4 2L16 10L4 18V2Z" fill="white" />
-              </svg>
-              {actionButtonText}
-            </motion.button>
-            <motion.button
-              onClick={handleExploreExamplesClick}
-              className="flex items-center justify-center cursor-pointer gap-2 border-2 border-gray-300 bg-white shadow-md px-8 sm:px-12 py-3 sm:py-4 rounded-lg text-[#261753] text-base sm:text-lg font-semibold hover:shadow-lg transition whitespace-nowrap"
-              style={{ fontFamily: "var(--font-raleway)", fontWeight: 500 }}
-              whileHover={{ scale: 1.05, y: -2 }}
-              whileTap={{ scale: 0.95 }}
-              transition={{ duration: 0.1 }}
-            >
-              <Image src="/ri_gemini-fill.png" alt="Explore Examples" width={20} height={20} />
-              Book a Demo
-            </motion.button>
-          </motion.div>
+          <HeroActions
+            isInView={isInView}
+            actionButtonText={actionButtonText}
+            onActionClick={handleActionButtonClick}
+            onExploreClick={handleExploreExamplesClick}
+          />
         </motion.div>
 
-        <motion.div
-          className="w-full mt-2 sm:mt-3 md:mt-4 rounded-4xl overflow-hidden"
-          variants={fadeInUp}
-          initial="hidden"
-          animate={isInView ? "visible" : "hidden"}
-          aria-label="Landing page hero image"
-        >
-          <Image
-            src="/images/landing_image.png"
-            alt="Interactive demo showcase"
-            width={1200}
-            height={600}
-            className="w-full h-auto object-cover dark:hidden"
-            priority
-          />
-          <Image
-            src="/images/landing_image_dark.png"
-            alt="Interactive demo showcase dark"
-            width={1200}
-            height={600}
-            className="w-full h-auto object-cover hidden dark:block"
-            priority
-          />
-        </motion.div>
+        <HeroImage isInView={isInView} />
       </div>
     </section>
   );

--- a/app/components/Hero3.tsx
+++ b/app/components/Hero3.tsx
@@ -6,23 +6,26 @@ import { Check } from "lucide-react";
 import Image from "next/image";
 import { toast } from "sonner";
 
-const Hero3: React.FC = () => {
-  const sectionRef = useRef(null);
-  // Set `once: true` to trigger only once when section enters viewport
-  const isInView = useInView(sectionRef, { once: true, margin: "-100px" });
-  const { scrollYProgress } = useScroll({
-    target: sectionRef,
-    offset: ["start end", "end start"],
-  });
+const featureItems = [
+  {
+    label: "Reducing time-to-value for prospects and users",
+    icon: "check",
+  },
+  {
+    label: "Professional voiceover and background music",
+    icon: "briefcase",
+  },
+  {
+    label: "Compelling video editing workspace integration",
+    icon: "music",
+  },
+];
+
+const useBookDemoForm = () => {
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
   const [company, setCompany] = useState(""); // Added state for company
   const [url, setUrl] = useState(""); // Added state for product URL
-
-  const y1 = useTransform(scrollYProgress, [0, 1], [0, -50]);
-  const y2 = useTransform(scrollYProgress, [0, 1], [0, 50]);
-  const scale = useTransform(scrollYProgress, [0, 0.5, 1], [1, 1.02, 1]);
-
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -64,6 +67,218 @@ const Hero3: React.FC = () => {
     }
   };
 
+  return {
+    email,
+    setEmail,
+    name,
+    setName,
+    company,
+    setCompany,
+    url,
+    setUrl,
+    isSubmitting,
+    handleSubmit,
+  };
+};
+
+const BookDemoInfo: React.FC<{ isInView: boolean }> = ({ isInView }) => (
+  <>
+    <motion.h1
+      className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold text-gray-900 mb-4 sm:mb-6 leading-tight"
+      initial={{ opacity: 0, y: 60, rotateX: -15 }}
+      animate={{
+        opacity: isInView ? 1 : 0,
+        y: isInView ? 0 : 60,
+        rotateX: isInView ? 0 : -15,
+      }}
+      transition={{
+        duration: 0.8,
+        ease: easeOut,
+      }}
+      style={{ fontWeight: 700 }}
+    >
+      <span className="text-[#494369]">Ready to Transform Your</span>{" "}
+      <span className="text-[#8A76FC]/70">Product Demos?</span>
+    </motion.h1>
+    <motion.p
+      className="text-sm sm:text-base md:text-lg text-gray-700 mb-6 sm:mb-8"
+      initial={{ opacity: 0, y: 60 }}
+      animate={{
+        opacity: isInView ? 1 : 0,
+        y: isInView ? 0 : 60,
+      }}
+      transition={{
+        duration: 0.8,
+        ease: easeOut,
+        delay: 0.2,
+      }}
+    >
+      An edge that you will get and let your product <br className="hidden sm:block" /> speak for
+      itself.
+    </motion.p>
+    <motion.ul
+      className="text-gray-700 space-y-4 sm:space-y-6 text-sm sm:text-base md:text-lg"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: isInView ? 1 : 0 }}
+      transition={{
+        duration: 0.8,
+        ease: easeOut,
+        delay: 0.4,
+      }}
+    >
+      {featureItems.map((item, index) => (
+        <motion.li
+          key={index}
+          className="flex items-start"
+          initial={{ opacity: 0, x: -20 }}
+          animate={{
+            opacity: isInView ? 1 : 0,
+            x: isInView ? 0 : -20,
+          }}
+          transition={{
+            duration: 0.5,
+            ease: easeOut,
+            delay: 0.6 + index * 0.1,
+          }}
+          whileHover={{ x: 5, scale: 1.02 }}
+        >
+          <span className="mr-3 shrink-0 flex items-center justify-center">
+            {item.icon === "check" && <Check color="#8C5BFF" size={24} strokeWidth={3} />}
+            {item.icon === "briefcase" && (
+              <Image src="/solar_card-broken.png" alt="voiceover" width={24} height={24} />
+            )}
+            {item.icon === "music" && (
+              <Image src="/iconamoon_headphone.png" alt="editing" width={24} height={24} />
+            )}
+          </span>
+          {item.label}
+        </motion.li>
+      ))}
+    </motion.ul>
+  </>
+);
+
+const DemoInput: React.FC<{
+  type: string;
+  placeholder: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  isInView: boolean;
+  delay: number;
+}> = ({ type, placeholder, value, onChange, isInView, delay }) => (
+  <motion.input
+    type={type}
+    placeholder={placeholder}
+    value={value}
+    onChange={onChange}
+    className="w-full py-3 sm:py-4 px-4 sm:px-5 rounded-lg bg-[#DCC8FF] text-gray-700 text-sm sm:text-base placeholder:text-white/70 focus:outline-none focus:ring-2 focus:ring-white"
+    style={{ fontFamily: "var(--font-raleway)", fontWeight: 400 }}
+    whileFocus={{
+      scale: 1.02,
+      boxShadow: "0 0 20px rgba(255, 255, 255, 0.2)",
+    }}
+    initial={{ opacity: 0, y: 20 }}
+    animate={{
+      opacity: isInView ? 1 : 0,
+      y: isInView ? 0 : 20,
+    }}
+    transition={{
+      duration: 0.5,
+      ease: easeOut,
+      delay,
+    }}
+  />
+);
+
+const BookDemoForm: React.FC<{ isInView: boolean }> = ({ isInView }) => {
+  const {
+    email,
+    setEmail,
+    name,
+    setName,
+    company,
+    setCompany,
+    url,
+    setUrl,
+    isSubmitting,
+    handleSubmit,
+  } = useBookDemoForm();
+
+  return (
+    <form className="space-y-4 sm:space-y-6" onSubmit={handleSubmit}>
+      <DemoInput
+        type="email"
+        placeholder="Enter your Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        isInView={isInView}
+        delay={0.5}
+      />
+      <DemoInput
+        type="text"
+        placeholder="Full Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        isInView={isInView}
+        delay={0.6}
+      />
+      <DemoInput
+        type="text"
+        placeholder="Company"
+        value={company}
+        onChange={(e) => setCompany(e.target.value)}
+        isInView={isInView}
+        delay={0.7}
+      />
+      <DemoInput
+        type="text"
+        placeholder="Product URL (Optional)"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        isInView={isInView}
+        delay={0.8}
+      />
+      <motion.button
+        type="submit"
+        disabled={isSubmitting}
+        className="w-full cursor-pointer py-3 sm:py-4 bg-white text-[#8370F0] font-semibold rounded-lg flex items-center justify-center gap-2 text-sm sm:text-base hover:bg-purple-100 transition"
+        whileHover={{
+          scale: 1.05,
+          boxShadow: "0 10px 25px rgba(0, 0, 0, 0.1)",
+          y: -2,
+        }}
+        whileTap={{ scale: 0.95 }}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{
+          opacity: isInView ? 1 : 0,
+          y: isInView ? 0 : 20,
+        }}
+        transition={{
+          duration: 0.5,
+          ease: easeOut,
+          delay: 0.9,
+        }}
+      >
+        <Image src="/Group 55.png" alt="Start Free Trial" width={20} height={20} />
+        {isSubmitting ? "Sending..." : "Book a Demo"}
+      </motion.button>
+    </form>
+  );
+};
+
+const Hero3: React.FC = () => {
+  const sectionRef = useRef(null);
+  // Set `once: true` to trigger only once when section enters viewport
+  const isInView = useInView(sectionRef, { once: true, margin: "-100px" });
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start end", "end start"],
+  });
+
+  const y1 = useTransform(scrollYProgress, [0, 1], [0, -50]);
+  const y2 = useTransform(scrollYProgress, [0, 1], [0, 50]);
+  const scale = useTransform(scrollYProgress, [0, 0.5, 1], [1, 1.02, 1]);
+
   return (
     <div
       id="book-demo"
@@ -86,91 +301,7 @@ const Hero3: React.FC = () => {
             }}
             style={{ y: y1, fontFamily: "var(--font-raleway)" }}
           >
-            <motion.h1
-              className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold text-gray-900 mb-4 sm:mb-6 leading-tight"
-              initial={{ opacity: 0, y: 60, rotateX: -15 }}
-              animate={{
-                opacity: isInView ? 1 : 0,
-                y: isInView ? 0 : 60,
-                rotateX: isInView ? 0 : -15,
-              }}
-              transition={{
-                duration: 0.8,
-                ease: easeOut,
-              }}
-              style={{ fontWeight: 700 }}
-            >
-              <span className="text-[#494369]">Ready to Transform Your</span>{" "}
-              <span className="text-[#8A76FC]/70">Product Demos?</span>
-            </motion.h1>
-            <motion.p
-              className="text-sm sm:text-base md:text-lg text-gray-700 mb-6 sm:mb-8"
-              initial={{ opacity: 0, y: 60 }}
-              animate={{
-                opacity: isInView ? 1 : 0,
-                y: isInView ? 0 : 60,
-              }}
-              transition={{
-                duration: 0.8,
-                ease: easeOut,
-                delay: 0.2,
-              }}
-            >
-              An edge that you will get and let your product <br className="hidden sm:block" />{" "}
-              speak for itself.
-            </motion.p>
-            <motion.ul
-              className="text-gray-700 space-y-4 sm:space-y-6 text-sm sm:text-base md:text-lg"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: isInView ? 1 : 0 }}
-              transition={{
-                duration: 0.8,
-                ease: easeOut,
-                delay: 0.4,
-              }}
-            >
-              {[
-                {
-                  label: "Reducing time-to-value for prospects and users",
-                  icon: "check",
-                },
-                {
-                  label: "Professional voiceover and background music",
-                  icon: "briefcase",
-                },
-                {
-                  label: "Compelling video editing workspace integration",
-                  icon: "music",
-                },
-              ].map((item, index) => (
-                <motion.li
-                  key={index}
-                  className="flex items-start"
-                  initial={{ opacity: 0, x: -20 }}
-                  animate={{
-                    opacity: isInView ? 1 : 0,
-                    x: isInView ? 0 : -20,
-                  }}
-                  transition={{
-                    duration: 0.5,
-                    ease: easeOut,
-                    delay: 0.6 + index * 0.1,
-                  }}
-                  whileHover={{ x: 5, scale: 1.02 }}
-                >
-                  <span className="mr-3 shrink-0 flex items-center justify-center">
-                    {item.icon === "check" && <Check color="#8C5BFF" size={24} strokeWidth={3} />}
-                    {item.icon === "briefcase" && (
-                      <Image src="/solar_card-broken.png" alt="voiceover" width={24} height={24} />
-                    )}
-                    {item.icon === "music" && (
-                      <Image src="/iconamoon_headphone.png" alt="editing" width={24} height={24} />
-                    )}
-                  </span>
-                  {item.label}
-                </motion.li>
-              ))}
-            </motion.ul>
+            <BookDemoInfo isInView={isInView} />
           </motion.div>
           <motion.div
             className="mt-6 md:mt-0 w-full max-w-md p-4 sm:p-6 md:p-8 rounded-2xl shadow-lg sm:shadow-xl relative z-10 shrink-0"
@@ -195,120 +326,7 @@ const Hero3: React.FC = () => {
               y: -5,
             }}
           >
-            <form className="space-y-4 sm:space-y-6" onSubmit={handleSubmit}>
-              <motion.input
-                type="email"
-                placeholder="Enter your Email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="w-full py-3 sm:py-4 px-4 sm:px-5 rounded-lg bg-[#DCC8FF] text-gray-700 text-sm sm:text-base placeholder:text-white/70 focus:outline-none focus:ring-2 focus:ring-white"
-                style={{ fontFamily: "var(--font-raleway)", fontWeight: 400 }}
-                whileFocus={{
-                  scale: 1.02,
-                  boxShadow: "0 0 20px rgba(255, 255, 255, 0.2)",
-                }}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{
-                  opacity: isInView ? 1 : 0,
-                  y: isInView ? 0 : 20,
-                }}
-                transition={{
-                  duration: 0.5,
-                  ease: easeOut,
-                  delay: 0.5,
-                }}
-              />
-              <motion.input
-                type="text"
-                placeholder="Full Name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                className="w-full py-3 sm:py-4 px-4 sm:px-5 rounded-lg bg-[#DCC8FF] text-gray-700 text-sm sm:text-base placeholder:text-white/70 focus:outline-none focus:ring-2 focus:ring-white"
-                style={{ fontFamily: "var(--font-raleway)", fontWeight: 400 }}
-                whileFocus={{
-                  scale: 1.02,
-                  boxShadow: "0 0 20px rgba(255, 255, 255, 0.2)",
-                }}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{
-                  opacity: isInView ? 1 : 0,
-                  y: isInView ? 0 : 20,
-                }}
-                transition={{
-                  duration: 0.5,
-                  ease: easeOut,
-                  delay: 0.6,
-                }}
-              />
-              <motion.input
-                type="text"
-                placeholder="Company"
-                value={company}
-                onChange={(e) => setCompany(e.target.value)}
-                className="w-full py-3 sm:py-4 px-4 sm:px-5 rounded-lg bg-[#DCC8FF] text-gray-700 text-sm sm:text-base placeholder:text-white/70 focus:outline-none focus:ring-2 focus:ring-white"
-                style={{ fontFamily: "var(--font-raleway)", fontWeight: 400 }}
-                whileFocus={{
-                  scale: 1.02,
-                  boxShadow: "0 0 20px rgba(255, 255, 255, 0.2)",
-                }}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{
-                  opacity: isInView ? 1 : 0,
-                  y: isInView ? 0 : 20,
-                }}
-                transition={{
-                  duration: 0.5,
-                  ease: easeOut,
-                  delay: 0.7,
-                }}
-              />
-              <motion.input
-                type="text"
-                placeholder="Product URL (Optional)"
-                value={url}
-                onChange={(e) => setUrl(e.target.value)}
-                className="w-full py-3 sm:py-4 px-4 sm:px-5 rounded-lg bg-[#DCC8FF] text-gray-700 text-sm sm:text-base placeholder:text-white/70 focus:outline-none focus:ring-2 focus:ring-white"
-                style={{ fontFamily: "var(--font-raleway)", fontWeight: 400 }}
-                whileFocus={{
-                  scale: 1.02,
-                  boxShadow: "0 0 20px rgba(255, 255, 255, 0.2)",
-                }}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{
-                  opacity: isInView ? 1 : 0,
-                  y: isInView ? 0 : 20,
-                }}
-                transition={{
-                  duration: 0.5,
-                  ease: easeOut,
-                  delay: 0.8,
-                }}
-              />
-              <motion.button
-                type="submit"
-                disabled={isSubmitting}
-                className="w-full cursor-pointer py-3 sm:py-4 bg-white text-[#8370F0] font-semibold rounded-lg flex items-center justify-center gap-2 text-sm sm:text-base hover:bg-purple-100 transition"
-                whileHover={{
-                  scale: 1.05,
-                  boxShadow: "0 10px 25px rgba(0, 0, 0, 0.1)",
-                  y: -2,
-                }}
-                whileTap={{ scale: 0.95 }}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{
-                  opacity: isInView ? 1 : 0,
-                  y: isInView ? 0 : 20,
-                }}
-                transition={{
-                  duration: 0.5,
-                  ease: easeOut,
-                  delay: 0.9,
-                }}
-              >
-                <Image src="/Group 55.png" alt="Start Free Trial" width={20} height={20} />
-                {isSubmitting ? "Sending..." : "Book a Demo"}
-              </motion.button>
-            </form>
+            <BookDemoForm isInView={isInView} />
           </motion.div>
         </div>
       </div>

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -7,6 +7,12 @@ import { useSession } from "next-auth/react";
 import { Menu, X, Sun, Moon } from "lucide-react";
 import { useTheme } from "next-themes";
 
+const NAV_LINKS = [
+  { id: "features", label: "Features" },
+  { id: "pricing", label: "Pricing" },
+  { id: "reviews", label: "Reviews" },
+];
+
 const NavButton: React.FC<{
   children: React.ReactNode;
   onClick: () => void;
@@ -19,6 +25,88 @@ const NavButton: React.FC<{
     {children}
   </button>
 );
+
+const NavbarLogo: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="flex items-center space-x-3 cursor-pointer"
+    aria-label="Go to dashboard"
+  >
+    <Image
+      src="/images/Transparent logo.png"
+      alt="Marvedge logo"
+      width={80}
+      height={80}
+      className="w-12 h-12 md:w-16 md:h-16 object-contain dark:hidden"
+      priority
+    />
+    <Image
+      src="/images/logo_dark.png"
+      alt="Marvedge logo dark"
+      width={80}
+      height={80}
+      className="w-12 h-12 md:w-16 md:h-16 object-contain hidden dark:block"
+      priority
+    />
+    <span className="text-[#8C5BFF] dark:text-[#9c7dff] text-xl md:text-2xl font-semibold">
+      Marvedge
+    </span>
+  </button>
+);
+
+const ThemeToggle: React.FC<{ isDark: boolean; onToggle: () => void }> = ({ isDark, onToggle }) => (
+  <button
+    onClick={onToggle}
+    className="relative w-[46px] h-[24px] sm:w-[50px] sm:h-[26px] rounded-full flex items-center justify-between px-1.5 transition-colors duration-300 cursor-pointer border outline-none bg-[#F1ECFF] border-[#bcb3f7] dark:bg-[#151229] dark:border-[rgba(255,255,255,0.08)]"
+    aria-label="Toggle theme"
+  >
+    <Sun
+      size={12}
+      className="transition-all duration-300 text-amber-500 fill-amber-500/20 dark:text-gray-400 dark:opacity-30 dark:fill-none"
+    />
+    <Moon
+      size={12}
+      className="transition-all duration-300 text-gray-400 opacity-30 dark:text-[#a085ff] dark:opacity-100"
+    />
+    <div
+      className={`absolute top-[2px] left-[2px] w-[18px] h-[18px] sm:w-[20px] sm:h-[20px] rounded-full shadow-md transition-all duration-300 flex items-center justify-center ${
+        isDark
+          ? "translate-x-[24px] sm:translate-x-[26px] bg-gradient-to-b from-[#8a63ff] to-[#5c38f7]"
+          : "translate-x-0 bg-white"
+      }`}
+    >
+      {isDark ? (
+        <Moon size={10} className="text-white fill-white/10" />
+      ) : (
+        <Sun size={10} className="text-amber-500 fill-amber-500/10" />
+      )}
+    </div>
+  </button>
+);
+
+const NavLinks: React.FC<{ onNavigate?: () => void }> = ({ onNavigate }) => {
+  const router = useRouter();
+  return (
+    <>
+      {NAV_LINKS.map((link) => (
+        <NavButton
+          key={link.id}
+          onClick={() => {
+            if (window.location.pathname === "/") {
+              document.getElementById(link.id)?.scrollIntoView({ behavior: "smooth" });
+            } else {
+              router.push(`/#${link.id}`);
+            }
+            onNavigate?.();
+          }}
+        >
+          {link.label}
+        </NavButton>
+      ))}
+    </>
+  );
+};
 
 const Navbar: React.FC = () => {
   const router = useRouter();
@@ -47,37 +135,14 @@ const Navbar: React.FC = () => {
     router.push("/");
   };
 
+  const handleThemeToggle = () => setTheme(isDark ? "light" : "dark");
+
   return (
     <>
       <nav className="fixed top-0 left-0 w-full z-50 bg-white dark:bg-[#05050d] border-b border-gray-100 dark:border-[rgba(255,255,255,0.08)] min-h-20 flex flex-col justify-start transition-colors duration-300">
         <div className="px-4 sm:px-6 w-full">
           <div className="flex items-center justify-between w-full pt-2">
-            <button
-              type="button"
-              onClick={handleLogoClick}
-              className="flex items-center space-x-3 cursor-pointer"
-              aria-label="Go to dashboard"
-            >
-              <Image
-                src="/images/Transparent logo.png"
-                alt="Marvedge logo"
-                width={80}
-                height={80}
-                className="w-12 h-12 md:w-16 md:h-16 object-contain dark:hidden"
-                priority
-              />
-              <Image
-                src="/images/logo_dark.png"
-                alt="Marvedge logo dark"
-                width={80}
-                height={80}
-                className="w-12 h-12 md:w-16 md:h-16 object-contain hidden dark:block"
-                priority
-              />
-              <span className="text-[#8C5BFF] dark:text-[#9c7dff] text-xl md:text-2xl font-semibold">
-                Marvedge
-              </span>
-            </button>
+            <NavbarLogo onClick={handleLogoClick} />
             <button
               onClick={toggleMenu}
               className="md:hidden text-[#313053] dark:text-white focus:outline-none focus:ring-2 focus:ring-[#8C5BFF] p-2"
@@ -91,66 +156,8 @@ const Navbar: React.FC = () => {
 
         {pathname !== "/pricing" && (
           <div className="hidden md:flex items-center space-x-8 text-[#313053] dark:text-white font-medium absolute right-8 top-6">
-            <button
-              onClick={() => setTheme(isDark ? "light" : "dark")}
-              className="relative w-[46px] h-[24px] sm:w-[50px] sm:h-[26px] rounded-full flex items-center justify-between px-1.5 transition-colors duration-300 cursor-pointer border outline-none bg-[#F1ECFF] border-[#bcb3f7] dark:bg-[#151229] dark:border-[rgba(255,255,255,0.08)]"
-              aria-label="Toggle theme"
-            >
-              <Sun
-                size={12}
-                className="transition-all duration-300 text-amber-500 fill-amber-500/20 dark:text-gray-400 dark:opacity-30 dark:fill-none"
-              />
-              <Moon
-                size={12}
-                className="transition-all duration-300 text-gray-400 opacity-30 dark:text-[#a085ff] dark:opacity-100"
-              />
-              <div
-                className={`absolute top-[2px] left-[2px] w-[18px] h-[18px] sm:w-[20px] sm:h-[20px] rounded-full shadow-md transition-all duration-300 flex items-center justify-center ${
-                  isDark
-                    ? "translate-x-[24px] sm:translate-x-[26px] bg-gradient-to-b from-[#8a63ff] to-[#5c38f7]"
-                    : "translate-x-0 bg-white"
-                }`}
-              >
-                {isDark ? (
-                  <Moon size={10} className="text-white fill-white/10" />
-                ) : (
-                  <Sun size={10} className="text-amber-500 fill-amber-500/10" />
-                )}
-              </div>
-            </button>
-            <NavButton
-              onClick={() => {
-                if (window.location.pathname === "/") {
-                  document.getElementById("features")?.scrollIntoView({ behavior: "smooth" });
-                } else {
-                  router.push("/#features");
-                }
-              }}
-            >
-              Features
-            </NavButton>
-            <NavButton
-              onClick={() => {
-                if (window.location.pathname === "/") {
-                  document.getElementById("pricing")?.scrollIntoView({ behavior: "smooth" });
-                } else {
-                  router.push("/#pricing");
-                }
-              }}
-            >
-              Pricing
-            </NavButton>
-            <NavButton
-              onClick={() => {
-                if (window.location.pathname === "/") {
-                  document.getElementById("reviews")?.scrollIntoView({ behavior: "smooth" });
-                } else {
-                  router.push("/#reviews");
-                }
-              }}
-            >
-              Reviews
-            </NavButton>
+            <ThemeToggle isDark={isDark} onToggle={handleThemeToggle} />
+            <NavLinks />
           </div>
         )}
 
@@ -160,70 +167,9 @@ const Navbar: React.FC = () => {
               <span className="text-[#313053] dark:text-gray-300 text-sm font-semibold">
                 Switch Theme
               </span>
-              <button
-                onClick={() => setTheme(isDark ? "light" : "dark")}
-                className="relative w-[46px] h-[24px] sm:w-[50px] sm:h-[26px] rounded-full flex items-center justify-between px-1.5 transition-colors duration-300 cursor-pointer border outline-none bg-[#F1ECFF] border-[#bcb3f7] dark:bg-[#151229] dark:border-[rgba(255,255,255,0.08)]"
-                aria-label="Toggle theme"
-              >
-                <Sun
-                  size={12}
-                  className="transition-all duration-300 text-amber-500 fill-amber-500/20 dark:text-gray-400 dark:opacity-30 dark:fill-none"
-                />
-                <Moon
-                  size={12}
-                  className="transition-all duration-300 text-gray-400 opacity-30 dark:text-[#a085ff] dark:opacity-100"
-                />
-                <div
-                  className={`absolute top-[2px] left-[2px] w-[18px] h-[18px] sm:w-[20px] sm:h-[20px] rounded-full shadow-md transition-all duration-300 flex items-center justify-center ${
-                    isDark
-                      ? "translate-x-[24px] sm:translate-x-[26px] bg-gradient-to-b from-[#8a63ff] to-[#5c38f7]"
-                      : "translate-x-0 bg-white"
-                  }`}
-                >
-                  {isDark ? (
-                    <Moon size={10} className="text-white fill-white/10" />
-                  ) : (
-                    <Sun size={10} className="text-amber-500 fill-amber-500/10" />
-                  )}
-                </div>
-              </button>
+              <ThemeToggle isDark={isDark} onToggle={handleThemeToggle} />
             </div>
-            <NavButton
-              onClick={() => {
-                if (window.location.pathname === "/") {
-                  document.getElementById("features")?.scrollIntoView({ behavior: "smooth" });
-                } else {
-                  router.push("/#features");
-                }
-                toggleMenu();
-              }}
-            >
-              Features
-            </NavButton>
-            <NavButton
-              onClick={() => {
-                if (window.location.pathname === "/") {
-                  document.getElementById("pricing")?.scrollIntoView({ behavior: "smooth" });
-                } else {
-                  router.push("/#pricing");
-                }
-                toggleMenu();
-              }}
-            >
-              Pricing
-            </NavButton>
-            <NavButton
-              onClick={() => {
-                if (window.location.pathname === "/") {
-                  document.getElementById("reviews")?.scrollIntoView({ behavior: "smooth" });
-                } else {
-                  router.push("/#reviews");
-                }
-                toggleMenu();
-              }}
-            >
-              Reviews
-            </NavButton>
+            <NavLinks onNavigate={toggleMenu} />
           </div>
         )}
       </nav>

--- a/app/components/Pricing.tsx
+++ b/app/components/Pricing.tsx
@@ -8,15 +8,36 @@ import { useSession } from "next-auth/react";
 import Script from "next/script";
 import { toast } from "react-hot-toast";
 
-const Pricing: React.FC = () => {
-  const sectionRef = useRef<HTMLDivElement>(null);
-  const isInView = useInView(sectionRef, { once: true, margin: "-50px" });
+const freeFeatures = [
+  "Record up to 5 mins",
+  "Basic edit features",
+  "Up to 3 demos",
+  "Basic analytics included",
+  "Export 1 demo",
+];
+
+const proFeatures = [
+  "Full recording/editing",
+  "AI voiceover & subtitles",
+  "5 GB storage",
+  "30 demos/month",
+  "Request custom branding",
+];
+
+const enterpriseFeatures = [
+  "Everything in Pro",
+  "SSO & advanced analytics",
+  "Onboarding support",
+  "Unlimited demos & viewers",
+  "High usage or white-glove needs",
+];
+
+const usePricingCheckout = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { status } = useSession();
-  const [loading, setLoading] = useState(false);
-
   const pathname = usePathname();
+  const [loading, setLoading] = useState(false);
 
   const handleAuthRedirect = async (amount: number, plan: string) => {
     if (plan === "enterprise") {
@@ -102,6 +123,157 @@ const Pricing: React.FC = () => {
     }
   };
 
+  return { handleAuthRedirect, loading };
+};
+
+const PricingHeader: React.FC<{ isInView: boolean }> = ({ isInView }) => (
+  <motion.div
+    className="text-center mb-16"
+    initial={{ opacity: 0, y: 30 }}
+    animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 30 }}
+    transition={{ duration: 0.6, ease: easeOut }}
+  >
+    <div className="inline-block bg-[#EBE5FF] text-[#514088] rounded-full px-6 py-2 text-sm font-semibold mb-6">
+      Pricing Plans
+    </div>
+    <h2 className="text-4xl md:text-5xl font-bold text-[#3B3356] mb-4">
+      Simple, <span className="text-[#8C5BFF]">Transparent Pricing</span>
+    </h2>
+    <p className="text-[#666666] text-lg max-w-2xl mx-auto">
+      All plans include a 14-day free trial with no credit card required.
+    </p>
+  </motion.div>
+);
+
+const FreePlanCard: React.FC<{ isInView: boolean; onSelect: () => void }> = ({
+  isInView,
+  onSelect,
+}) => (
+  <motion.div
+    className="flex-1 bg-white rounded-[2rem] border border-[#E9E4F5] p-8 md:p-10 shadow-[0_8px_30px_rgb(0,0,0,0.04)] hover:shadow-[0_8px_30px_rgb(0,0,0,0.08)] transition-all duration-300 relative flex flex-col"
+    initial={{ opacity: 0, y: 40 }}
+    animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 40 }}
+    transition={{ duration: 0.6, ease: easeOut, delay: 0.2 }}
+  >
+    <div className="mb-6">
+      <h3 className="text-3xl font-bold text-[#1A1A1A] mb-2">Free</h3>
+      <p className="text-[#666666] text-sm">Perfect for trying out FlowSaaS</p>
+    </div>
+    <div className="mb-8">
+      <div className="flex items-end">
+        <span className="text-5xl font-extrabold text-[#1A1A1A]">$0</span>
+        <span className="text-gray-500 text-lg mb-1 ml-1">/month</span>
+      </div>
+    </div>
+    <button
+      onClick={onSelect}
+      className="w-full bg-[#8C5BFF] hover:bg-[#7a4fcf] text-white font-semibold rounded-xl py-4 text-lg transition-colors cursor-pointer mb-8"
+    >
+      Get Started
+    </button>
+    <div className="flex-1">
+      <ul className="space-y-4">
+        {freeFeatures.map((feature, i) => (
+          <li key={i} className="flex items-start text-[#4A4A4A]">
+            <Check className="w-5 h-5 text-[#8C5BFF] mr-3 shrink-0 mt-0.5" strokeWidth={2.5} />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </motion.div>
+);
+
+const ProPlanCard: React.FC<{ isInView: boolean; loading: boolean; onSelect: () => void }> = ({
+  isInView,
+  loading,
+  onSelect,
+}) => (
+  <motion.div
+    className="flex-1 bg-[#8C5BFF] rounded-[2rem] p-8 md:p-10 shadow-[0_20px_40px_rgba(140,91,255,0.3)] hover:-translate-y-2 transition-all duration-300 relative flex flex-col z-10 lg:scale-[1.05]"
+    initial={{ opacity: 0, y: 40 }}
+    animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 40 }}
+    transition={{ duration: 0.6, ease: easeOut, delay: 0.4 }}
+  >
+    <div className="absolute top-8 right-8">
+      <span className="bg-[#FAA226] text-white text-sm font-bold px-4 py-1.5 rounded-full shadow-md">
+        Most Popular
+      </span>
+    </div>
+    <div className="mb-6 mt-2">
+      <h3 className="text-3xl font-bold text-white mb-2">Pro</h3>
+      <p className="text-white/80 text-sm">Perfect for trying out FlowSaaS</p>
+    </div>
+    <div className="mb-8">
+      <div className="flex items-end">
+        <span className="text-5xl font-extrabold text-white">$49</span>
+        <span className="text-white/80 text-lg mb-1 ml-1">/month</span>
+      </div>
+    </div>
+    <button
+      onClick={onSelect}
+      className="w-full bg-white hover:bg-gray-50 text-[#8C5BFF] font-semibold rounded-xl py-4 text-lg transition-colors cursor-pointer mb-8 shadow-md disabled:opacity-50"
+      disabled={loading}
+    >
+      {loading ? "Loading..." : "Start Free Trial"}
+    </button>
+    <div className="flex-1">
+      <ul className="space-y-4">
+        {proFeatures.map((feature, i) => (
+          <li key={i} className="flex items-start text-white">
+            <span className="w-5 h-5 rounded-full bg-white flex items-center justify-center mr-3 shrink-0 mt-0.5">
+              <Check className="w-3.5 h-3.5 text-[#8C5BFF]" strokeWidth={3} />
+            </span>
+            <span className="font-medium text-white/95">{feature}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </motion.div>
+);
+
+const EnterprisePlanCard: React.FC<{ isInView: boolean; onSelect: () => void }> = ({
+  isInView,
+  onSelect,
+}) => (
+  <motion.div
+    className="flex-1 bg-white rounded-[2rem] border border-[#E9E4F5] p-8 md:p-10 shadow-[0_8px_30px_rgb(0,0,0,0.04)] hover:shadow-[0_8px_30px_rgb(0,0,0,0.08)] transition-all duration-300 relative flex flex-col"
+    initial={{ opacity: 0, y: 40 }}
+    animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 40 }}
+    transition={{ duration: 0.6, ease: easeOut, delay: 0.6 }}
+  >
+    <div className="mb-6">
+      <h3 className="text-3xl font-bold text-[#1A1A1A] mb-2">Enterprise</h3>
+      <p className="text-[#666666] text-sm">For large organizations</p>
+    </div>
+    <div className="mb-8 h-[60px] flex items-end">
+      <span className="text-4xl font-extrabold text-[#1A1A1A]">Enterprise</span>
+    </div>
+    <button
+      onClick={onSelect}
+      className="w-full bg-[#8C5BFF] hover:bg-[#7a4fcf] text-white font-semibold rounded-xl py-4 text-lg transition-colors cursor-pointer mb-8"
+    >
+      Contact Us
+    </button>
+    <div className="flex-1">
+      <ul className="space-y-4">
+        {enterpriseFeatures.map((feature, i) => (
+          <li key={i} className="flex items-start text-[#4A4A4A]">
+            <Check className="w-5 h-5 text-[#8C5BFF] mr-3 shrink-0 mt-0.5" strokeWidth={2.5} />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </motion.div>
+);
+
+const Pricing: React.FC = () => {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const isInView = useInView(sectionRef, { once: true, margin: "-50px" });
+  const pathname = usePathname();
+  const { handleAuthRedirect, loading } = usePricingCheckout();
+
   return (
     <div
       id="pricing"
@@ -112,160 +284,20 @@ const Pricing: React.FC = () => {
       <Script src="https://checkout.razorpay.com/v1/checkout.js" />
       <div className="max-w-7xl auto mx-auto">
         {/* Header */}
-        {pathname !== "/pricing" && (
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 30 }}
-            transition={{ duration: 0.6, ease: easeOut }}
-          >
-            <div className="inline-block bg-[#EBE5FF] text-[#514088] rounded-full px-6 py-2 text-sm font-semibold mb-6">
-              Pricing Plans
-            </div>
-            <h2 className="text-4xl md:text-5xl font-bold text-[#3B3356] mb-4">
-              Simple, <span className="text-[#8C5BFF]">Transparent Pricing</span>
-            </h2>
-            <p className="text-[#666666] text-lg max-w-2xl mx-auto">
-              All plans include a 14-day free trial with no credit card required.
-            </p>
-          </motion.div>
-        )}
+        {pathname !== "/pricing" && <PricingHeader isInView={isInView} />}
 
         {/* Pricing Cards */}
         <div className="flex flex-col lg:flex-row justify-center items-stretch gap-8 lg:gap-10 mt-12 px-4 max-w-6xl mx-auto">
-          {/* Free Plan */}
-          <motion.div
-            className="flex-1 bg-white rounded-[2rem] border border-[#E9E4F5] p-8 md:p-10 shadow-[0_8px_30px_rgb(0,0,0,0.04)] hover:shadow-[0_8px_30px_rgb(0,0,0,0.08)] transition-all duration-300 relative flex flex-col"
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 40 }}
-            transition={{ duration: 0.6, ease: easeOut, delay: 0.2 }}
-          >
-            <div className="mb-6">
-              <h3 className="text-3xl font-bold text-[#1A1A1A] mb-2">Free</h3>
-              <p className="text-[#666666] text-sm">Perfect for trying out FlowSaaS</p>
-            </div>
-            <div className="mb-8">
-              <div className="flex items-end">
-                <span className="text-5xl font-extrabold text-[#1A1A1A]">$0</span>
-                <span className="text-gray-500 text-lg mb-1 ml-1">/month</span>
-              </div>
-            </div>
-            <button
-              onClick={() => handleAuthRedirect(0, "free")}
-              className="w-full bg-[#8C5BFF] hover:bg-[#7a4fcf] text-white font-semibold rounded-xl py-4 text-lg transition-colors cursor-pointer mb-8"
-            >
-              Get Started
-            </button>
-            <div className="flex-1">
-              <ul className="space-y-4">
-                {[
-                  "Record up to 5 mins",
-                  "Basic edit features",
-                  "Up to 3 demos",
-                  "Basic analytics included",
-                  "Export 1 demo",
-                ].map((feature, i) => (
-                  <li key={i} className="flex items-start text-[#4A4A4A]">
-                    <Check
-                      className="w-5 h-5 text-[#8C5BFF] mr-3 shrink-0 mt-0.5"
-                      strokeWidth={2.5}
-                    />
-                    <span>{feature}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </motion.div>
-
-          {/* Pro Plan */}
-          <motion.div
-            className="flex-1 bg-[#8C5BFF] rounded-[2rem] p-8 md:p-10 shadow-[0_20px_40px_rgba(140,91,255,0.3)] hover:-translate-y-2 transition-all duration-300 relative flex flex-col z-10 lg:scale-[1.05]"
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 40 }}
-            transition={{ duration: 0.6, ease: easeOut, delay: 0.4 }}
-          >
-            <div className="absolute top-8 right-8">
-              <span className="bg-[#FAA226] text-white text-sm font-bold px-4 py-1.5 rounded-full shadow-md">
-                Most Popular
-              </span>
-            </div>
-            <div className="mb-6 mt-2">
-              <h3 className="text-3xl font-bold text-white mb-2">Pro</h3>
-              <p className="text-white/80 text-sm">Perfect for trying out FlowSaaS</p>
-            </div>
-            <div className="mb-8">
-              <div className="flex items-end">
-                <span className="text-5xl font-extrabold text-white">$49</span>
-                <span className="text-white/80 text-lg mb-1 ml-1">/month</span>
-              </div>
-            </div>
-            <button
-              onClick={() => handleAuthRedirect(49, "pro")}
-              className="w-full bg-white hover:bg-gray-50 text-[#8C5BFF] font-semibold rounded-xl py-4 text-lg transition-colors cursor-pointer mb-8 shadow-md disabled:opacity-50"
-              disabled={loading}
-            >
-              {loading ? "Loading..." : "Start Free Trial"}
-            </button>
-            <div className="flex-1">
-              <ul className="space-y-4">
-                {[
-                  "Full recording/editing",
-                  "AI voiceover & subtitles",
-                  "5 GB storage",
-                  "30 demos/month",
-                  "Request custom branding",
-                ].map((feature, i) => (
-                  <li key={i} className="flex items-start text-white">
-                    <span className="w-5 h-5 rounded-full bg-white flex items-center justify-center mr-3 shrink-0 mt-0.5">
-                      <Check className="w-3.5 h-3.5 text-[#8C5BFF]" strokeWidth={3} />
-                    </span>
-                    <span className="font-medium text-white/95">{feature}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </motion.div>
-
-          {/* Enterprise Plan */}
-          <motion.div
-            className="flex-1 bg-white rounded-[2rem] border border-[#E9E4F5] p-8 md:p-10 shadow-[0_8px_30px_rgb(0,0,0,0.04)] hover:shadow-[0_8px_30px_rgb(0,0,0,0.08)] transition-all duration-300 relative flex flex-col"
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 40 }}
-            transition={{ duration: 0.6, ease: easeOut, delay: 0.6 }}
-          >
-            <div className="mb-6">
-              <h3 className="text-3xl font-bold text-[#1A1A1A] mb-2">Enterprise</h3>
-              <p className="text-[#666666] text-sm">For large organizations</p>
-            </div>
-            <div className="mb-8 h-[60px] flex items-end">
-              <span className="text-4xl font-extrabold text-[#1A1A1A]">Enterprise</span>
-            </div>
-            <button
-              onClick={() => handleAuthRedirect(0, "enterprise")}
-              className="w-full bg-[#8C5BFF] hover:bg-[#7a4fcf] text-white font-semibold rounded-xl py-4 text-lg transition-colors cursor-pointer mb-8"
-            >
-              Contact Us
-            </button>
-            <div className="flex-1">
-              <ul className="space-y-4">
-                {[
-                  "Everything in Pro",
-                  "SSO & advanced analytics",
-                  "Onboarding support",
-                  "Unlimited demos & viewers",
-                  "High usage or white-glove needs",
-                ].map((feature, i) => (
-                  <li key={i} className="flex items-start text-[#4A4A4A]">
-                    <Check
-                      className="w-5 h-5 text-[#8C5BFF] mr-3 shrink-0 mt-0.5"
-                      strokeWidth={2.5}
-                    />
-                    <span>{feature}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </motion.div>
+          <FreePlanCard isInView={isInView} onSelect={() => handleAuthRedirect(0, "free")} />
+          <ProPlanCard
+            isInView={isInView}
+            loading={loading}
+            onSelect={() => handleAuthRedirect(49, "pro")}
+          />
+          <EnterprisePlanCard
+            isInView={isInView}
+            onSelect={() => handleAuthRedirect(0, "enterprise")}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Refactors the five flagged landing/marketing components so every function is
under 150 lines, clearing the `max-lines-per-function` ESLint warnings tracked
in #196. This is a **pure, behavior-preserving** refactor — no UI, logic, prop,
type, or export-signature changes. All default/named exports keep identical
signatures.

## Changes

| File | Before | What was extracted |
|------|--------|--------------------|
| `app/components/Hero.tsx` | ~232 | Animation variants + `textSegments` → module constants; `HeroBlobs`, `HeroEllipses`, `HeroHeading`, `HeroActions`, `HeroImage` sub-components |
| `app/components/Hero3.tsx` | ~303 | `useBookDemoForm` hook (form state + submit); `BookDemoInfo`, reusable `DemoInput`, `BookDemoForm`; feature list → constant |
| `app/components/Pricing.tsx` | ~251 | `usePricingCheckout` hook (Razorpay/checkout + loading); `PricingHeader`, `FreePlanCard`, `ProPlanCard`, `EnterprisePlanCard`; feature lists → constants |
| `app/components/Navbar.tsx` | ~203 | `NavbarLogo`, `ThemeToggle` (dedupes desktop/mobile), `NavLinks` driven by a `NAV_LINKS` constant |
| `app/components/Footer.tsx` | ~162 | `FooterBrandContent`, `FooterSocials`, `FooterCopyright` |

Extracted sub-components/hooks are co-located at module scope in their parent
files to keep the diff focused. Repeated markup was de-duplicated into shared
components (e.g. the 4 identical Hero3 inputs → one `DemoInput`; the duplicated
Navbar theme toggle → one `ThemeToggle`).

10/40 functions done