### PR TITLE
refactor(auth): split auth pages under max-lines-per-function (#196) 3/13

### DIFF
--- a/app/auth/reset-password/ResetPasswordIllustration.tsx
+++ b/app/auth/reset-password/ResetPasswordIllustration.tsx
@@ -1,0 +1,38 @@
+"use client";
+import Image from "next/image";
+import AuthPulseDots from "@/app/components/AuthPulseDots";
+
+type ResetPasswordIllustrationProps = {
+  animatePanel: boolean;
+};
+
+const ResetPasswordIllustration = ({ animatePanel }: ResetPasswordIllustrationProps) => {
+  return (
+    <div className="hidden md:flex md:w-1/2 relative justify-center items-center overflow-hidden rounded-r-[75px] bg-[#B09EE4]">
+      <div
+        className={`absolute inset-0 bg-[#261753] rounded-r-[75px] z-0 transition-all duration-700 ease-out ${
+          animatePanel ? "mr-[20px]" : "mr-[100%]"
+        }`}
+      />
+      <div className="relative z-10 px-6 sm:px-8">
+        <Image
+          src="/icons/sign-up-Vector.svg"
+          alt="Reset Illustration"
+          width={400}
+          height={400}
+          className="max-w-full h-auto"
+        />
+      </div>
+      <div className="absolute top-4 sm:top-6 left-6 sm:left-10 flex items-center gap-2 sm:gap-3 z-10">
+        <Image src="/icons/logo.png" alt="Logo" width={28} height={28} />
+        <span className="text-base sm:text-lg font-extrabold tracking-wider text-[#B09EE4]">
+          MARVEDGE
+        </span>
+      </div>
+      {/* Pulse elements */}
+      <AuthPulseDots />
+    </div>
+  );
+};
+
+export default ResetPasswordIllustration;

--- a/app/auth/reset-password/ResetPasswordMobileNav.tsx
+++ b/app/auth/reset-password/ResetPasswordMobileNav.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { useRouter } from "next/navigation";
+
+const ResetPasswordMobileNav = () => {
+  const router = useRouter();
+
+  return (
+    <div
+      className="md:hidden absolute top-0 left-0 w-full h-20 bg-gradient-to-b from-[#313053] to-[#261753] z-[1000] flex justify-center items-center shadow-lg"
+      style={{
+        borderBottomLeftRadius: "50% 20%",
+        borderBottomRightRadius: "50% 20%",
+      }}
+    >
+      <div className="flex bg-[#313053]/80 backdrop-blur-sm rounded-full p-1.5 shadow-inner">
+        <button
+          onClick={() => router.push("/auth/signin")}
+          className="px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
+        >
+          Sign In
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordMobileNav;

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -1,123 +1,28 @@
 "use client";
-import { useState, useRef, useEffect, Suspense } from "react";
+import { Suspense } from "react";
 import Image from "next/image";
-import { useRouter, useSearchParams } from "next/navigation";
-import { z } from "zod";
-import { toast } from "sonner";
-import axios from "axios";
-
-const resetPasswordSchema = z
-  .object({
-    email: z.string().min(1, "Please enter your email").email("Invalid email address"),
-    token: z.string().min(1, "Invalid reset token"),
-    password: z.string().min(6, "Password must be at least 6 characters"),
-    confirmPassword: z.string(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: "Passwords do not match",
-    path: ["confirmPassword"],
-  });
+import { useResetPassword } from "./useResetPassword";
+import ResetPasswordMobileNav from "./ResetPasswordMobileNav";
+import ResetPasswordIllustration from "./ResetPasswordIllustration";
 
 const ResetPassword = () => {
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [animatePanel, setAnimatePanel] = useState(false);
-  const emailRef = useRef<HTMLInputElement>(null);
-  const passwordRef = useRef<HTMLInputElement>(null);
-  const confirmPasswordRef = useRef<HTMLInputElement>(null);
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    const timer = setTimeout(() => setAnimatePanel(true), 100);
-    return () => clearTimeout(timer);
-  }, []);
-
-  // Pre-fill email if passed as query param
-  useEffect(() => {
-    const email = searchParams.get("email");
-    if (email && emailRef.current) {
-      emailRef.current.value = email;
-    }
-  }, [searchParams]);
-
-  const togglePassword = () => setShowPassword(!showPassword);
-  const toggleConfirm = () => setShowConfirmPassword(!showConfirmPassword);
-
-  const handleReset = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsLoading(true);
-    const formData = {
-      email: emailRef.current?.value.trim(),
-      token: searchParams.get("token") || "",
-      password: passwordRef.current?.value,
-      confirmPassword: confirmPasswordRef.current?.value,
-    };
-    try {
-      const validated = resetPasswordSchema.parse(formData);
-      const res = await axios.post("/api/auth/verify-reset", validated);
-      if (res.status === 200) {
-        toast.success("Password reset successfully!");
-        setTimeout(() => router.push("/auth/signin"), 1500);
-      }
-    } catch (err) {
-      const message =
-        err instanceof z.ZodError
-          ? err.errors[0].message
-          : (axios.isAxiosError(err) && err.response?.data?.error) || "Reset failed.";
-      toast.error(message);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const {
+    showPassword,
+    togglePassword,
+    showConfirmPassword,
+    toggleConfirm,
+    isLoading,
+    animatePanel,
+    emailRef,
+    passwordRef,
+    confirmPasswordRef,
+    handleReset,
+  } = useResetPassword();
 
   return (
     <div className="flex flex-col md:flex-row h-full min-h-screen font-sans bg-[#F1ECFF]">
-      <div
-        className="md:hidden absolute top-0 left-0 w-full h-20 bg-gradient-to-b from-[#313053] to-[#261753] z-[1000] flex justify-center items-center shadow-lg"
-        style={{
-          borderBottomLeftRadius: "50% 20%",
-          borderBottomRightRadius: "50% 20%",
-        }}
-      >
-        <div className="flex bg-[#313053]/80 backdrop-blur-sm rounded-full p-1.5 shadow-inner">
-          <button
-            onClick={() => router.push("/auth/signin")}
-            className="px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
-          >
-            Sign In
-          </button>
-        </div>
-      </div>
-      <div className="hidden md:flex md:w-1/2 relative justify-center items-center overflow-hidden rounded-r-[75px] bg-[#B09EE4]">
-        <div
-          className={`absolute inset-0 bg-[#261753] rounded-r-[75px] z-0 transition-all duration-700 ease-out ${
-            animatePanel ? "mr-[20px]" : "mr-[100%]"
-          }`}
-        />
-        <div className="relative z-10 px-6 sm:px-8">
-          <Image
-            src="/icons/sign-up-Vector.svg"
-            alt="Reset Illustration"
-            width={400}
-            height={400}
-            className="max-w-full h-auto"
-          />
-        </div>
-        <div className="absolute top-4 sm:top-6 left-6 sm:left-10 flex items-center gap-2 sm:gap-3 z-10">
-          <Image src="/icons/logo.png" alt="Logo" width={28} height={28} />
-          <span className="text-base sm:text-lg font-extrabold tracking-wider text-[#B09EE4]">
-            MARVEDGE
-          </span>
-        </div>
-        {/* Pulse elements */}
-        <div className="absolute top-1/4 right-1/4 w-3 h-3 bg-white/20 rounded-full animate-pulse hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute bottom-1/3 left-1/4 w-4 h-4 bg-white/15 rounded-full animate-pulse delay-1000 hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute top-1/2 left-1/3 w-2 h-2 bg-white/25 rounded-full animate-pulse delay-500 hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute top-1/5 left-1/5 w-2.5 h-2.5 bg-white/20 rounded-full animate-pulse delay-200 hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute bottom-1/5 right-1/3 w-3.5 h-3.5 bg-white/15 rounded-full animate-pulse delay-1200 hover:scale-150 transition-transform duration-300"></div>
-      </div>
+      <ResetPasswordMobileNav />
+      <ResetPasswordIllustration animatePanel={animatePanel} />
       <div
         className={`w-full md:w-1/2 flex justify-center items-center px-4 sm:px-10 lg:px-20 py-10 transition-all duration-700 ease-out pt-24 md:pt-10 ${
           animatePanel ? "opacity-100 translate-x-0" : "opacity-0 translate-x-10"

--- a/app/auth/reset-password/useResetPassword.ts
+++ b/app/auth/reset-password/useResetPassword.ts
@@ -1,0 +1,85 @@
+import { useState, useRef, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { z } from "zod";
+import { toast } from "sonner";
+import axios from "axios";
+
+const resetPasswordSchema = z
+  .object({
+    email: z.string().min(1, "Please enter your email").email("Invalid email address"),
+    token: z.string().min(1, "Invalid reset token"),
+    password: z.string().min(6, "Password must be at least 6 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export const useResetPassword = () => {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [animatePanel, setAnimatePanel] = useState(false);
+  const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const confirmPasswordRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const timer = setTimeout(() => setAnimatePanel(true), 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Pre-fill email if passed as query param
+  useEffect(() => {
+    const email = searchParams.get("email");
+    if (email && emailRef.current) {
+      emailRef.current.value = email;
+    }
+  }, [searchParams]);
+
+  const togglePassword = () => setShowPassword(!showPassword);
+  const toggleConfirm = () => setShowConfirmPassword(!showConfirmPassword);
+
+  const handleReset = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+    const formData = {
+      email: emailRef.current?.value.trim(),
+      token: searchParams.get("token") || "",
+      password: passwordRef.current?.value,
+      confirmPassword: confirmPasswordRef.current?.value,
+    };
+    try {
+      const validated = resetPasswordSchema.parse(formData);
+      const res = await axios.post("/api/auth/verify-reset", validated);
+      if (res.status === 200) {
+        toast.success("Password reset successfully!");
+        setTimeout(() => router.push("/auth/signin"), 1500);
+      }
+    } catch (err) {
+      const message =
+        err instanceof z.ZodError
+          ? err.errors[0].message
+          : (axios.isAxiosError(err) && err.response?.data?.error) || "Reset failed.";
+      toast.error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    showPassword,
+    togglePassword,
+    showConfirmPassword,
+    toggleConfirm,
+    isLoading,
+    animatePanel,
+    emailRef,
+    passwordRef,
+    confirmPasswordRef,
+    handleReset,
+  };
+};

--- a/app/auth/signin/SignInIllustration.tsx
+++ b/app/auth/signin/SignInIllustration.tsx
@@ -1,0 +1,45 @@
+"use client";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import AuthPulseDots from "@/app/components/AuthPulseDots";
+
+type SignInIllustrationProps = {
+  animatePanel: boolean;
+};
+
+const SignInIllustration = ({ animatePanel }: SignInIllustrationProps) => {
+  const router = useRouter();
+
+  return (
+    <div className="hidden md:flex md:w-1/2 relative justify-center items-center overflow-hidden rounded-l-[75px] bg-[#B09EE4]">
+      <div
+        className={`absolute inset-0 bg-[#261753] rounded-l-[75px] z-0 transition-all duration-700 ease-out ${
+          animatePanel ? "ml-[20px]" : "ml-[100%]"
+        }`}
+      />
+      <div className="relative z-10 px-6 sm:px-8">
+        <Image
+          src="/icons/login-vector.svg"
+          alt="Login Illustration"
+          width={400}
+          height={400}
+          className="max-w-full h-auto"
+        />
+      </div>
+      <button
+        onClick={() => router.push("/")}
+        className="absolute top-4 sm:top-6 right-6 sm:right-10 flex items-center gap-2 sm:gap-3 z-10 cursor-pointer"
+      >
+        <Image src="/icons/logo.png" alt="Logo" width={28} height={28} />
+
+        <span className="text-base sm:text-lg font-extrabold tracking-wider text-[#B09EE4]">
+          MARVEDGE
+        </span>
+      </button>
+
+      <AuthPulseDots />
+    </div>
+  );
+};
+
+export default SignInIllustration;

--- a/app/auth/signin/SignInMobileNav.tsx
+++ b/app/auth/signin/SignInMobileNav.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useRouter, usePathname } from "next/navigation";
+
+const SignInMobileNav = () => {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  return (
+    <div
+      className="md:hidden absolute top-0 left-0 w-full h-20 bg-gradient-to-b from-[#313053] to-[#261753] z-[1000] flex justify-center items-center shadow-lg"
+      style={{
+        borderBottomLeftRadius: "50% 20%",
+        borderBottomRightRadius: "50% 20%",
+      }}
+    >
+      <div className="flex bg-[#313053]/80 backdrop-blur-sm rounded-full p-1.5 shadow-inner">
+        <button
+          onClick={() => router.push("/auth/signin")}
+          className={`px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 ${
+            pathname === "/auth/signin"
+              ? "bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
+              : "text-gray-300 hover:bg-[#615fa1] hover:text-white"
+          }`}
+        >
+          Sign In
+        </button>
+        <button
+          onClick={() => router.push("/auth/signup")}
+          className={`px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 ${
+            pathname === "/auth/signup"
+              ? "bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
+              : "text-gray-300 hover:bg-[#615fa1] hover:text-white"
+          }`}
+        >
+          Sign Up
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SignInMobileNav;

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,161 +1,25 @@
 "use client";
-import { useState, useRef, useEffect } from "react";
 import Image from "next/image";
-import { signIn, useSession } from "next-auth/react";
-import { useRouter, usePathname } from "next/navigation";
-import { z } from "zod";
-import { toast } from "sonner";
-
-const signInSchema = z.object({
-  email: z.string().min(1, "Please enter your email").email("Invalid email address"),
-  password: z.string().min(1, "Please enter your password"),
-});
+import { signIn } from "next-auth/react";
+import { useSignIn } from "./useSignIn";
+import SignInMobileNav from "./SignInMobileNav";
+import SignInIllustration from "./SignInIllustration";
 
 const SignIn = () => {
-  const [showPassword, setShowPassword] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const emailRef = useRef<HTMLInputElement>(null);
-  const passwordRef = useRef<HTMLInputElement>(null);
-  const [animatePanel, setAnimatePanel] = useState(false);
-  const router = useRouter();
-  const pathname = usePathname();
-  const { update } = useSession();
-
-  useEffect(() => {
-    const timeout = setTimeout(() => setAnimatePanel(true), 100);
-    return () => clearTimeout(timeout);
-  }, []);
-
-  const togglePasswordVisibility = () => setShowPassword(!showPassword);
-
-  // const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-  //   e.preventDefault();
-  //   const email = emailRef.current?.value ?? "";
-  //   const password = passwordRef.current?.value ?? "";
-  //   setIsLoading(true);
-  //   try {
-  //     signInSchema.parse({ email, password });
-  //   } catch (error) {
-  //     if (error instanceof z.ZodError) {
-  //       toast.error(error.errors[0].message);
-  //       setIsLoading(false);
-  //       return;
-  //     }
-  //   }
-  //   try {
-  //     const res = await signIn("credentials", {
-  //       email,
-  //       password,
-  //       redirect: false,
-  //     });
-  //     if (res?.ok) {
-  //       toast.success("Signed in successfully! from try");
-  //       console.log("Signed in successfully!");
-  //       console.log(status);
-  //       await update();
-  //       // await new Promise((resolve) => setTimeout(resolve, 1000));
-  //       router.push("/dashboard");
-  //       // setTimeout(() => window.location.reload(), 100);
-  //     } else {
-  //       toast.error(res?.error || "Invalid credentials.");
-  //     }
-  //   } catch (err) {
-  //     console.warn(err);
-  //     if (
-  //       err instanceof TypeError &&
-  //       err.message.includes("Failed to construct 'URL'")
-  //     ) {
-  //       toast.success("Signed in successfully! from catch");
-  //       console.log("signed in successfully from catch block");
-  //       await update();
-  //       // setTimeout(() => window.location.reload(), 100);
-  //       router.push("/dashboard");
-  //       return;
-  //     }
-  //     toast.error("Something went wrong. Please try again.");
-  //   } finally {
-  //     setIsLoading(false);
-  //   }
-  // };
-
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    const email = emailRef.current?.value ?? "";
-    const password = passwordRef.current?.value ?? "";
-    console.log(email, password, "first");
-    setIsLoading(true);
-
-    try {
-      // ✅ Validate input
-      signInSchema.parse({ email, password });
-      console.log(email, password);
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        toast.error(error.errors[0].message);
-        setIsLoading(false);
-        return;
-      }
-    }
-
-    try {
-      // ✅ Sign in with credentials
-      const res = await signIn("credentials", {
-        email,
-        password,
-        redirect: false,
-      });
-      console.log(email, password);
-      console.log("Sign-in response:", res);
-
-      if (res?.ok) {
-        toast.success("Signed in successfully!");
-        await update(); // refresh session
-        router.push("/dashboard"); // ✅ only one redirect
-      } else {
-        toast.error(res?.error || "Invalid credentials.");
-      }
-    } catch (err) {
-      console.log("error from the new catch block");
-      console.error("Sign-in error:", err);
-      toast.error("Something went wrong. Please try again.");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const {
+    showPassword,
+    togglePasswordVisibility,
+    isLoading,
+    animatePanel,
+    emailRef,
+    passwordRef,
+    router,
+    handleSubmit,
+  } = useSignIn();
 
   return (
     <div className="flex flex-col md:flex-row min-h-screen w-full font-sans bg-[#F1ECFF]">
-      <div
-        className="md:hidden absolute top-0 left-0 w-full h-20 bg-gradient-to-b from-[#313053] to-[#261753] z-[1000] flex justify-center items-center shadow-lg"
-        style={{
-          borderBottomLeftRadius: "50% 20%",
-          borderBottomRightRadius: "50% 20%",
-        }}
-      >
-        <div className="flex bg-[#313053]/80 backdrop-blur-sm rounded-full p-1.5 shadow-inner">
-          <button
-            onClick={() => router.push("/auth/signin")}
-            className={`px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 ${
-              pathname === "/auth/signin"
-                ? "bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
-                : "text-gray-300 hover:bg-[#615fa1] hover:text-white"
-            }`}
-          >
-            Sign In
-          </button>
-          <button
-            onClick={() => router.push("/auth/signup")}
-            className={`px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 ${
-              pathname === "/auth/signup"
-                ? "bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
-                : "text-gray-300 hover:bg-[#615fa1] hover:text-white"
-            }`}
-          >
-            Sign Up
-          </button>
-        </div>
-      </div>
+      <SignInMobileNav />
 
       <div
         className={`w-full md:w-1/2 flex justify-center items-center px-4 sm:px-10 lg:px-20 py-6 md:py-10 transition-all duration-700 ease-out pt-24 md:pt-10 ${
@@ -258,38 +122,7 @@ const SignIn = () => {
           </div>
         </form>
       </div>
-      <div className="hidden md:flex md:w-1/2 relative justify-center items-center overflow-hidden rounded-l-[75px] bg-[#B09EE4]">
-        <div
-          className={`absolute inset-0 bg-[#261753] rounded-l-[75px] z-0 transition-all duration-700 ease-out ${
-            animatePanel ? "ml-[20px]" : "ml-[100%]"
-          }`}
-        />
-        <div className="relative z-10 px-6 sm:px-8">
-          <Image
-            src="/icons/login-vector.svg"
-            alt="Login Illustration"
-            width={400}
-            height={400}
-            className="max-w-full h-auto"
-          />
-        </div>
-        <button
-          onClick={() => router.push("/")}
-          className="absolute top-4 sm:top-6 right-6 sm:right-10 flex items-center gap-2 sm:gap-3 z-10 cursor-pointer"
-        >
-          <Image src="/icons/logo.png" alt="Logo" width={28} height={28} />
-
-          <span className="text-base sm:text-lg font-extrabold tracking-wider text-[#B09EE4]">
-            MARVEDGE
-          </span>
-        </button>
-
-        <div className="absolute top-1/4 right-1/4 w-3 h-3 bg-white/20 rounded-full animate-pulse hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute bottom-1/3 left-1/4 w-4 h-4 bg-white/15 rounded-full animate-pulse delay-1000 hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute top-1/2 left-1/3 w-2 h-2 bg-white/25 rounded-full animate-pulse delay-500 hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute top-1/5 left-1/5 w-2.5 h-2.5 bg-white/20 rounded-full animate-pulse delay-200 hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute bottom-1/5 right-1/3 w-3.5 h-3.5 bg-white/15 rounded-full animate-pulse delay-1200 hover:scale-150 transition-transform duration-300"></div>
-      </div>
+      <SignInIllustration animatePanel={animatePanel} />
     </div>
   );
 };

--- a/app/auth/signin/useSignIn.ts
+++ b/app/auth/signin/useSignIn.ts
@@ -1,0 +1,84 @@
+import { useState, useRef, useEffect } from "react";
+import { signIn, useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+import { toast } from "sonner";
+
+const signInSchema = z.object({
+  email: z.string().min(1, "Please enter your email").email("Invalid email address"),
+  password: z.string().min(1, "Please enter your password"),
+});
+
+export const useSignIn = () => {
+  const [showPassword, setShowPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const [animatePanel, setAnimatePanel] = useState(false);
+  const router = useRouter();
+  const { update } = useSession();
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setAnimatePanel(true), 100);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  const togglePasswordVisibility = () => setShowPassword(!showPassword);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const email = emailRef.current?.value ?? "";
+    const password = passwordRef.current?.value ?? "";
+    console.log(email, password, "first");
+    setIsLoading(true);
+
+    try {
+      // ✅ Validate input
+      signInSchema.parse({ email, password });
+      console.log(email, password);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        toast.error(error.errors[0].message);
+        setIsLoading(false);
+        return;
+      }
+    }
+
+    try {
+      // ✅ Sign in with credentials
+      const res = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+      });
+      console.log(email, password);
+      console.log("Sign-in response:", res);
+
+      if (res?.ok) {
+        toast.success("Signed in successfully!");
+        await update(); // refresh session
+        router.push("/dashboard"); // ✅ only one redirect
+      } else {
+        toast.error(res?.error || "Invalid credentials.");
+      }
+    } catch (err) {
+      console.log("error from the new catch block");
+      console.error("Sign-in error:", err);
+      toast.error("Something went wrong. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    showPassword,
+    togglePasswordVisibility,
+    isLoading,
+    animatePanel,
+    emailRef,
+    passwordRef,
+    router,
+    handleSubmit,
+  };
+};

--- a/app/auth/signup/SignUpForm.tsx
+++ b/app/auth/signup/SignUpForm.tsx
@@ -1,145 +1,33 @@
 "use client";
-import { useState, useRef, useEffect } from "react";
 import Image from "next/image";
-import axios from "axios";
-import { useRouter, usePathname } from "next/navigation";
-import { z } from "zod";
-import { toast } from "sonner";
 import { signIn } from "next-auth/react";
-import { useSearchParams } from "next/navigation";
-
-const signUpSchema = z
-  .object({
-    name: z.string().min(1, "Please enter your name"),
-    email: z.string().min(1, "Please enter your email").email("Invalid email address"),
-
-    password: z.string().min(6, "Password must be at least 6 characters"),
-    confirmPassword: z.string(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: "Passwords do not match",
-    path: ["confirmPassword"],
-  });
+import { useSignUp } from "./useSignUp";
+import SignUpMobileNav from "./SignUpMobileNav";
+import SignUpIllustration from "./SignUpIllustration";
 
 const SignUp = () => {
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [animatePanel, setAnimatePanel] = useState(false);
-  // const nameRef = useRef<HTMLInputElement>(null);
-  // const emailRef = useRef<HTMLInputElement>(null);
-
-  const searchParams = useSearchParams();
-  const emailFromQuery = searchParams.get("email") || "";
-  const nameFromQuery = searchParams.get("name") || "";
-  const [email, setEmail] = useState(emailFromQuery);
-  const [name, setName] = useState(nameFromQuery);
-
-  const passwordRef = useRef<HTMLInputElement>(null);
-  const confirmPasswordRef = useRef<HTMLInputElement>(null);
-  const router = useRouter();
-  const pathname = usePathname();
-
-  useEffect(() => {
-    const timer = setTimeout(() => setAnimatePanel(true), 100);
-    return () => clearTimeout(timer);
-  }, []);
-  useEffect(() => {
-    const timer = setTimeout(() => setAnimatePanel(true), 100);
-    return () => clearTimeout(timer);
-  }, []);
-
-  const togglePassword = () => setShowPassword(!showPassword);
-  const toggleConfirm = () => setShowConfirmPassword(!showConfirmPassword);
-
-  const handleSignUp = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsLoading(true);
-    const formData = {
-      name: name.trim(),
-      email: email.trim(),
-      password: passwordRef.current?.value,
-      confirmPassword: confirmPasswordRef.current?.value,
-    };
-    try {
-      const validated = signUpSchema.parse(formData);
-      const res = await axios.post("/api/auth/signup", validated);
-      if (res.status === 201 || res.status === 200) {
-        toast.success("Account created successfully!");
-        router.push("/auth/signin");
-      }
-    } catch (err) {
-      const message = err instanceof z.ZodError ? err.errors[0].message : "Sign-up failed.";
-      toast.error(message);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const {
+    showPassword,
+    togglePassword,
+    showConfirmPassword,
+    toggleConfirm,
+    isLoading,
+    animatePanel,
+    email,
+    setEmail,
+    name,
+    setName,
+    passwordRef,
+    confirmPasswordRef,
+    router,
+    handleSignUp,
+  } = useSignUp();
 
   return (
     <div className="flex flex-col md:flex-row h-full min-h-screen font-sans bg-[#F1ECFF]">
-      <div
-        className="md:hidden absolute top-0 left-0 w-full h-20 bg-gradient-to-b from-[#313053] to-[#261753] z-[1000] flex justify-center items-center shadow-lg"
-        style={{
-          borderBottomLeftRadius: "50% 20%",
-          borderBottomRightRadius: "50% 20%",
-        }}
-      >
-        <div className="flex bg-[#313053]/80 backdrop-blur-sm rounded-full p-1.5 shadow-inner">
-          <button
-            onClick={() => router.push("/auth/signin")}
-            className={`px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 cursor-pointer ${
-              pathname === "/auth/signin"
-                ? "bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
-                : "text-gray-300 hover:bg-[#615fa1] hover:text-white"
-            }`}
-          >
-            Sign In
-          </button>
-          <button
-            onClick={() => router.push("/auth/signup")}
-            className={`px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 cursor-pointer ${
-              pathname === "/auth/signup"
-                ? "bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
-                : "text-gray-300 hover:bg-[#615fa1] hover:text-white"
-            }`}
-          >
-            Sign Up
-          </button>
-        </div>
-      </div>
+      <SignUpMobileNav />
 
-      <div className="hidden md:flex md:w-1/2 relative justify-center items-center overflow-hidden rounded-r-[75px] bg-[#B09EE4]">
-        <div
-          className={`absolute inset-0 bg-[#261753] rounded-r-[75px] z-0 transition-all duration-700 ease-out ${
-            animatePanel ? "mr-[20px]" : "mr-[100%]"
-          }`}
-        />
-        <div className="relative z-10 px-6 sm:px-8">
-          <Image
-            src="/icons/sign-up-Vector.svg"
-            alt="Signup Illustration"
-            width={400}
-            height={400}
-            className="max-w-full h-auto"
-          />
-        </div>
-        <button
-          onClick={() => router.push("/")}
-          className="absolute top-4 sm:top-6 left-6 sm:left-10 flex items-center gap-2 sm:gap-3 z-10 cursor-pointer"
-        >
-          <Image src="/icons/logo.png" alt="Logo" width={28} height={28} />
-          <span className="text-base sm:text-lg font-extrabold tracking-wider text-[#B09EE4]">
-            MARVEDGE
-          </span>
-        </button>
-
-        <div className="absolute top-1/4 right-1/4 w-3 h-3 bg-white/20 rounded-full animate-pulse hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute bottom-1/3 left-1/4 w-4 h-4 bg-white/15 rounded-full animate-pulse delay-1000 hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute top-1/2 left-1/3 w-2 h-2 bg-white/25 rounded-full animate-pulse delay-500 hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute top-1/5 left-1/5 w-2.5 h-2.5 bg-white/20 rounded-full animate-pulse delay-200 hover:scale-150 transition-transform duration-300"></div>
-        <div className="absolute bottom-1/5 right-1/3 w-3.5 h-3.5 bg-white/15 rounded-full animate-pulse delay-1200 hover:scale-150 transition-transform duration-300"></div>
-      </div>
+      <SignUpIllustration animatePanel={animatePanel} />
 
       <div
         className={`w-full md:w-1/2 flex justify-center items-center px-4 sm:px-10 lg:px-20 py-10 transition-all duration-700 ease-out pt-24 md:pt-10 ${

--- a/app/auth/signup/SignUpIllustration.tsx
+++ b/app/auth/signup/SignUpIllustration.tsx
@@ -1,0 +1,44 @@
+"use client";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import AuthPulseDots from "@/app/components/AuthPulseDots";
+
+type SignUpIllustrationProps = {
+  animatePanel: boolean;
+};
+
+const SignUpIllustration = ({ animatePanel }: SignUpIllustrationProps) => {
+  const router = useRouter();
+
+  return (
+    <div className="hidden md:flex md:w-1/2 relative justify-center items-center overflow-hidden rounded-r-[75px] bg-[#B09EE4]">
+      <div
+        className={`absolute inset-0 bg-[#261753] rounded-r-[75px] z-0 transition-all duration-700 ease-out ${
+          animatePanel ? "mr-[20px]" : "mr-[100%]"
+        }`}
+      />
+      <div className="relative z-10 px-6 sm:px-8">
+        <Image
+          src="/icons/sign-up-Vector.svg"
+          alt="Signup Illustration"
+          width={400}
+          height={400}
+          className="max-w-full h-auto"
+        />
+      </div>
+      <button
+        onClick={() => router.push("/")}
+        className="absolute top-4 sm:top-6 left-6 sm:left-10 flex items-center gap-2 sm:gap-3 z-10 cursor-pointer"
+      >
+        <Image src="/icons/logo.png" alt="Logo" width={28} height={28} />
+        <span className="text-base sm:text-lg font-extrabold tracking-wider text-[#B09EE4]">
+          MARVEDGE
+        </span>
+      </button>
+
+      <AuthPulseDots />
+    </div>
+  );
+};
+
+export default SignUpIllustration;

--- a/app/auth/signup/SignUpMobileNav.tsx
+++ b/app/auth/signup/SignUpMobileNav.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useRouter, usePathname } from "next/navigation";
+
+const SignUpMobileNav = () => {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  return (
+    <div
+      className="md:hidden absolute top-0 left-0 w-full h-20 bg-gradient-to-b from-[#313053] to-[#261753] z-[1000] flex justify-center items-center shadow-lg"
+      style={{
+        borderBottomLeftRadius: "50% 20%",
+        borderBottomRightRadius: "50% 20%",
+      }}
+    >
+      <div className="flex bg-[#313053]/80 backdrop-blur-sm rounded-full p-1.5 shadow-inner">
+        <button
+          onClick={() => router.push("/auth/signin")}
+          className={`px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 cursor-pointer ${
+            pathname === "/auth/signin"
+              ? "bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
+              : "text-gray-300 hover:bg-[#615fa1] hover:text-white"
+          }`}
+        >
+          Sign In
+        </button>
+        <button
+          onClick={() => router.push("/auth/signup")}
+          className={`px-6 py-2 rounded-full transition-all duration-300 transform hover:scale-105 cursor-pointer ${
+            pathname === "/auth/signup"
+              ? "bg-gradient-to-r from-[#615fa1] to-[#313053] text-white shadow-md"
+              : "text-gray-300 hover:bg-[#615fa1] hover:text-white"
+          }`}
+        >
+          Sign Up
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SignUpMobileNav;

--- a/app/auth/signup/useSignUp.ts
+++ b/app/auth/signup/useSignUp.ts
@@ -1,0 +1,84 @@
+import { useState, useRef, useEffect } from "react";
+import axios from "axios";
+import { useRouter, useSearchParams } from "next/navigation";
+import { z } from "zod";
+import { toast } from "sonner";
+
+const signUpSchema = z
+  .object({
+    name: z.string().min(1, "Please enter your name"),
+    email: z.string().min(1, "Please enter your email").email("Invalid email address"),
+
+    password: z.string().min(6, "Password must be at least 6 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export const useSignUp = () => {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [animatePanel, setAnimatePanel] = useState(false);
+
+  const searchParams = useSearchParams();
+  const emailFromQuery = searchParams.get("email") || "";
+  const nameFromQuery = searchParams.get("name") || "";
+  const [email, setEmail] = useState(emailFromQuery);
+  const [name, setName] = useState(nameFromQuery);
+
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const confirmPasswordRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => setAnimatePanel(true), 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const togglePassword = () => setShowPassword(!showPassword);
+  const toggleConfirm = () => setShowConfirmPassword(!showConfirmPassword);
+
+  const handleSignUp = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+    const formData = {
+      name: name.trim(),
+      email: email.trim(),
+      password: passwordRef.current?.value,
+      confirmPassword: confirmPasswordRef.current?.value,
+    };
+    try {
+      const validated = signUpSchema.parse(formData);
+      const res = await axios.post("/api/auth/signup", validated);
+      if (res.status === 201 || res.status === 200) {
+        toast.success("Account created successfully!");
+        router.push("/auth/signin");
+      }
+    } catch (err) {
+      const message = err instanceof z.ZodError ? err.errors[0].message : "Sign-up failed.";
+      toast.error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    showPassword,
+    togglePassword,
+    showConfirmPassword,
+    toggleConfirm,
+    isLoading,
+    animatePanel,
+    email,
+    setEmail,
+    name,
+    setName,
+    passwordRef,
+    confirmPasswordRef,
+    router,
+    handleSignUp,
+  };
+};

--- a/app/components/AuthPulseDots.tsx
+++ b/app/components/AuthPulseDots.tsx
@@ -1,0 +1,13 @@
+const AuthPulseDots = () => {
+  return (
+    <>
+      <div className="absolute top-1/4 right-1/4 w-3 h-3 bg-white/20 rounded-full animate-pulse hover:scale-150 transition-transform duration-300"></div>
+      <div className="absolute bottom-1/3 left-1/4 w-4 h-4 bg-white/15 rounded-full animate-pulse delay-1000 hover:scale-150 transition-transform duration-300"></div>
+      <div className="absolute top-1/2 left-1/3 w-2 h-2 bg-white/25 rounded-full animate-pulse delay-500 hover:scale-150 transition-transform duration-300"></div>
+      <div className="absolute top-1/5 left-1/5 w-2.5 h-2.5 bg-white/20 rounded-full animate-pulse delay-200 hover:scale-150 transition-transform duration-300"></div>
+      <div className="absolute bottom-1/5 right-1/3 w-3.5 h-3.5 bg-white/15 rounded-full animate-pulse delay-1200 hover:scale-150 transition-transform duration-300"></div>
+    </>
+  );
+};
+
+export default AuthPulseDots;


### PR DESCRIPTION
Refactor the three flagged auth components to under 150 lines each

- signin/page.tsx: extract useSignIn hook + SignInMobileNav, SignInIllustration
- signup/SignUpForm.tsx: extract useSignUp hook + SignUpMobileNav, SignUpIllustration
- reset-password/page.tsx: extract useResetPassword hook + ResetPasswordMobileNav, ResetPasswordIllustration
- add shared AuthPulseDots component for the identical decorative dots

fixes part  of #196