### PR TITLE
refactor(recorder): split recorder feature under max-lines-per-function  4/13

### DIFF
--- a/app/(signed)/recorder/RecorderClient.tsx
+++ b/app/(signed)/recorder/RecorderClient.tsx
@@ -1,45 +1,23 @@
 "use client";
-import { useRef, useCallback } from "react";
+import { useRef } from "react";
 import ReactPlayer from "react-player";
-import { useRouter } from "next/navigation";
 import { useBlobStore } from "@/app/store/blobStore";
 import { useScreenRecorder } from "@/app/hooks/useScreenRecorder";
 import RecorderTopbar from "@/app/components/RecorderTopbar";
-import { videoToMP4 } from "@/app/lib/ffmpeg";
 
-import { toast, Toaster } from "sonner";
+import { Toaster } from "sonner";
 import { useSession } from "next-auth/react";
 import SavePopupForm from "@/app/components/SavePopupForm";
-import { sanitizeFilename } from "@/app/lib/constants";
 
 import { useRecorderState, useRecordingTimer } from "./hooks/useRecorderState";
 import { useVideoDuration } from "./hooks/useVideoDuration";
+import { useRecorderActions, getUserInitials } from "./hooks/useRecorderActions";
 
-import VideoPlayerSection from "@/app/components/VideoPlayerSection";
-import RecordingControls from "@/app/components/RecordingControls";
 import InitialRecorderView from "@/app/components/InitialRecorderView";
+import RecorderWorkspaceView from "./RecorderWorkspaceView";
 
 export default function RecorderPage() {
   const videoPlayerRef = useRef<ReactPlayer>(null);
-  const router = useRouter();
-
-  const isProcessingRef = useRef(false);
-
-  const handleBack = useCallback(() => {
-    try {
-      router.back();
-    } catch (error) {
-      console.error("Navigation error:", error);
-    }
-  }, [router]);
-
-  const handleEditVideo = useCallback(() => {
-    try {
-      router.push("/editor");
-    } catch (error) {
-      console.error("Navigation error:", error);
-    }
-  }, [router]);
 
   const {
     uploadMessage,
@@ -83,15 +61,13 @@ export default function RecorderPage() {
   } = useScreenRecorder();
 
   const { data: session } = useSession();
+  const initials = getUserInitials(session);
 
-  const initials = session?.user?.name
-    ? session.user.name
-        .split(" ")
-        .map((part: string) => part[0])
-        .join("")
-        .toUpperCase()
-        .slice(0, 2)
-    : session?.user?.email?.[0]?.toUpperCase() || "U";
+  const { handleBack, handleEditVideo, handlePopupDownload, isProcessingRef } = useRecorderActions({
+    blob,
+    setProcessingDownload,
+    setShowSavePopup,
+  });
 
   useRecordingTimer(recording, recordingIntervalRef, setRecordingTimer);
   useVideoDuration({
@@ -103,124 +79,43 @@ export default function RecorderPage() {
     videoPlayerRef,
   });
 
-  const handlePopupDownload = async (data: { title: string; format: string }) => {
-    if (!blob) {
-      isProcessingRef.current = false;
-      return;
-    }
-
-    setProcessingDownload(true);
-    try {
-      if (data.format === "mp4") {
-        const outputBlob = await videoToMP4(blob);
-        const url = URL.createObjectURL(outputBlob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `${sanitizeFilename(data.title) || "recording"}.mp4`;
-        a.click();
-      } else {
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `${sanitizeFilename(data.title) || "recording"}.webm`;
-        a.click();
-      }
-      toast.success("Video downloaded successfully!");
-      setShowSavePopup(false);
-    } catch (err) {
-      console.error(err);
-      toast.error("Failed to download video.");
-
-      isProcessingRef.current = false;
-    } finally {
-      setProcessingDownload(false);
-    }
-  };
-
   if (screenStream || uploadedFileUrl || videoUrl) {
     const isUploaded = !!uploadedFileUrl && !screenStream && !videoUrl;
     return (
-      <div
-        className="page flex flex-col h-screen w-full overflow-hidden"
-        style={{ fontFamily: "var(--font-raleway)" }}
-      >
-        <RecorderTopbar onBack={handleBack} userInitials={initials} />
-        <div className="flex flex-1 overflow-hidden">
-          <main className="flex-1 flex flex-col h-full overflow-hidden">
-            <div className="header w-full flex flex-col sm:flex-row items-start sm:items-center justify-between px-4 sm:px-12 py-4 sm:py-6 bg-[#f3f0fc] border-b border-[#ede7fa]">
-              <div>
-                <div className="text-lg sm:text-2xl font-semibold text-[#1A0033]">
-                  New Recording
-                </div>
-                <p className="text-xs sm:text-sm text-gray-400">Last saved 2 minutes ago</p>
-              </div>
-            </div>
-            <div className="flex-1 overflow-y-auto flex flex-col">
-              <div className="video-wrapper bg-white rounded-2xl shadow p-4 sm:p-8 flex-1 overflow-y-auto ml-4 sm:ml-12 mr-4 sm:mr-12">
-                <VideoPlayerSection
-                  uploadedFileType={uploadedFileType}
-                  uploadedFileUrl={uploadedFileUrl}
-                  videoUrl={videoUrl}
-                  screenStream={screenStream}
-                  recording={recording}
-                  videoPlaying={videoPlaying}
-                  setVideoPlaying={setVideoPlaying}
-                  videoCurrentTime={videoCurrentTime}
-                  setVideoCurrentTime={setVideoCurrentTime}
-                  videoDuration={videoDuration}
-                  setVideoDuration={setVideoDuration}
-                  recordingDuration={recordingDuration}
-                  recordingTimer={recordingTimer}
-                  videoPlayerRef={videoPlayerRef}
-                />
-                <RecordingControls
-                  screenStream={screenStream}
-                  recording={recording}
-                  isUploaded={isUploaded}
-                  videoUrl={videoUrl}
-                  saveMessage={saveMessage}
-                  startScreenShare={startScreenShare}
-                  stopRecording={stopRecording}
-                  setUploadedFileUrl={setUploadedFileUrl}
-                  setUploadedFileType={setUploadedFileType}
-                  setBlob={setBlob}
-                  reset={reset}
-                  onEditVideo={handleEditVideo}
-                  fileInputRef={fileInputRef}
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-
-        <input
-          type="file"
-          accept="video/mp4,video/webm,video/*"
-          ref={fileInputRef}
-          className="hidden"
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) {
-              const fileUrl = URL.createObjectURL(file);
-              setUploadedFileUrl(fileUrl);
-              setUploadedFileType(file.type);
-              setBlob(file);
-              toast.success("File uploaded successfully!");
-            }
-          }}
-        />
-
-        <SavePopupForm
-          isOpen={showSavePopup}
-          onClose={() => {
-            setShowSavePopup(false);
-            isProcessingRef.current = false;
-          }}
-          onDownload={handlePopupDownload}
-          initialTitle={title}
-          processing={processingDownload}
-        />
-      </div>
+      <RecorderWorkspaceView
+        initials={initials}
+        isUploaded={isUploaded}
+        onBack={handleBack}
+        onEditVideo={handleEditVideo}
+        uploadedFileType={uploadedFileType}
+        uploadedFileUrl={uploadedFileUrl}
+        videoUrl={videoUrl}
+        screenStream={screenStream}
+        recording={recording}
+        videoPlaying={videoPlaying}
+        setVideoPlaying={setVideoPlaying}
+        videoCurrentTime={videoCurrentTime}
+        setVideoCurrentTime={setVideoCurrentTime}
+        videoDuration={videoDuration}
+        setVideoDuration={setVideoDuration}
+        recordingDuration={recordingDuration}
+        recordingTimer={recordingTimer}
+        videoPlayerRef={videoPlayerRef}
+        saveMessage={saveMessage}
+        startScreenShare={startScreenShare}
+        stopRecording={stopRecording}
+        setUploadedFileUrl={setUploadedFileUrl}
+        setUploadedFileType={setUploadedFileType}
+        setBlob={setBlob}
+        reset={reset}
+        fileInputRef={fileInputRef}
+        showSavePopup={showSavePopup}
+        setShowSavePopup={setShowSavePopup}
+        onPopupDownload={handlePopupDownload}
+        title={title}
+        processingDownload={processingDownload}
+        isProcessingRef={isProcessingRef}
+      />
     );
   }
 

--- a/app/(signed)/recorder/RecorderWorkspaceView.tsx
+++ b/app/(signed)/recorder/RecorderWorkspaceView.tsx
@@ -1,0 +1,158 @@
+import ReactPlayer from "react-player";
+import { toast } from "sonner";
+import RecorderTopbar from "@/app/components/RecorderTopbar";
+import SavePopupForm from "@/app/components/SavePopupForm";
+import VideoPlayerSection from "@/app/components/VideoPlayerSection";
+import RecordingControls from "@/app/components/RecordingControls";
+
+interface RecorderWorkspaceViewProps {
+  initials: string;
+  isUploaded: boolean;
+  onBack: () => void;
+  onEditVideo: () => void;
+  uploadedFileType: string | null;
+  uploadedFileUrl: string | null;
+  videoUrl: string | null;
+  screenStream: MediaStream | null;
+  recording: boolean;
+  videoPlaying: boolean;
+  setVideoPlaying: (playing: boolean) => void;
+  videoCurrentTime: number;
+  setVideoCurrentTime: (time: number) => void;
+  videoDuration: number;
+  setVideoDuration: (duration: number) => void;
+  recordingDuration: number;
+  recordingTimer: number;
+  videoPlayerRef: React.RefObject<ReactPlayer | null>;
+  saveMessage: string;
+  startScreenShare: () => void;
+  stopRecording: () => void;
+  setUploadedFileUrl: (url: string | null) => void;
+  setUploadedFileType: (type: string | null) => void;
+  setBlob: (blob: Blob | null) => void;
+  reset: () => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  showSavePopup: boolean;
+  setShowSavePopup: (open: boolean) => void;
+  onPopupDownload: (data: { title: string; format: string }) => void;
+  title: string;
+  processingDownload: boolean;
+  isProcessingRef: React.MutableRefObject<boolean>;
+}
+
+export default function RecorderWorkspaceView({
+  initials,
+  isUploaded,
+  onBack,
+  onEditVideo,
+  uploadedFileType,
+  uploadedFileUrl,
+  videoUrl,
+  screenStream,
+  recording,
+  videoPlaying,
+  setVideoPlaying,
+  videoCurrentTime,
+  setVideoCurrentTime,
+  videoDuration,
+  setVideoDuration,
+  recordingDuration,
+  recordingTimer,
+  videoPlayerRef,
+  saveMessage,
+  startScreenShare,
+  stopRecording,
+  setUploadedFileUrl,
+  setUploadedFileType,
+  setBlob,
+  reset,
+  fileInputRef,
+  showSavePopup,
+  setShowSavePopup,
+  onPopupDownload,
+  title,
+  processingDownload,
+  isProcessingRef,
+}: RecorderWorkspaceViewProps) {
+  return (
+    <div
+      className="page flex flex-col h-screen w-full overflow-hidden"
+      style={{ fontFamily: "var(--font-raleway)" }}
+    >
+      <RecorderTopbar onBack={onBack} userInitials={initials} />
+      <div className="flex flex-1 overflow-hidden">
+        <main className="flex-1 flex flex-col h-full overflow-hidden">
+          <div className="header w-full flex flex-col sm:flex-row items-start sm:items-center justify-between px-4 sm:px-12 py-4 sm:py-6 bg-[#f3f0fc] border-b border-[#ede7fa]">
+            <div>
+              <div className="text-lg sm:text-2xl font-semibold text-[#1A0033]">New Recording</div>
+              <p className="text-xs sm:text-sm text-gray-400">Last saved 2 minutes ago</p>
+            </div>
+          </div>
+          <div className="flex-1 overflow-y-auto flex flex-col">
+            <div className="video-wrapper bg-white rounded-2xl shadow p-4 sm:p-8 flex-1 overflow-y-auto ml-4 sm:ml-12 mr-4 sm:mr-12">
+              <VideoPlayerSection
+                uploadedFileType={uploadedFileType}
+                uploadedFileUrl={uploadedFileUrl}
+                videoUrl={videoUrl}
+                screenStream={screenStream}
+                recording={recording}
+                videoPlaying={videoPlaying}
+                setVideoPlaying={setVideoPlaying}
+                videoCurrentTime={videoCurrentTime}
+                setVideoCurrentTime={setVideoCurrentTime}
+                videoDuration={videoDuration}
+                setVideoDuration={setVideoDuration}
+                recordingDuration={recordingDuration}
+                recordingTimer={recordingTimer}
+                videoPlayerRef={videoPlayerRef}
+              />
+              <RecordingControls
+                screenStream={screenStream}
+                recording={recording}
+                isUploaded={isUploaded}
+                videoUrl={videoUrl}
+                saveMessage={saveMessage}
+                startScreenShare={startScreenShare}
+                stopRecording={stopRecording}
+                setUploadedFileUrl={setUploadedFileUrl}
+                setUploadedFileType={setUploadedFileType}
+                setBlob={setBlob}
+                reset={reset}
+                onEditVideo={onEditVideo}
+                fileInputRef={fileInputRef}
+              />
+            </div>
+          </div>
+        </main>
+      </div>
+
+      <input
+        type="file"
+        accept="video/mp4,video/webm,video/*"
+        ref={fileInputRef}
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) {
+            const fileUrl = URL.createObjectURL(file);
+            setUploadedFileUrl(fileUrl);
+            setUploadedFileType(file.type);
+            setBlob(file);
+            toast.success("File uploaded successfully!");
+          }
+        }}
+      />
+
+      <SavePopupForm
+        isOpen={showSavePopup}
+        onClose={() => {
+          setShowSavePopup(false);
+          isProcessingRef.current = false;
+        }}
+        onDownload={onPopupDownload}
+        initialTitle={title}
+        processing={processingDownload}
+      />
+    </div>
+  );
+}

--- a/app/(signed)/recorder/hooks/useRecorderActions.ts
+++ b/app/(signed)/recorder/hooks/useRecorderActions.ts
@@ -1,0 +1,84 @@
+import { useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { Session } from "next-auth";
+import { videoToMP4 } from "@/app/lib/ffmpeg";
+import { sanitizeFilename } from "@/app/lib/constants";
+
+export function getUserInitials(session: Session | null): string {
+  return session?.user?.name
+    ? session.user.name
+        .split(" ")
+        .map((part: string) => part[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2)
+    : session?.user?.email?.[0]?.toUpperCase() || "U";
+}
+
+interface UseRecorderActionsProps {
+  blob: Blob | null;
+  setProcessingDownload: (value: boolean) => void;
+  setShowSavePopup: (value: boolean) => void;
+}
+
+export function useRecorderActions({
+  blob,
+  setProcessingDownload,
+  setShowSavePopup,
+}: UseRecorderActionsProps) {
+  const router = useRouter();
+  const isProcessingRef = useRef(false);
+
+  const handleBack = useCallback(() => {
+    try {
+      router.back();
+    } catch (error) {
+      console.error("Navigation error:", error);
+    }
+  }, [router]);
+
+  const handleEditVideo = useCallback(() => {
+    try {
+      router.push("/editor");
+    } catch (error) {
+      console.error("Navigation error:", error);
+    }
+  }, [router]);
+
+  const handlePopupDownload = async (data: { title: string; format: string }) => {
+    if (!blob) {
+      isProcessingRef.current = false;
+      return;
+    }
+
+    setProcessingDownload(true);
+    try {
+      if (data.format === "mp4") {
+        const outputBlob = await videoToMP4(blob);
+        const url = URL.createObjectURL(outputBlob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${sanitizeFilename(data.title) || "recording"}.mp4`;
+        a.click();
+      } else {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${sanitizeFilename(data.title) || "recording"}.webm`;
+        a.click();
+      }
+      toast.success("Video downloaded successfully!");
+      setShowSavePopup(false);
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to download video.");
+
+      isProcessingRef.current = false;
+    } finally {
+      setProcessingDownload(false);
+    }
+  };
+
+  return { handleBack, handleEditVideo, handlePopupDownload, isProcessingRef };
+}

--- a/app/components/InitialRecorderView.tsx
+++ b/app/components/InitialRecorderView.tsx
@@ -1,8 +1,8 @@
-import Image from "next/image";
-import { Dialog } from "@headlessui/react";
 import { Menu } from "lucide-react";
 import { toast } from "sonner";
 import { useBlobStore } from "@/app/store/blobStore";
+import RecorderSettingsDialog from "@/app/components/RecorderSettingsDialog";
+import RecorderMainPanel from "@/app/components/RecorderMainPanel";
 
 interface InitialRecorderViewProps {
   sidebarOpen: boolean;
@@ -64,161 +64,25 @@ export default function InitialRecorderView({
         </button>
       </div>
 
-      <Dialog open={sidebarOpen} onClose={() => setSidebarOpen(false)} className="relative z-50">
-        <div className="fixed inset-0 bg-black/40" aria-hidden="true" />
-        <div className="fixed inset-y-0 left-0 w-[90vw] max-w-xs bg-white shadow-2xl p-6 flex flex-col gap-6 overflow-y-auto">
-          <div className="flex items-center justify-between mb-2">
-            <h2 className="text-xl font-bold text-[#7C5CFC]">Recorder Settings</h2>
-            <button
-              className="text-[#7C5CFC] text-2xl p-1 rounded hover:bg-[#ede7fa] focus:outline-none"
-              onClick={() => setSidebarOpen(false)}
-              aria-label="Close settings"
-            >
-              ✕
-            </button>
-          </div>
+      <RecorderSettingsDialog
+        sidebarOpen={sidebarOpen}
+        setSidebarOpen={setSidebarOpen}
+        title={title}
+        setTitle={setTitle}
+        fileInputRef={fileInputRef}
+        handleFileUpload={handleFileUpload}
+        uploadMessage={uploadMessage}
+        startScreenShare={startScreenShare}
+      />
 
-          <div>
-            <label className="block text-[#7C5CFC] font-semibold mb-1">Title</label>
-            <input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full border border-[#ede7fa] rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#7C5CFC] text-base"
-              placeholder="Enter recording title"
-            />
-          </div>
-
-          <div>
-            <label className="block text-[#7C5CFC] font-semibold mb-1">Recording Source</label>
-            <div className="border-2 border-dashed border-[#A594F9] rounded-lg p-4 flex flex-col items-center justify-center mb-4 bg-[#F8F6FF]">
-              <button
-                onClick={() => fileInputRef.current?.click()}
-                className="flex flex-col items-center gap-2 text-[#7C5CFC] font-semibold text-base focus:outline-none"
-              >
-                <span className="text-2xl">
-                  <Image
-                    src="/icons/upload_icon.png"
-                    alt="Notifications"
-                    width={20}
-                    height={20}
-                    className="md:w-6 md:h-6"
-                  />
-                </span>
-                Upload Screen Recording
-                <span className="text-xs text-gray-400">MP4, MOV up to 100MB</span>
-              </button>
-              <input
-                type="file"
-                accept="video/mp4,video/webm,video/*"
-                ref={fileInputRef}
-                className="hidden"
-                onChange={handleFileUpload}
-              />
-              {uploadMessage && <div className="mt-2 text-green-600 text-xs">{uploadMessage}</div>}
-            </div>
-            <button
-              onClick={startScreenShare}
-              className="w-full mt-2 px-4 py-3 rounded-lg bg-white text-[#7C5CFC] font-semibold shadow hover:bg-[#8A76FC] hover:text-white transition flex items-center justify-center gap-2 text-base"
-            >
-              <Image
-                src="/icons/play_button_icon.png"
-                alt="Notifications"
-                width={20}
-                height={20}
-                className="md:w-6 md:h-6"
-              />
-              Start Screen Sharing
-            </button>
-          </div>
-        </div>
-      </Dialog>
-
-      <main className="flex-1 flex flex-col h-full overflow-hidden">
-        <div className="header w-full flex flex-col sm:flex-row items-start sm:items-center justify-between px- sm:px-12 py-4 sm:py-6 bg-[#f3f0fc] border-b border-[#ede7fa]">
-          <div>
-            <div className="text-lg sm:text-2xl font-semibold text-[#1A0033]">New Recording</div>
-            <p className="text-xs sm:text-sm text-gray-400">Last saved 2 minutes ago</p>
-          </div>
-        </div>
-
-        <div className="flex-1 flex flex-col h-full overflow-hidden px-0 sm:px-2 pb-0 sm:pb-2">
-          <div className="record-card w-full max-w-360 mx-auto flex flex-col items-center justify-center bg-white rounded-2xl shadow-lg p-4 sm:p-8 flex-1 overflow-y-auto">
-            {uploadedFileUrl ? (
-              <video
-                src={uploadedFileUrl}
-                controls
-                className="w-full h-[200px] sm:h-[400px] object-contain bg-[#F6F4FF] mb-4 sm:mb-6 rounded-xl border border-[#7C5CFC]"
-                style={{ maxWidth: 900 }}
-              />
-            ) : (
-              <>
-                <span
-                  className="mb-10 mt-0"
-                  style={{ width: 96, height: 66, display: "inline-block" }}
-                >
-                  <svg
-                    className="video-icon w-full h-full"
-                    viewBox="0 0 118 118"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M73.75 49.1667L96.1356 37.9763C96.885 37.6019 97.7176 37.4251 98.5546 37.4628C99.3915 37.5005 100.205 37.7514 100.918 38.1917C101.63 38.632 102.219 39.2472 102.627 39.9788C103.035 40.7103 103.25 41.5341 103.25 42.3718V75.6282C103.25 76.4659 103.035 77.2897 102.627 78.0212C102.219 78.7528 101.63 79.368 100.918 79.8083C100.205 80.2486 99.3915 80.4995 98.5546 80.5372C97.7176 80.5749 96.885 80.3981 96.1356 80.0237L73.75 68.8333V49.1667ZM14.75 39.3333C14.75 36.7254 15.786 34.2242 17.6301 32.3801C19.4742 30.536 21.9754 29.5 24.5833 29.5H63.9167C66.5246 29.5 69.0258 30.536 70.8699 32.3801C72.714 34.2242 73.75 36.7254 73.75 39.3333V78.6667C73.75 81.2746 72.714 83.7758 70.8699 85.6199C69.0258 87.464 66.5246 88.5 63.9167 88.5H24.5833C21.9754 88.5 19.4742 87.464 17.6301 85.6199C15.786 83.7758 14.75 81.2746 14.75 78.6667V39.3333Z"
-                      stroke="currentColor"
-                      strokeWidth="7"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </span>
-                <div className="record-content flex flex-col items-center">
-                  <div className="text-lg sm:text-xl font-semibold text-[#1A0033] mb-2 dark:text-white">
-                    Start Sharing Your Screen
-                  </div>
-                  <p className="text-gray-400 text-center max-w-md mb-4 sm:mb-6 text-sm sm:text-base">
-                    Click the below button or upload a screen share to begin.
-                    <br />
-                    creating your interactive demo
-                  </p>
-                </div>
-              </>
-            )}
-            <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 mt-4 sm:mt-6 justify-center items-center w-full">
-              <button
-                onClick={startScreenShare}
-                className="share-btn w-full sm:w-auto px-4 sm:px-8 py-2 sm:py-3 rounded-lg bg-[#7C5CFC] text-white font-semibold shadow hover:bg-[#8A76FC] transition text-sm sm:text-base cursor-pointer"
-              >
-                Start Screen Share
-              </button>
-              <button
-                onClick={() => fileInputRef.current?.click()}
-                className="upload-btn w-full sm:w-auto px-4 sm:px-8 py-2 sm:py-3 rounded-lg bg-white border border-[#ede7fa] text-[#7C5CFC] font-semibold shadow hover:bg-[#F3F0FC] transition text-sm sm:text-base cursor-pointer"
-              >
-                Upload File
-              </button>
-              <div className="mic flex items-center gap-2 sm:gap-3 ml-0 sm:ml-4 mt-2 sm:mt-0 w-full sm:w-auto justify-center">
-                <span className="text-[#888] font-medium text-sm sm:text-base">Microphone</span>
-                <button
-                  onClick={toggleMic}
-                  className={`toggle w-10 sm:w-12 h-6 rounded-full flex items-center px-1 transition ${micEnabled ? "bg-[#6C63FF]" : "bg-gray-300"} cursor-pointer`}
-                >
-                  <span
-                    className={`toggle-circle w-4 h-4 bg-white rounded-full shadow transition-transform ${micEnabled ? "translate-x-4 sm:translate-x-6" : ""}`}
-                  />
-                </button>
-              </div>
-            </div>
-
-            <input
-              type="file"
-              accept="video/mp4,video/webm,video/*"
-              ref={fileInputRef}
-              className="hidden"
-              onChange={handleFileUpload}
-            />
-          </div>
-        </div>
-      </main>
+      <RecorderMainPanel
+        uploadedFileUrl={uploadedFileUrl}
+        fileInputRef={fileInputRef}
+        handleFileUpload={handleFileUpload}
+        startScreenShare={startScreenShare}
+        toggleMic={toggleMic}
+        micEnabled={micEnabled}
+      />
     </div>
   );
 }

--- a/app/components/RecorderMainPanel.tsx
+++ b/app/components/RecorderMainPanel.tsx
@@ -1,0 +1,106 @@
+interface RecorderMainPanelProps {
+  uploadedFileUrl: string | null;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  handleFileUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  startScreenShare: () => void;
+  toggleMic: () => void;
+  micEnabled: boolean;
+}
+
+export default function RecorderMainPanel({
+  uploadedFileUrl,
+  fileInputRef,
+  handleFileUpload,
+  startScreenShare,
+  toggleMic,
+  micEnabled,
+}: RecorderMainPanelProps) {
+  return (
+    <main className="flex-1 flex flex-col h-full overflow-hidden">
+      <div className="header w-full flex flex-col sm:flex-row items-start sm:items-center justify-between px- sm:px-12 py-4 sm:py-6 bg-[#f3f0fc] border-b border-[#ede7fa]">
+        <div>
+          <div className="text-lg sm:text-2xl font-semibold text-[#1A0033]">New Recording</div>
+          <p className="text-xs sm:text-sm text-gray-400">Last saved 2 minutes ago</p>
+        </div>
+      </div>
+
+      <div className="flex-1 flex flex-col h-full overflow-hidden px-0 sm:px-2 pb-0 sm:pb-2">
+        <div className="record-card w-full max-w-360 mx-auto flex flex-col items-center justify-center bg-white rounded-2xl shadow-lg p-4 sm:p-8 flex-1 overflow-y-auto">
+          {uploadedFileUrl ? (
+            <video
+              src={uploadedFileUrl}
+              controls
+              className="w-full h-[200px] sm:h-[400px] object-contain bg-[#F6F4FF] mb-4 sm:mb-6 rounded-xl border border-[#7C5CFC]"
+              style={{ maxWidth: 900 }}
+            />
+          ) : (
+            <>
+              <span
+                className="mb-10 mt-0"
+                style={{ width: 96, height: 66, display: "inline-block" }}
+              >
+                <svg
+                  className="video-icon w-full h-full"
+                  viewBox="0 0 118 118"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M73.75 49.1667L96.1356 37.9763C96.885 37.6019 97.7176 37.4251 98.5546 37.4628C99.3915 37.5005 100.205 37.7514 100.918 38.1917C101.63 38.632 102.219 39.2472 102.627 39.9788C103.035 40.7103 103.25 41.5341 103.25 42.3718V75.6282C103.25 76.4659 103.035 77.2897 102.627 78.0212C102.219 78.7528 101.63 79.368 100.918 79.8083C100.205 80.2486 99.3915 80.4995 98.5546 80.5372C97.7176 80.5749 96.885 80.3981 96.1356 80.0237L73.75 68.8333V49.1667ZM14.75 39.3333C14.75 36.7254 15.786 34.2242 17.6301 32.3801C19.4742 30.536 21.9754 29.5 24.5833 29.5H63.9167C66.5246 29.5 69.0258 30.536 70.8699 32.3801C72.714 34.2242 73.75 36.7254 73.75 39.3333V78.6667C73.75 81.2746 72.714 83.7758 70.8699 85.6199C69.0258 87.464 66.5246 88.5 63.9167 88.5H24.5833C21.9754 88.5 19.4742 87.464 17.6301 85.6199C15.786 83.7758 14.75 81.2746 14.75 78.6667V39.3333Z"
+                    stroke="currentColor"
+                    strokeWidth="7"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </span>
+              <div className="record-content flex flex-col items-center">
+                <div className="text-lg sm:text-xl font-semibold text-[#1A0033] mb-2 dark:text-white">
+                  Start Sharing Your Screen
+                </div>
+                <p className="text-gray-400 text-center max-w-md mb-4 sm:mb-6 text-sm sm:text-base">
+                  Click the below button or upload a screen share to begin.
+                  <br />
+                  creating your interactive demo
+                </p>
+              </div>
+            </>
+          )}
+          <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 mt-4 sm:mt-6 justify-center items-center w-full">
+            <button
+              onClick={startScreenShare}
+              className="share-btn w-full sm:w-auto px-4 sm:px-8 py-2 sm:py-3 rounded-lg bg-[#7C5CFC] text-white font-semibold shadow hover:bg-[#8A76FC] transition text-sm sm:text-base cursor-pointer"
+            >
+              Start Screen Share
+            </button>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="upload-btn w-full sm:w-auto px-4 sm:px-8 py-2 sm:py-3 rounded-lg bg-white border border-[#ede7fa] text-[#7C5CFC] font-semibold shadow hover:bg-[#F3F0FC] transition text-sm sm:text-base cursor-pointer"
+            >
+              Upload File
+            </button>
+            <div className="mic flex items-center gap-2 sm:gap-3 ml-0 sm:ml-4 mt-2 sm:mt-0 w-full sm:w-auto justify-center">
+              <span className="text-[#888] font-medium text-sm sm:text-base">Microphone</span>
+              <button
+                onClick={toggleMic}
+                className={`toggle w-10 sm:w-12 h-6 rounded-full flex items-center px-1 transition ${micEnabled ? "bg-[#6C63FF]" : "bg-gray-300"} cursor-pointer`}
+              >
+                <span
+                  className={`toggle-circle w-4 h-4 bg-white rounded-full shadow transition-transform ${micEnabled ? "translate-x-4 sm:translate-x-6" : ""}`}
+                />
+              </button>
+            </div>
+          </div>
+
+          <input
+            type="file"
+            accept="video/mp4,video/webm,video/*"
+            ref={fileInputRef}
+            className="hidden"
+            onChange={handleFileUpload}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/components/RecorderSettingsDialog.tsx
+++ b/app/components/RecorderSettingsDialog.tsx
@@ -1,0 +1,95 @@
+import Image from "next/image";
+import { Dialog } from "@headlessui/react";
+
+interface RecorderSettingsDialogProps {
+  sidebarOpen: boolean;
+  setSidebarOpen: (open: boolean) => void;
+  title: string;
+  setTitle: (title: string) => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  handleFileUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  uploadMessage: string;
+  startScreenShare: () => void;
+}
+
+export default function RecorderSettingsDialog({
+  sidebarOpen,
+  setSidebarOpen,
+  title,
+  setTitle,
+  fileInputRef,
+  handleFileUpload,
+  uploadMessage,
+  startScreenShare,
+}: RecorderSettingsDialogProps) {
+  return (
+    <Dialog open={sidebarOpen} onClose={() => setSidebarOpen(false)} className="relative z-50">
+      <div className="fixed inset-0 bg-black/40" aria-hidden="true" />
+      <div className="fixed inset-y-0 left-0 w-[90vw] max-w-xs bg-white shadow-2xl p-6 flex flex-col gap-6 overflow-y-auto">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-xl font-bold text-[#7C5CFC]">Recorder Settings</h2>
+          <button
+            className="text-[#7C5CFC] text-2xl p-1 rounded hover:bg-[#ede7fa] focus:outline-none"
+            onClick={() => setSidebarOpen(false)}
+            aria-label="Close settings"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div>
+          <label className="block text-[#7C5CFC] font-semibold mb-1">Title</label>
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full border border-[#ede7fa] rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#7C5CFC] text-base"
+            placeholder="Enter recording title"
+          />
+        </div>
+
+        <div>
+          <label className="block text-[#7C5CFC] font-semibold mb-1">Recording Source</label>
+          <div className="border-2 border-dashed border-[#A594F9] rounded-lg p-4 flex flex-col items-center justify-center mb-4 bg-[#F8F6FF]">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="flex flex-col items-center gap-2 text-[#7C5CFC] font-semibold text-base focus:outline-none"
+            >
+              <span className="text-2xl">
+                <Image
+                  src="/icons/upload_icon.png"
+                  alt="Notifications"
+                  width={20}
+                  height={20}
+                  className="md:w-6 md:h-6"
+                />
+              </span>
+              Upload Screen Recording
+              <span className="text-xs text-gray-400">MP4, MOV up to 100MB</span>
+            </button>
+            <input
+              type="file"
+              accept="video/mp4,video/webm,video/*"
+              ref={fileInputRef}
+              className="hidden"
+              onChange={handleFileUpload}
+            />
+            {uploadMessage && <div className="mt-2 text-green-600 text-xs">{uploadMessage}</div>}
+          </div>
+          <button
+            onClick={startScreenShare}
+            className="w-full mt-2 px-4 py-3 rounded-lg bg-white text-[#7C5CFC] font-semibold shadow hover:bg-[#8A76FC] hover:text-white transition flex items-center justify-center gap-2 text-base"
+          >
+            <Image
+              src="/icons/play_button_icon.png"
+              alt="Notifications"
+              width={20}
+              height={20}
+              className="md:w-6 md:h-6"
+            />
+            Start Screen Sharing
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/app/hooks/useInteractionRecorder.ts
+++ b/app/hooks/useInteractionRecorder.ts
@@ -1,5 +1,12 @@
 "use client";
-import { useRef, useState, useCallback } from "react";
+import {
+  useRef,
+  useState,
+  useCallback,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
 import html2canvas from "html2canvas";
 
 export interface CursorPosition {
@@ -32,6 +39,152 @@ export interface RecordingSession {
   startTime: number;
 }
 
+// Capture the visible viewport with html2canvas, falling back to a placeholder
+// canvas when html2canvas fails so callers always receive a usable image.
+const captureScreenshot = async (): Promise<string | null> => {
+  try {
+    console.log("Starting capture...");
+    const element = document.documentElement;
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    const canvas = await html2canvas(element, {
+      width,
+      height,
+      x: 0,
+      y: 0,
+      windowWidth: width,
+      windowHeight: height,
+      allowTaint: true,
+      useCORS: true,
+      foreignObjectRendering: true,
+      backgroundColor: null,
+    });
+
+    const dataUrl = canvas.toDataURL("image/png");
+    console.log("Capture successful, size:", dataUrl.length);
+    return dataUrl;
+  } catch (error) {
+    console.error("html2canvas failed:", error);
+    const canvas = document.createElement("canvas");
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.fillStyle = "#f0f0f0";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = "#000";
+      ctx.font = "20px Arial";
+      ctx.fillText("Screenshot Placeholder", 20, 50);
+      ctx.fillText(`Captured at ${new Date().toLocaleTimeString()}`, 20, 100);
+      const fallbackUrl = canvas.toDataURL("image/png");
+      console.log("Using fallback screenshot");
+      return fallbackUrl;
+    }
+    return null;
+  }
+};
+
+const buildAutoSlide = (imageData: string, clicks: ClickEvent[], timestamp: number): Slide => ({
+  id: `slide-${Date.now()}`,
+  timestamp,
+  imageData,
+  clicks: [...clicks],
+  title: `Step ${Date.now()}`,
+  description: clicks.length > 0 ? `Clicked ${clicks.length} element(s)` : "Capture point",
+});
+
+interface RecordingHandlerDeps {
+  captureVisibleArea: () => Promise<string | null>;
+  clicksRef: MutableRefObject<ClickEvent[]>;
+  pendingCapturesRef: MutableRefObject<Promise<void>[]>;
+  recordingStartTimeRef: MutableRefObject<number>;
+  setSlides: Dispatch<SetStateAction<Slide[]>>;
+}
+
+// Build the click / navigation listeners used while recording. Kept at module
+// scope so the recorder hook body stays small; all mutable state is shared via
+// the refs passed in.
+const createRecordingHandlers = ({
+  captureVisibleArea,
+  clicksRef,
+  pendingCapturesRef,
+  recordingStartTimeRef,
+  setSlides,
+}: RecordingHandlerDeps) => {
+  const captureHandler = async () => {
+    try {
+      const imageData = await captureVisibleArea();
+      if (!imageData) {
+        console.warn("No image data captured");
+        return;
+      }
+
+      const now = Date.now();
+      const timestamp = now - recordingStartTimeRef.current;
+      const newSlide = buildAutoSlide(imageData, clicksRef.current, timestamp);
+
+      console.log("Adding slide:", newSlide.id);
+      setSlides((prev) => [...prev, newSlide]);
+      clicksRef.current = [];
+    } catch (error) {
+      console.error("Error in captureHandler:", error);
+    }
+  };
+
+  const handleClick = (e: MouseEvent) => {
+    console.log("Click detected at:", e.clientX, e.clientY);
+    const target = e.target as HTMLElement;
+    const now = Date.now();
+    clicksRef.current.push({
+      x: e.clientX,
+      y: e.clientY,
+      timestamp: now - recordingStartTimeRef.current,
+      elementText: target.textContent?.substring(0, 50) || "",
+      elementId: target.id,
+    });
+    const capturePromise = captureHandler();
+    pendingCapturesRef.current.push(capturePromise);
+  };
+
+  return { captureHandler, handleClick };
+};
+
+const requestSaveTutorial = async (
+  title: string,
+  description: string | undefined,
+  slides: Slide[]
+) => {
+  if (!title.trim() || slides.length === 0) {
+    throw new Error("Title and slides are required");
+  }
+
+  const payload = {
+    title,
+    description: description || null,
+    slides: slides.map((slide) => ({
+      title: slide.title,
+      description: slide.description,
+      imageData: slide.imageData,
+      clicks: slide.clicks,
+      timestamp: slide.timestamp,
+    })),
+  };
+
+  const response = await fetch("/api/tutorials", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || "Failed to save tutorial");
+  }
+
+  return response.json();
+};
+
 export const useInteractionRecorder = () => {
   const [recording, setRecording] = useState(false);
   const [slides, setSlides] = useState<Slide[]>([]);
@@ -44,49 +197,7 @@ export const useInteractionRecorder = () => {
     captureHandler?: () => Promise<void>;
   }>({});
 
-  const captureVisibleArea = useCallback(async () => {
-    try {
-      console.log("Starting capture...");
-      const element = document.documentElement;
-      const width = window.innerWidth;
-      const height = window.innerHeight;
-
-      const canvas = await html2canvas(element, {
-        width,
-        height,
-        x: 0,
-        y: 0,
-        windowWidth: width,
-        windowHeight: height,
-        allowTaint: true,
-        useCORS: true,
-        foreignObjectRendering: true,
-        backgroundColor: null,
-      });
-
-      const dataUrl = canvas.toDataURL("image/png");
-      console.log("Capture successful, size:", dataUrl.length);
-      return dataUrl;
-    } catch (error) {
-      console.error("html2canvas failed:", error);
-      const canvas = document.createElement("canvas");
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
-      const ctx = canvas.getContext("2d");
-      if (ctx) {
-        ctx.fillStyle = "#f0f0f0";
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        ctx.fillStyle = "#000";
-        ctx.font = "20px Arial";
-        ctx.fillText("Screenshot Placeholder", 20, 50);
-        ctx.fillText(`Captured at ${new Date().toLocaleTimeString()}`, 20, 100);
-        const fallbackUrl = canvas.toDataURL("image/png");
-        console.log("Using fallback screenshot");
-        return fallbackUrl;
-      }
-      return null;
-    }
-  }, []);
+  const captureVisibleArea = useCallback(() => captureScreenshot(), []);
 
   const startRecording = useCallback(() => {
     setRecording(true);
@@ -95,51 +206,13 @@ export const useInteractionRecorder = () => {
     recordingStartTimeRef.current = Date.now();
     setSlides([]);
 
-    const captureHandler = async () => {
-      try {
-        const imageData = await captureVisibleArea();
-        if (!imageData) {
-          console.warn("No image data captured");
-          return;
-        }
-
-        const now = Date.now();
-        const timestamp = now - recordingStartTimeRef.current;
-
-        const newSlide: Slide = {
-          id: `slide-${Date.now()}`,
-          timestamp,
-          imageData,
-          clicks: [...clicksRef.current],
-          title: `Step ${Date.now()}`,
-          description:
-            clicksRef.current.length > 0
-              ? `Clicked ${clicksRef.current.length} element(s)`
-              : "Capture point",
-        };
-
-        console.log("Adding slide:", newSlide.id);
-        setSlides((prev) => [...prev, newSlide]);
-        clicksRef.current = [];
-      } catch (error) {
-        console.error("Error in captureHandler:", error);
-      }
-    };
-
-    const handleClick = (e: MouseEvent) => {
-      console.log("Click detected at:", e.clientX, e.clientY);
-      const target = e.target as HTMLElement;
-      const now = Date.now();
-      clicksRef.current.push({
-        x: e.clientX,
-        y: e.clientY,
-        timestamp: now - recordingStartTimeRef.current,
-        elementText: target.textContent?.substring(0, 50) || "",
-        elementId: target.id,
-      });
-      const capturePromise = captureHandler();
-      pendingCapturesRef.current.push(capturePromise);
-    };
+    const { captureHandler, handleClick } = createRecordingHandlers({
+      captureVisibleArea,
+      clicksRef,
+      pendingCapturesRef,
+      recordingStartTimeRef,
+      setSlides,
+    });
 
     document.addEventListener("click", handleClick);
     window.addEventListener("hashchange", captureHandler);
@@ -226,34 +299,7 @@ export const useInteractionRecorder = () => {
   const saveTutorial = useCallback(
     async (title: string, description?: string) => {
       try {
-        if (!title.trim() || slides.length === 0) {
-          throw new Error("Title and slides are required");
-        }
-
-        const payload = {
-          title,
-          description: description || null,
-          slides: slides.map((slide) => ({
-            title: slide.title,
-            description: slide.description,
-            imageData: slide.imageData,
-            clicks: slide.clicks,
-            timestamp: slide.timestamp,
-          })),
-        };
-
-        const response = await fetch("/api/tutorials", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        });
-
-        if (!response.ok) {
-          const error = await response.json();
-          throw new Error(error.error || "Failed to save tutorial");
-        }
-
-        const tutorial = await response.json();
+        const tutorial = await requestSaveTutorial(title, description, slides);
         reset();
         return tutorial;
       } catch (error) {

--- a/app/hooks/useScreenRecorder.ts
+++ b/app/hooks/useScreenRecorder.ts
@@ -3,6 +3,81 @@ import { useRef, useState } from "react";
 import { useBlobStore } from "../store/blobStore";
 import { toast } from "sonner";
 
+// Build a combined screen + audio MediaStream. A silent oscillator is added
+// when no real audio source exists so the recording always has a valid audio
+// track (FFmpeg's stream-copy trim needs audio timestamps for correct duration).
+const buildCombinedStream = async (
+  screenStream: MediaStream,
+  micEnabled: boolean
+): Promise<MediaStream> => {
+  const audioContext = new AudioContext();
+  const destination = audioContext.createMediaStreamDestination();
+
+  let micStream: MediaStream | null = null;
+  if (micEnabled) {
+    try {
+      micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      console.warn("Mic access denied:", err);
+    }
+  }
+
+  let hasAudioSource = false;
+
+  if (screenStream.getAudioTracks().length > 0) {
+    const tabSource = audioContext.createMediaStreamSource(
+      new MediaStream(screenStream.getAudioTracks())
+    );
+    tabSource.connect(destination);
+    hasAudioSource = true;
+  }
+  if (micStream) {
+    const micSource = audioContext.createMediaStreamSource(micStream);
+    micSource.connect(destination);
+    hasAudioSource = true;
+  }
+
+  if (!hasAudioSource) {
+    const oscillator = audioContext.createOscillator();
+    const gain = audioContext.createGain();
+    gain.gain.value = 0; // complete silence
+    oscillator.connect(gain);
+    gain.connect(destination);
+    oscillator.start();
+  }
+
+  return new MediaStream([
+    ...screenStream.getVideoTracks(),
+    ...destination.stream.getAudioTracks(),
+  ]);
+};
+
+const pickRecorderMimeType = (): string =>
+  MediaRecorder.isTypeSupported("video/webm; codecs=vp8,opus")
+    ? "video/webm; codecs=vp8,opus"
+    : MediaRecorder.isTypeSupported("video/webm")
+      ? "video/webm"
+      : "";
+
+const createMediaRecorder = (stream: MediaStream): MediaRecorder => {
+  const mimeType = pickRecorderMimeType();
+  return mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+};
+
+const reportScreenShareError = (err: unknown) => {
+  if (err instanceof Error) {
+    if (err.name === "NotAllowedError" || err.name === "PermissionDeniedError") {
+      console.log("User denied screen share.");
+    } else {
+      console.warn("Screen share failed:", err);
+      toast.error("Screen share failed. Please try again.");
+    }
+  } else {
+    console.warn("Screen share failed with unknown error:", err);
+    toast.error("Screen share failed. Please try again.");
+  }
+};
+
 export const useScreenRecorder = () => {
   const mediaRecorder = useRef<MediaRecorder | null>(null);
   const screenStreamRef = useRef<MediaStream | null>(null);
@@ -52,68 +127,16 @@ export const useScreenRecorder = () => {
 
   const startRecording = async () => {
     try {
-      const audioContext = new AudioContext();
-      const destination = audioContext.createMediaStreamDestination();
       if (!screenStreamRef.current) {
         return;
       }
 
-      let micStream: MediaStream | null = null;
-
-      if (micEnabled) {
-        try {
-          micStream = await navigator.mediaDevices.getUserMedia({
-            audio: true,
-          });
-        } catch (err) {
-          console.warn("Mic access denied:", err);
-        }
-      }
-
-      let hasAudioSource = false;
-
-      if (screenStreamRef.current.getAudioTracks().length > 0) {
-        const tabSource = audioContext.createMediaStreamSource(
-          new MediaStream(screenStreamRef.current.getAudioTracks())
-        );
-        tabSource.connect(destination);
-        hasAudioSource = true;
-      }
-      if (micStream) {
-        const micSource = audioContext.createMediaStreamSource(micStream);
-        micSource.connect(destination);
-        hasAudioSource = true;
-      }
-
-      // If no real audio source, add a silent oscillator so the recording
-      // always has a valid audio track. This is required because FFmpeg's
-      // stream-copy trim needs audio timestamps to produce correct duration.
-      if (!hasAudioSource) {
-        const oscillator = audioContext.createOscillator();
-        const gain = audioContext.createGain();
-        gain.gain.value = 0; // complete silence
-        oscillator.connect(gain);
-        gain.connect(destination);
-        oscillator.start();
-      }
-
-      const combinedStream = new MediaStream([
-        ...screenStreamRef.current.getVideoTracks(),
-        ...destination.stream.getAudioTracks(),
-      ]);
+      const combinedStream = await buildCombinedStream(screenStreamRef.current, micEnabled);
       combinedStreamRef.current = combinedStream;
       chunksRef.current = [];
       hasFinalizedRef.current = false;
 
-      const mimeType = MediaRecorder.isTypeSupported("video/webm; codecs=vp8,opus")
-        ? "video/webm; codecs=vp8,opus"
-        : MediaRecorder.isTypeSupported("video/webm")
-          ? "video/webm"
-          : "";
-
-      mediaRecorder.current = mimeType
-        ? new MediaRecorder(combinedStream, { mimeType })
-        : new MediaRecorder(combinedStream);
+      mediaRecorder.current = createMediaRecorder(combinedStream);
       recorderMimeTypeRef.current = mediaRecorder.current.mimeType || "video/webm";
 
       mediaRecorder.current.ondataavailable = (e) => {
@@ -164,17 +187,7 @@ export const useScreenRecorder = () => {
 
       await startRecording();
     } catch (err: unknown) {
-      if (err instanceof Error) {
-        if (err.name === "NotAllowedError" || err.name === "PermissionDeniedError") {
-          console.log("User denied screen share.");
-        } else {
-          console.warn("Screen share failed:", err);
-          toast.error("Screen share failed. Please try again.");
-        }
-      } else {
-        console.warn("Screen share failed with unknown error:", err);
-        toast.error("Screen share failed. Please try again.");
-      }
+      reportScreenShareError(err);
     }
   };
 


### PR DESCRIPTION
Partial Fixes #196 
Refactor the four flagged recorder functions to under 150 lines

- RecorderClient.tsx (RecorderPage): extract useRecorderActions hook (handleBack / handleEditVideo / handlePopupDownload + getUserInitials) and RecorderWorkspaceView sub-view
- InitialRecorderView.tsx: extract RecorderSettingsDialog + RecorderMainPanel
- useInteractionRecorder.ts: move captureScreenshot, buildAutoSlide, createRecordingHandlers, and requestSaveTutorial to module scope
- useScreenRecorder.ts: move buildCombinedStream, pickRecorderMimeType, createMediaRecorder, and reportScreenShareError to module scope