### PR TITLE
refactor(editor): split editor sub-components & modals under max-lines-per-function (#196) 5/13

### DIFF
--- a/app/components/CustomVideoControls.tsx
+++ b/app/components/CustomVideoControls.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import ReactPlayer from "react-player";
 import Image from "next/image";
 import { formatTime } from "@/app/lib/dateTimeUtils";
-import { FaVolumeMute, FaVolumeUp } from "react-icons/fa";
+import VideoUtilityControls from "./VideoUtilityControls";
 
 interface CustomVideoControlsProps {
   playerRef: React.RefObject<ReactPlayer>;
@@ -121,65 +121,16 @@ export default function CustomVideoControls({
           </span>
         </div>
 
-        <div className="flex items-center gap-3">
-          <button
-            onClick={() => {
-              const newEffective = Math.max(0, effectiveCurrentTime - 5);
-              const newSource = newEffective * speed;
-              setCurrentTime(newSource);
-              playerRef.current?.seekTo(newSource, "seconds");
-            }}
-            className="p-2 rounded-full cursor-pointer bg-[#7C5CFC] hover:bg-[#6A4DE8] text-white transition playback-utility-icon"
-            title="Back 5 seconds"
-          >
-            <Image src="/icons/replay.svg" alt="Replay" width={16} height={16} />
-          </button>
-
-          <button
-            onClick={() => {
-              const newEffective = Math.min(effectiveDuration, effectiveCurrentTime + 5);
-              const newSource = newEffective * speed;
-              setCurrentTime(newSource);
-              playerRef.current?.seekTo(newSource, "seconds");
-            }}
-            className="p-2 rounded-full cursor-pointer bg-[#7C5CFC] hover:bg-[#6A4DE8] text-white transition playback-utility-icon"
-            title="Forward 5 seconds"
-          >
-            <Image src="/icons/forward.svg" alt="Forward" width={16} height={16} />
-          </button>
-
-          <div className="flex items-center gap-2 w-36">
-            <button
-              onClick={() => setVolume(volume === 0 ? 1 : 0)}
-              className="playback-utility-icon cursor-pointer"
-            >
-              {volume === 0 ? (
-                <FaVolumeMute className="text-[#7C5CFC] text-xl" />
-              ) : (
-                <FaVolumeUp className="text-[#7C5CFC] text-xl" />
-              )}
-            </button>
-
-            <input
-              type="range"
-              min={0}
-              max={1}
-              step={0.01}
-              value={volume}
-              onChange={(e) => setVolume(Number(e.target.value))}
-              className="w-full h-2 rounded-lg accent-[#7C5CFC] playback-progress-bar-rail"
-            />
-          </div>
-
-          <button
-            onClick={handleFullscreen}
-            className="p-2 rounded-full cursor-pointer bg-[#7C5CFC] hover:bg-[#6A4DE8] text-white transition playback-utility-icon"
-            title="Fullscreen"
-            type="button"
-          >
-            <Image src="/icons/Group 316.svg" alt="Fullscreen" width={16} height={16} />
-          </button>
-        </div>
+        <VideoUtilityControls
+          playerRef={playerRef}
+          effectiveCurrentTime={effectiveCurrentTime}
+          effectiveDuration={effectiveDuration}
+          speed={speed}
+          setCurrentTime={setCurrentTime}
+          volume={volume}
+          setVolume={setVolume}
+          handleFullscreen={handleFullscreen}
+        />
       </div>
     </div>
   );

--- a/app/components/EditorControls.tsx
+++ b/app/components/EditorControls.tsx
@@ -2,6 +2,7 @@
 import { Button } from "@/app/components/ui/button";
 import { useEffect, useState, RefObject, useCallback } from "react";
 import { formatTimeFull } from "@/app/lib/dateTimeUtils";
+import TrimRangeSlider from "./TrimRangeSlider";
 
 type EditorControlsProps = {
   onTrim: (start: string, end: string) => void;
@@ -116,89 +117,41 @@ const EditorControls = ({ onTrim, processing, videoRef, duration }: EditorContro
           </Button>
         </div>
 
-        <div className="pt-2">
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            ⏱ Start Time: <span className="font-mono">{formatTimeFull(start)}</span>
-          </label>
+        <TrimRangeSlider
+          label="⏱ Start Time:"
+          displayTime={formatTimeFull(start)}
+          inputValue={startTimeInput}
+          placeholder="00:00:00"
+          rangeMin={0}
+          rangeMax={Math.max(0, end - 1)}
+          rangeValue={start}
+          onRangeChange={(e) => {
+            const val = Number(e.target.value);
+            setStart(val);
+            if (val >= end) {
+              setEnd(val + 1 <= duration ? val + 1 : duration);
+            }
+          }}
+          processing={processing}
+        />
 
-          {/* Manual input for start time */}
-          <div className="mb-3">
-            <div className="flex items-center gap-2 mb-2">
-              <div className="relative flex-1">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"></div>
-                <input
-                  type="text"
-                  value={startTimeInput}
-                  readOnly
-                  placeholder="00:00:00"
-                  disabled={processing}
-                  className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg text-sm font-mono bg-gray-50 shadow-sm transition-all duration-200 disabled:bg-gray-50 disabled:cursor-not-allowed cursor-default"
-                />
-                <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
-                  <span className="text-xs text-gray-400 font-medium">HH:MM:SS</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <input
-            type="range"
-            min={0}
-            max={Math.max(0, end - 1)}
-            value={start}
-            onChange={(e) => {
-              const val = Number(e.target.value);
-              setStart(val);
-              if (val >= end) {
-                setEnd(val + 1 <= duration ? val + 1 : duration);
-              }
-            }}
-            disabled={processing}
-            className="w-full accent-blue-500 cursor-pointer"
-          />
-        </div>
-
-        <div className="pt-2">
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            ⏲ End Time: <span className="font-mono">{formatTimeFull(end)}</span>
-          </label>
-
-          {/* Manual input for end time */}
-          <div className="mb-3">
-            <div className="flex items-center gap-2 mb-2">
-              <div className="relative flex-1">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"></div>
-                <input
-                  type="text"
-                  value={endTimeInput}
-                  readOnly
-                  placeholder="00:00:10"
-                  disabled={processing}
-                  className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg text-sm font-mono bg-gray-50 shadow-sm transition-all duration-200 disabled:bg-gray-50 disabled:cursor-not-allowed cursor-default"
-                />
-                <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
-                  <span className="text-xs text-gray-400 font-medium">HH:MM:SS</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <input
-            type="range"
-            min={start + 1}
-            max={duration}
-            value={end}
-            onChange={(e) => {
-              const val = Number(e.target.value);
-              setEnd(val);
-              if (val <= start) {
-                setStart(val - 1 >= 0 ? val - 1 : 0);
-              }
-            }}
-            disabled={processing}
-            className="w-full accent-blue-500 cursor-pointer"
-          />
-        </div>
+        <TrimRangeSlider
+          label="⏲ End Time:"
+          displayTime={formatTimeFull(end)}
+          inputValue={endTimeInput}
+          placeholder="00:00:10"
+          rangeMin={start + 1}
+          rangeMax={duration}
+          rangeValue={end}
+          onRangeChange={(e) => {
+            const val = Number(e.target.value);
+            setEnd(val);
+            if (val <= start) {
+              setStart(val - 1 >= 0 ? val - 1 : 0);
+            }
+          }}
+          processing={processing}
+        />
       </div>
 
       <div className="text-xs text-gray-500 mt-6 border-t pt-4">

--- a/app/components/EditorTopbar.tsx
+++ b/app/components/EditorTopbar.tsx
@@ -1,9 +1,11 @@
-import { useSession, signOut } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { useRef, useState, useEffect } from "react";
 import Image from "next/image";
 import { FaBars, FaXmark } from "react-icons/fa6";
 import { useRouter } from "next/navigation";
 import SidemenuDashboard from "./SidemenuDashboard";
+import EditorTopbarUserMenu from "./EditorTopbarUserMenu";
+import { useProfileImage } from "./useProfileImage";
 
 type EditorTopbarProps = {
   onBack: () => void;
@@ -16,56 +18,12 @@ const EditorTopbar = ({ onBack, userInitials, onToggleMenu }: EditorTopbarProps)
   const { data: session } = useSession();
   const [showDropdown, setShowDropdown] = useState(false);
   const [isDashboardMenuOpen, setIsDashboardMenuOpen] = useState(false);
-  const [profileImage, setProfileImage] = useState<string | null | undefined>(null);
+  const profileImage = useProfileImage(session);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const hamburgerRef = useRef<HTMLDivElement>(null);
 
   const username =
     session?.user?.name?.split(" ")[0] || session?.user?.email?.split("@")?.[0] || "User";
-
-  useEffect(() => {
-    const fetchUserImage = async () => {
-      try {
-        const res = await fetch("/api/user/get");
-        const data = await res.json();
-        if (data.user?.image && data.user.image.trim()) {
-          setProfileImage(data.user.image + `?t=${Date.now()}`);
-        } else {
-          setProfileImage(null);
-        }
-      } catch (error) {
-        console.error("Error fetching user image:", error);
-        setProfileImage(null);
-      }
-    };
-
-    if (session?.user) {
-      fetchUserImage();
-    }
-  }, [session]);
-
-  useEffect(() => {
-    const handlePhotoUpdate = () => {
-      const fetchUserImage = async () => {
-        try {
-          const res = await fetch("/api/user/get");
-          const data = await res.json();
-          if (data.user?.image && data.user.image.trim()) {
-            setProfileImage(data.user.image + `?t=${Date.now()}`);
-          } else {
-            setProfileImage(null);
-          }
-        } catch (error) {
-          console.error("Error fetching user image:", error);
-          setProfileImage(null);
-        }
-      };
-      fetchUserImage();
-    };
-
-    window.addEventListener("photoUpdated", handlePhotoUpdate);
-    return () => window.removeEventListener("photoUpdated", handlePhotoUpdate);
-  }, []);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -140,63 +98,15 @@ const EditorTopbar = ({ onBack, userInitials, onToggleMenu }: EditorTopbarProps)
           MARVEDGE
         </button>
       </div>
-      <div className="flex items-center gap-2 sm:gap-4">
-        <span className="hidden sm:block text-[#7C5CFC] font-medium text-base mr-2 items-center gap-1">
-          Welcome, {username}
-          <span role="img" aria-label="waving hand" className="ml-1">
-            👋
-          </span>
-        </span>
-        <div className="flex items-center gap-2 shrink-0">
-          <button className="relative text-[#7C5CFC] hover:bg-[#ede7fa] rounded-full p-1 w-8 h-8 sm:w-10 sm:h-10  items-center justify-center shrink-0 hidden sm:block">
-            <Image
-              src="/icons/bell.png"
-              alt="Notifications"
-              width={16}
-              height={16}
-              className="w-4 h-4 sm:w-5 sm:h-5"
-            />
-          </button>
-          <div className="relative" ref={dropdownRef}>
-            <button
-              className="w-8 h-8 sm:w-10 sm:h-10 rounded-full text-white  items-center justify-center text-base sm:text-lg font-bold shadow cursor-pointer border-2 border-white hover:scale-105 transition-all block shrink-0 overflow-hidden"
-              onClick={() => setShowDropdown((v) => !v)}
-              title={session?.user?.name || session?.user?.email || undefined}
-              style={profileImage ? {} : { backgroundColor: "#6356D7" }}
-            >
-              {profileImage ? (
-                <Image
-                  key={profileImage}
-                  src={profileImage}
-                  alt="Profile"
-                  width={40}
-                  height={40}
-                  className="w-full h-full object-cover"
-                  unoptimized
-                />
-              ) : (
-                userInitials
-              )}
-            </button>
-            {showDropdown && (
-              <div className="absolute right-0 mt-2 w-56 md:w-64 bg-white rounded-lg shadow-lg p-3 md:p-4 z-50 border border-gray-200 animate-fade-in">
-                <div className="mb-2 text-base md:text-lg font-bold text-[#6356D7]">
-                  {session?.user?.name || "User"}
-                </div>
-                <div className="mb-1 text-gray-700 text-xs md:text-sm font-semibold">
-                  {session?.user?.email}
-                </div>
-                <button
-                  onClick={() => signOut({ callbackUrl: "/" })}
-                  className="mt-3 md:mt-4 w-full px-3 md:px-4 py-2 bg-[#6356D7] text-white rounded hover:bg-[#7E5FFF] font-semibold transition-all text-sm md:text-base"
-                >
-                  Sign out
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <EditorTopbarUserMenu
+        username={username}
+        session={session}
+        userInitials={userInitials}
+        profileImage={profileImage}
+        showDropdown={showDropdown}
+        setShowDropdown={setShowDropdown}
+        dropdownRef={dropdownRef}
+      />
     </div>
   );
 };

--- a/app/components/EditorTopbarUserMenu.tsx
+++ b/app/components/EditorTopbarUserMenu.tsx
@@ -1,0 +1,85 @@
+import Image from "next/image";
+import { signOut } from "next-auth/react";
+import type { Session } from "next-auth";
+
+type EditorTopbarUserMenuProps = {
+  username: string;
+  session: Session | null;
+  userInitials: string;
+  profileImage: string | null | undefined;
+  showDropdown: boolean;
+  setShowDropdown: React.Dispatch<React.SetStateAction<boolean>>;
+  dropdownRef: React.RefObject<HTMLDivElement | null>;
+};
+
+const EditorTopbarUserMenu = ({
+  username,
+  session,
+  userInitials,
+  profileImage,
+  showDropdown,
+  setShowDropdown,
+  dropdownRef,
+}: EditorTopbarUserMenuProps) => {
+  return (
+    <div className="flex items-center gap-2 sm:gap-4">
+      <span className="hidden sm:block text-[#7C5CFC] font-medium text-base mr-2 items-center gap-1">
+        Welcome, {username}
+        <span role="img" aria-label="waving hand" className="ml-1">
+          👋
+        </span>
+      </span>
+      <div className="flex items-center gap-2 shrink-0">
+        <button className="relative text-[#7C5CFC] hover:bg-[#ede7fa] rounded-full p-1 w-8 h-8 sm:w-10 sm:h-10  items-center justify-center shrink-0 hidden sm:block">
+          <Image
+            src="/icons/bell.png"
+            alt="Notifications"
+            width={16}
+            height={16}
+            className="w-4 h-4 sm:w-5 sm:h-5"
+          />
+        </button>
+        <div className="relative" ref={dropdownRef}>
+          <button
+            className="w-8 h-8 sm:w-10 sm:h-10 rounded-full text-white  items-center justify-center text-base sm:text-lg font-bold shadow cursor-pointer border-2 border-white hover:scale-105 transition-all block shrink-0 overflow-hidden"
+            onClick={() => setShowDropdown((v) => !v)}
+            title={session?.user?.name || session?.user?.email || undefined}
+            style={profileImage ? {} : { backgroundColor: "#6356D7" }}
+          >
+            {profileImage ? (
+              <Image
+                key={profileImage}
+                src={profileImage}
+                alt="Profile"
+                width={40}
+                height={40}
+                className="w-full h-full object-cover"
+                unoptimized
+              />
+            ) : (
+              userInitials
+            )}
+          </button>
+          {showDropdown && (
+            <div className="absolute right-0 mt-2 w-56 md:w-64 bg-white rounded-lg shadow-lg p-3 md:p-4 z-50 border border-gray-200 animate-fade-in">
+              <div className="mb-2 text-base md:text-lg font-bold text-[#6356D7]">
+                {session?.user?.name || "User"}
+              </div>
+              <div className="mb-1 text-gray-700 text-xs md:text-sm font-semibold">
+                {session?.user?.email}
+              </div>
+              <button
+                onClick={() => signOut({ callbackUrl: "/" })}
+                className="mt-3 md:mt-4 w-full px-3 md:px-4 py-2 bg-[#6356D7] text-white rounded hover:bg-[#7E5FFF] font-semibold transition-all text-sm md:text-base"
+              >
+                Sign out
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EditorTopbarUserMenu;

--- a/app/components/ExportCompression.tsx
+++ b/app/components/ExportCompression.tsx
@@ -1,0 +1,45 @@
+import type { ExportSettings } from "./ExportSettingsModal";
+
+type ExportCompressionProps = {
+  settings: ExportSettings;
+  setSettings: React.Dispatch<React.SetStateAction<ExportSettings>>;
+};
+
+export default function ExportCompression({ settings, setSettings }: ExportCompressionProps) {
+  return (
+    <div className="mb-5">
+      <label className="block text-[#8A76FC] text-[15px] mb-2">Compression</label>
+      <div className="flex bg-[#EAE5FB] rounded-xl p-1 relative h-[42px]">
+        <div
+          className="absolute top-1 bottom-1 w-[calc(25%-6px)] bg-[#8A76FC] rounded-lg transition-transform duration-300 ease-in-out"
+          style={{
+            transform:
+              settings.compression === "Web"
+                ? "translateX(0)"
+                : settings.compression === "Medium"
+                  ? "translateX(105%)"
+                  : settings.compression === "High"
+                    ? "translateX(210%)"
+                    : "translateX(315%)",
+          }}
+        />
+        {["Web", "Medium", "High", "Ultra"].map((comp) => (
+          <button
+            key={comp}
+            className={`flex-1 relative z-10 text-sm font-medium transition-colors ${
+              settings.compression === comp ? "text-white" : "text-[#8A76FC]"
+            }`}
+            onClick={() =>
+              setSettings({
+                ...settings,
+                compression: comp as ExportSettings["compression"],
+              })
+            }
+          >
+            {comp}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ExportQualityFrameRate.tsx
+++ b/app/components/ExportQualityFrameRate.tsx
@@ -1,0 +1,70 @@
+import { ChevronUp, ChevronDown } from "lucide-react";
+import type { ExportSettings } from "./ExportSettingsModal";
+
+type ExportQualityFrameRateProps = {
+  settings: ExportSettings;
+  setSettings: React.Dispatch<React.SetStateAction<ExportSettings>>;
+};
+
+export default function ExportQualityFrameRate({
+  settings,
+  setSettings,
+}: ExportQualityFrameRateProps) {
+  return (
+    <div className="flex gap-4 mb-5">
+      {/* Quality */}
+      <div className="flex-1">
+        <label className="block text-[#8A76FC] text-[15px] mb-2">Quality</label>
+        <div className="flex bg-[#EAE5FB] rounded-xl p-1 relative h-[42px]">
+          <div
+            className="absolute top-1 bottom-1 w-[calc(50%-4px)] bg-[#8A76FC] rounded-lg transition-transform duration-300 ease-in-out"
+            style={{
+              transform: settings.quality === "1080p" ? "translateX(100%)" : "translateX(0)",
+            }}
+          />
+          <button
+            className={`flex-1 relative z-10 text-sm font-medium transition-colors ${
+              settings.quality === "720p" ? "text-white" : "text-[#8A76FC]"
+            }`}
+            onClick={() => setSettings({ ...settings, quality: "720p" })}
+          >
+            720p
+          </button>
+          <button
+            className={`flex-1 relative z-10 text-sm font-medium transition-colors ${
+              settings.quality === "1080p" ? "text-white" : "text-[#8A76FC]"
+            }`}
+            onClick={() => setSettings({ ...settings, quality: "1080p" })}
+          >
+            1080p
+          </button>
+        </div>
+      </div>
+
+      {/* Frame Rate */}
+      <div className="flex-1">
+        <label className="block text-[#8A76FC] text-[15px] mb-2">Frame rate</label>
+        <div
+          className="flex bg-[#EAE5FB] rounded-xl px-3 h-[42px] items-center justify-between cursor-pointer"
+          onClick={() =>
+            setSettings({
+              ...settings,
+              fps:
+                settings.fps === "24 FPS"
+                  ? "30 FPS"
+                  : settings.fps === "30 FPS"
+                    ? "60 FPS"
+                    : "24 FPS",
+            })
+          }
+        >
+          <span className="text-[#8A76FC] text-sm font-medium">{settings.fps}</span>
+          <div className="flex flex-col text-[#8A76FC] opacity-50">
+            <ChevronUp size={14} className="-mb-1" />
+            <ChevronDown size={14} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/ExportSettingsModal.tsx
+++ b/app/components/ExportSettingsModal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { ChevronUp, ChevronDown } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import axios from "axios";
+import ExportQualityFrameRate from "./ExportQualityFrameRate";
+import ExportCompression from "./ExportCompression";
 
 export interface ExportSettings {
   quality: "720p" | "1080p";
@@ -19,6 +20,49 @@ interface ExportSettingsModalProps {
   onClose: () => void;
   onConfirm: (settings: ExportSettings) => void;
   durationInSeconds: number; // to estimate file size
+}
+
+const EXEMPT_EMAILS = [
+  "aryaanandpathak30@gmail.com",
+  "sarthakbehera10@gmail.com",
+  "ashishmishra19122000@gmail.com",
+  "sandipsubham.32@gmail.com",
+  "kanupriya2052017@gmail.com",
+  "rathourrahul21@gmail.com",
+  "ajitkumarshankhwar25@gmail.com",
+  "somyanayak281@gmail.com",
+  "manushichillar412@gmail.com",
+];
+
+// Basic heuristic for file size estimation based on duration and settings
+function estimateFileSize(settings: ExportSettings, durationInSeconds: number) {
+  let baseMultiplier = 1.0;
+  if (settings.quality === "1080p") {
+    baseMultiplier *= 1.5;
+  }
+  if (settings.fps === "24 FPS") {
+    baseMultiplier *= 0.9;
+  }
+  if (settings.fps === "60 FPS") {
+    baseMultiplier *= 1.2;
+  }
+
+  if (settings.compression === "Ultra") {
+    baseMultiplier *= 2.5;
+  } else if (settings.compression === "High") {
+    baseMultiplier *= 1.8;
+  } else if (settings.compression === "Medium") {
+    baseMultiplier *= 1.3;
+  }
+
+  // Roughly 0.5MB per second at 720p 30fps Web compression as a total guess baseline
+  let sizeInMb = durationInSeconds * 0.25 * baseMultiplier;
+
+  if (sizeInMb < 1) {
+    sizeInMb = 1;
+  } // minimum
+
+  return `${Math.round(sizeInMb)}MB`;
 }
 
 export default function ExportSettingsModal({
@@ -65,53 +109,14 @@ export default function ExportSettingsModal({
     }
   }, [isOpen, defaultSettings]);
 
-  const EXEMPT_EMAILS = [
-    "aryaanandpathak30@gmail.com",
-    "sarthakbehera10@gmail.com",
-    "ashishmishra19122000@gmail.com",
-    "sandipsubham.32@gmail.com",
-    "kanupriya2052017@gmail.com",
-    "rathourrahul21@gmail.com",
-    "ajitkumarshankhwar25@gmail.com",
-    "somyanayak281@gmail.com",
-    "manushichillar412@gmail.com",
-  ];
-
   const isExempt =
     (session?.user?.email && EXEMPT_EMAILS.includes(session.user.email)) ||
     userPlan === "PRO" ||
     userPlan === "ENTERPRISE";
   const limitReached = !isExempt && exportCount !== null && exportCount >= 3;
 
-  // Basic heuristic for file size estimation based on duration and settings
   useEffect(() => {
-    let baseMultiplier = 1.0;
-    if (settings.quality === "1080p") {
-      baseMultiplier *= 1.5;
-    }
-    if (settings.fps === "24 FPS") {
-      baseMultiplier *= 0.9;
-    }
-    if (settings.fps === "60 FPS") {
-      baseMultiplier *= 1.2;
-    }
-
-    if (settings.compression === "Ultra") {
-      baseMultiplier *= 2.5;
-    } else if (settings.compression === "High") {
-      baseMultiplier *= 1.8;
-    } else if (settings.compression === "Medium") {
-      baseMultiplier *= 1.3;
-    }
-
-    // Roughly 0.5MB per second at 720p 30fps Web compression as a total guess baseline
-    let sizeInMb = durationInSeconds * 0.25 * baseMultiplier;
-
-    if (sizeInMb < 1) {
-      sizeInMb = 1;
-    } // minimum
-
-    setEstimatedSize(`${Math.round(sizeInMb)}MB`);
+    setEstimatedSize(estimateFileSize(settings, durationInSeconds));
   }, [settings, durationInSeconds]);
 
   if (!isOpen) {
@@ -135,97 +140,10 @@ export default function ExportSettingsModal({
         </div>
 
         {/* Quality & Frame Rate */}
-        <div className="flex gap-4 mb-5">
-          {/* Quality */}
-          <div className="flex-1">
-            <label className="block text-[#8A76FC] text-[15px] mb-2">Quality</label>
-            <div className="flex bg-[#EAE5FB] rounded-xl p-1 relative h-[42px]">
-              <div
-                className="absolute top-1 bottom-1 w-[calc(50%-4px)] bg-[#8A76FC] rounded-lg transition-transform duration-300 ease-in-out"
-                style={{
-                  transform: settings.quality === "1080p" ? "translateX(100%)" : "translateX(0)",
-                }}
-              />
-              <button
-                className={`flex-1 relative z-10 text-sm font-medium transition-colors ${
-                  settings.quality === "720p" ? "text-white" : "text-[#8A76FC]"
-                }`}
-                onClick={() => setSettings({ ...settings, quality: "720p" })}
-              >
-                720p
-              </button>
-              <button
-                className={`flex-1 relative z-10 text-sm font-medium transition-colors ${
-                  settings.quality === "1080p" ? "text-white" : "text-[#8A76FC]"
-                }`}
-                onClick={() => setSettings({ ...settings, quality: "1080p" })}
-              >
-                1080p
-              </button>
-            </div>
-          </div>
-
-          {/* Frame Rate */}
-          <div className="flex-1">
-            <label className="block text-[#8A76FC] text-[15px] mb-2">Frame rate</label>
-            <div
-              className="flex bg-[#EAE5FB] rounded-xl px-3 h-[42px] items-center justify-between cursor-pointer"
-              onClick={() =>
-                setSettings({
-                  ...settings,
-                  fps:
-                    settings.fps === "24 FPS"
-                      ? "30 FPS"
-                      : settings.fps === "30 FPS"
-                        ? "60 FPS"
-                        : "24 FPS",
-                })
-              }
-            >
-              <span className="text-[#8A76FC] text-sm font-medium">{settings.fps}</span>
-              <div className="flex flex-col text-[#8A76FC] opacity-50">
-                <ChevronUp size={14} className="-mb-1" />
-                <ChevronDown size={14} />
-              </div>
-            </div>
-          </div>
-        </div>
+        <ExportQualityFrameRate settings={settings} setSettings={setSettings} />
 
         {/* Compression */}
-        <div className="mb-5">
-          <label className="block text-[#8A76FC] text-[15px] mb-2">Compression</label>
-          <div className="flex bg-[#EAE5FB] rounded-xl p-1 relative h-[42px]">
-            <div
-              className="absolute top-1 bottom-1 w-[calc(25%-6px)] bg-[#8A76FC] rounded-lg transition-transform duration-300 ease-in-out"
-              style={{
-                transform:
-                  settings.compression === "Web"
-                    ? "translateX(0)"
-                    : settings.compression === "Medium"
-                      ? "translateX(105%)"
-                      : settings.compression === "High"
-                        ? "translateX(210%)"
-                        : "translateX(315%)",
-              }}
-            />
-            {["Web", "Medium", "High", "Ultra"].map((comp) => (
-              <button
-                key={comp}
-                className={`flex-1 relative z-10 text-sm font-medium transition-colors ${
-                  settings.compression === comp ? "text-white" : "text-[#8A76FC]"
-                }`}
-                onClick={() =>
-                  setSettings({
-                    ...settings,
-                    compression: comp as ExportSettings["compression"],
-                  })
-                }
-              >
-                {comp}
-              </button>
-            ))}
-          </div>
-        </div>
+        <ExportCompression settings={settings} setSettings={setSettings} />
 
         {/* License Info Box */}
         {limitReached ? (

--- a/app/components/TrimRangeSlider.tsx
+++ b/app/components/TrimRangeSlider.tsx
@@ -1,0 +1,65 @@
+import { ChangeEvent } from "react";
+
+type TrimRangeSliderProps = {
+  label: string;
+  displayTime: string;
+  inputValue: string;
+  placeholder: string;
+  rangeMin: number;
+  rangeMax: number;
+  rangeValue: number;
+  onRangeChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  processing: boolean;
+};
+
+const TrimRangeSlider = ({
+  label,
+  displayTime,
+  inputValue,
+  placeholder,
+  rangeMin,
+  rangeMax,
+  rangeValue,
+  onRangeChange,
+  processing,
+}: TrimRangeSliderProps) => {
+  return (
+    <div className="pt-2">
+      <label className="block text-sm font-medium text-gray-700 mb-1">
+        {label} <span className="font-mono">{displayTime}</span>
+      </label>
+
+      {/* Manual input for time */}
+      <div className="mb-3">
+        <div className="flex items-center gap-2 mb-2">
+          <div className="relative flex-1">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"></div>
+            <input
+              type="text"
+              value={inputValue}
+              readOnly
+              placeholder={placeholder}
+              disabled={processing}
+              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg text-sm font-mono bg-gray-50 shadow-sm transition-all duration-200 disabled:bg-gray-50 disabled:cursor-not-allowed cursor-default"
+            />
+            <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
+              <span className="text-xs text-gray-400 font-medium">HH:MM:SS</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <input
+        type="range"
+        min={rangeMin}
+        max={rangeMax}
+        value={rangeValue}
+        onChange={onRangeChange}
+        disabled={processing}
+        className="w-full accent-blue-500 cursor-pointer"
+      />
+    </div>
+  );
+};
+
+export default TrimRangeSlider;

--- a/app/components/VideoUtilityControls.tsx
+++ b/app/components/VideoUtilityControls.tsx
@@ -1,0 +1,87 @@
+import ReactPlayer from "react-player";
+import Image from "next/image";
+import { FaVolumeMute, FaVolumeUp } from "react-icons/fa";
+
+interface VideoUtilityControlsProps {
+  playerRef: React.RefObject<ReactPlayer>;
+  effectiveCurrentTime: number;
+  effectiveDuration: number;
+  speed: number;
+  setCurrentTime: (t: number) => void;
+  volume: number;
+  setVolume: (t: number) => void;
+  handleFullscreen: () => void;
+}
+
+export default function VideoUtilityControls({
+  playerRef,
+  effectiveCurrentTime,
+  effectiveDuration,
+  speed,
+  setCurrentTime,
+  volume,
+  setVolume,
+  handleFullscreen,
+}: VideoUtilityControlsProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        onClick={() => {
+          const newEffective = Math.max(0, effectiveCurrentTime - 5);
+          const newSource = newEffective * speed;
+          setCurrentTime(newSource);
+          playerRef.current?.seekTo(newSource, "seconds");
+        }}
+        className="p-2 rounded-full cursor-pointer bg-[#7C5CFC] hover:bg-[#6A4DE8] text-white transition playback-utility-icon"
+        title="Back 5 seconds"
+      >
+        <Image src="/icons/replay.svg" alt="Replay" width={16} height={16} />
+      </button>
+
+      <button
+        onClick={() => {
+          const newEffective = Math.min(effectiveDuration, effectiveCurrentTime + 5);
+          const newSource = newEffective * speed;
+          setCurrentTime(newSource);
+          playerRef.current?.seekTo(newSource, "seconds");
+        }}
+        className="p-2 rounded-full cursor-pointer bg-[#7C5CFC] hover:bg-[#6A4DE8] text-white transition playback-utility-icon"
+        title="Forward 5 seconds"
+      >
+        <Image src="/icons/forward.svg" alt="Forward" width={16} height={16} />
+      </button>
+
+      <div className="flex items-center gap-2 w-36">
+        <button
+          onClick={() => setVolume(volume === 0 ? 1 : 0)}
+          className="playback-utility-icon cursor-pointer"
+        >
+          {volume === 0 ? (
+            <FaVolumeMute className="text-[#7C5CFC] text-xl" />
+          ) : (
+            <FaVolumeUp className="text-[#7C5CFC] text-xl" />
+          )}
+        </button>
+
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={volume}
+          onChange={(e) => setVolume(Number(e.target.value))}
+          className="w-full h-2 rounded-lg accent-[#7C5CFC] playback-progress-bar-rail"
+        />
+      </div>
+
+      <button
+        onClick={handleFullscreen}
+        className="p-2 rounded-full cursor-pointer bg-[#7C5CFC] hover:bg-[#6A4DE8] text-white transition playback-utility-icon"
+        title="Fullscreen"
+        type="button"
+      >
+        <Image src="/icons/Group 316.svg" alt="Fullscreen" width={16} height={16} />
+      </button>
+    </div>
+  );
+}

--- a/app/components/ZoomEffectForm.tsx
+++ b/app/components/ZoomEffectForm.tsx
@@ -1,0 +1,142 @@
+import { Button } from "@/app/components/ui/button";
+import { formatTime } from "@/app/lib/dateTimeUtils";
+import { UseZoomEffectForm } from "./useZoomEffectForm";
+
+interface ZoomEffectFormProps {
+  form: UseZoomEffectForm;
+  currentTime: number;
+}
+
+export default function ZoomEffectForm({ form, currentTime }: ZoomEffectFormProps) {
+  const {
+    editingEffect,
+    startTime,
+    setStartTime,
+    endTime,
+    setEndTime,
+    zoomLevel,
+    setZoomLevel,
+    centerX,
+    setCenterX,
+    centerY,
+    setCenterY,
+    resetForm,
+    handleAddEffect,
+    handleUpdateEffect,
+    handleSetCurrentTime,
+    handleAddTestEffect,
+  } = form;
+
+  return (
+    <div className="space-y-4 mb-6">
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Start Time</label>
+          <input
+            type="text"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+            placeholder="0:00"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">End Time</label>
+          <input
+            type="text"
+            value={endTime}
+            onChange={(e) => setEndTime(e.target.value)}
+            placeholder="0:00"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Zoom Level</label>
+        <input
+          type="range"
+          min="1"
+          max="5"
+          step="0.1"
+          value={zoomLevel}
+          onChange={(e) => setZoomLevel(parseFloat(e.target.value))}
+          className="w-full"
+        />
+        <div className="text-sm text-gray-500 mt-1">{zoomLevel}x</div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Center Point</label>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">X Position</label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={centerX}
+              onChange={(e) => setCenterX(parseFloat(e.target.value))}
+              className="w-full"
+            />
+            <div className="text-xs text-gray-500">{Math.round(centerX * 100)}%</div>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Y Position</label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={centerY}
+              onChange={(e) => setCenterY(parseFloat(e.target.value))}
+              className="w-full"
+            />
+            <div className="text-xs text-gray-500">{Math.round(centerY * 100)}%</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          onClick={handleSetCurrentTime}
+          variant="outline"
+          size="sm"
+          className="btn-mini-cancel"
+        >
+          Set Current Time ({formatTime(currentTime)})
+        </Button>
+        <Button
+          onClick={handleAddTestEffect}
+          variant="outline"
+          size="sm"
+          className="btn-mini-cancel"
+        >
+          Add Test Effect
+        </Button>
+      </div>
+
+      <div className="flex gap-2">
+        {editingEffect ? (
+          <>
+            <Button onClick={handleUpdateEffect} className="flex-1 btn-mini-purple">
+              Update Effect
+            </Button>
+            <Button onClick={resetForm} variant="outline" className="btn-mini-cancel">
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button
+            onClick={handleAddEffect}
+            disabled={!startTime || !endTime}
+            className="flex-1 btn-mini-purple"
+          >
+            Add Effect
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ZoomEffectList.tsx
+++ b/app/components/ZoomEffectList.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@/app/components/ui/button";
+import { Trash2 } from "lucide-react";
+import { formatTime } from "@/app/lib/dateTimeUtils";
+import { ZoomEffect } from "../types/editor/zoom-effect";
+
+interface ZoomEffectListProps {
+  zoomEffects: ZoomEffect[];
+  onEdit: (effect: ZoomEffect) => void;
+  onDelete: (id: string) => void;
+}
+
+export default function ZoomEffectList({ zoomEffects, onEdit, onDelete }: ZoomEffectListProps) {
+  return (
+    <div>
+      <h3 className="text-lg font-semibold mb-4">Current Effects</h3>
+      {zoomEffects.length === 0 ? (
+        <p className="text-gray-500 text-center py-4">No zoom effects added yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {zoomEffects.map((effect) => (
+            <div
+              key={effect.id}
+              className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+            >
+              <div className="flex-1">
+                <div className="font-medium">
+                  {formatTime(effect.startTime)} - {formatTime(effect.endTime)}
+                </div>
+                <div className="text-sm text-gray-500">
+                  Zoom: {effect.zoomLevel}x | Center: ({Math.round(effect.x * 100)}%,{" "}
+                  {Math.round(effect.y * 100)}%)
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  onClick={() => onEdit(effect)}
+                  variant="outline"
+                  size="sm"
+                  className="btn-mini-cancel"
+                >
+                  Edit
+                </Button>
+                <Button
+                  onClick={() => onDelete(effect.id)}
+                  variant="outline"
+                  size="sm"
+                  className="text-red-600 hover:text-red-700"
+                >
+                  <Trash2 size={16} />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/ZoomEffectsPopup.tsx
+++ b/app/components/ZoomEffectsPopup.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { useState } from "react";
-import { Button } from "@/app/components/ui/button";
-import { X, Trash2 } from "lucide-react";
-import { formatTime } from "@/app/lib/dateTimeUtils";
+import { X } from "lucide-react";
 import { ZoomEffect } from "../types/editor/zoom-effect";
+import { useZoomEffectForm } from "./useZoomEffectForm";
+import ZoomEffectForm from "./ZoomEffectForm";
+import ZoomEffectList from "./ZoomEffectList";
 
 interface ZoomEffectsPopupProps {
   isOpen: boolean;
@@ -23,99 +23,12 @@ export default function ZoomEffectsPopup({
   currentTime,
   duration,
 }: ZoomEffectsPopupProps) {
-  const [editingEffect, setEditingEffect] = useState<ZoomEffect | null>(null);
-  const [startTime, setStartTime] = useState("");
-  const [endTime, setEndTime] = useState("");
-  const [zoomLevel, setZoomLevel] = useState(2.0);
-  const [centerX, setCenterX] = useState(0.5);
-  const [centerY, setCenterY] = useState(0.5);
-  const parseTime = (timeString: string) => {
-    const parts = timeString.split(":").map(Number);
-    if (parts.length === 2) {
-      return parts[0] * 60 + parts[1];
-    }
-    return 0;
-  };
-
-  const handleAddEffect = () => {
-    const newEffect: ZoomEffect = {
-      id: Date.now().toString(),
-      startTime: parseTime(startTime),
-      endTime: parseTime(endTime),
-      zoomLevel,
-      x: centerX,
-      y: centerY,
-    };
-
-    onZoomEffectsChange([...zoomEffects, newEffect]);
-    resetForm();
-  };
-
-  const handleEditEffect = (effect: ZoomEffect) => {
-    setEditingEffect(effect);
-    setStartTime(formatTime(effect.startTime));
-    setEndTime(formatTime(effect.endTime));
-    setZoomLevel(effect.zoomLevel);
-    setCenterX(effect.x);
-    setCenterY(effect.y);
-  };
-
-  const handleUpdateEffect = () => {
-    if (!editingEffect) {
-      return;
-    }
-
-    const updatedEffect: ZoomEffect = {
-      ...editingEffect,
-      startTime: parseTime(startTime),
-      endTime: parseTime(endTime),
-      zoomLevel,
-      x: centerX,
-      y: centerY,
-    };
-
-    const updatedEffects = zoomEffects.map((effect) =>
-      effect.id === editingEffect.id ? updatedEffect : effect
-    );
-
-    onZoomEffectsChange(updatedEffects);
-    setEditingEffect(null);
-    resetForm();
-  };
-
-  const handleDeleteEffect = (id: string) => {
-    onZoomEffectsChange(zoomEffects.filter((effect) => effect.id !== id));
-  };
-
-  const resetForm = () => {
-    setStartTime("");
-    setEndTime("");
-    setZoomLevel(2.0);
-    setCenterX(0.5);
-    setCenterY(0.5);
-    setEditingEffect(null);
-  };
-
-  const handleSetCurrentTime = () => {
-    if (editingEffect) {
-      setEndTime(formatTime(currentTime));
-    } else {
-      setStartTime(formatTime(currentTime));
-    }
-  };
-
-  const handleAddTestEffect = () => {
-    const testEffect: ZoomEffect = {
-      id: Date.now().toString(),
-      startTime: Math.max(0, currentTime - 5),
-      endTime: Math.min(duration, currentTime + 5),
-      zoomLevel: 2.0,
-      x: 0.5,
-      y: 0.5,
-    };
-
-    onZoomEffectsChange([...zoomEffects, testEffect]);
-  };
+  const form = useZoomEffectForm({
+    zoomEffects,
+    onZoomEffectsChange,
+    currentTime,
+    duration,
+  });
 
   if (!isOpen) {
     return null;
@@ -133,160 +46,13 @@ export default function ZoomEffectsPopup({
           </button>
         </div>
 
-        <div className="space-y-4 mb-6">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Start Time</label>
-              <input
-                type="text"
-                value={startTime}
-                onChange={(e) => setStartTime(e.target.value)}
-                placeholder="0:00"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">End Time</label>
-              <input
-                type="text"
-                value={endTime}
-                onChange={(e) => setEndTime(e.target.value)}
-                placeholder="0:00"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
-              />
-            </div>
-          </div>
+        <ZoomEffectForm form={form} currentTime={currentTime} />
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Zoom Level</label>
-            <input
-              type="range"
-              min="1"
-              max="5"
-              step="0.1"
-              value={zoomLevel}
-              onChange={(e) => setZoomLevel(parseFloat(e.target.value))}
-              className="w-full"
-            />
-            <div className="text-sm text-gray-500 mt-1">{zoomLevel}x</div>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Center Point</label>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-xs text-gray-500 mb-1">X Position</label>
-                <input
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.01"
-                  value={centerX}
-                  onChange={(e) => setCenterX(parseFloat(e.target.value))}
-                  className="w-full"
-                />
-                <div className="text-xs text-gray-500">{Math.round(centerX * 100)}%</div>
-              </div>
-              <div>
-                <label className="block text-xs text-gray-500 mb-1">Y Position</label>
-                <input
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.01"
-                  value={centerY}
-                  onChange={(e) => setCenterY(parseFloat(e.target.value))}
-                  className="w-full"
-                />
-                <div className="text-xs text-gray-500">{Math.round(centerY * 100)}%</div>
-              </div>
-            </div>
-          </div>
-
-          <div className="flex gap-2">
-            <Button
-              onClick={handleSetCurrentTime}
-              variant="outline"
-              size="sm"
-              className="btn-mini-cancel"
-            >
-              Set Current Time ({formatTime(currentTime)})
-            </Button>
-            <Button
-              onClick={handleAddTestEffect}
-              variant="outline"
-              size="sm"
-              className="btn-mini-cancel"
-            >
-              Add Test Effect
-            </Button>
-          </div>
-
-          <div className="flex gap-2">
-            {editingEffect ? (
-              <>
-                <Button onClick={handleUpdateEffect} className="flex-1 btn-mini-purple">
-                  Update Effect
-                </Button>
-                <Button onClick={resetForm} variant="outline" className="btn-mini-cancel">
-                  Cancel
-                </Button>
-              </>
-            ) : (
-              <Button
-                onClick={handleAddEffect}
-                disabled={!startTime || !endTime}
-                className="flex-1 btn-mini-purple"
-              >
-                Add Effect
-              </Button>
-            )}
-          </div>
-        </div>
-
-        <div>
-          <h3 className="text-lg font-semibold mb-4">Current Effects</h3>
-          {zoomEffects.length === 0 ? (
-            <p className="text-gray-500 text-center py-4">No zoom effects added yet.</p>
-          ) : (
-            <div className="space-y-2">
-              {zoomEffects.map((effect) => (
-                <div
-                  key={effect.id}
-                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
-                >
-                  <div className="flex-1">
-                    <div className="font-medium">
-                      {formatTime(effect.startTime)} - {formatTime(effect.endTime)}
-                    </div>
-                    <div className="text-sm text-gray-500">
-                      Zoom: {effect.zoomLevel}x | Center: ({Math.round(effect.x * 100)}%,{" "}
-                      {Math.round(effect.y * 100)}%)
-                    </div>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button
-                      onClick={() => handleEditEffect(effect)}
-                      variant="outline"
-                      size="sm"
-                      className="btn-mini-cancel"
-                    >
-                      Edit
-                    </Button>
-                    <Button
-                      onClick={() => handleDeleteEffect(effect.id)}
-                      variant="outline"
-                      size="sm"
-                      className="text-red-600 hover:text-red-700"
-                    >
-                      <Trash2 size={16} />
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+        <ZoomEffectList
+          zoomEffects={zoomEffects}
+          onEdit={form.handleEditEffect}
+          onDelete={form.handleDeleteEffect}
+        />
       </div>
     </div>
   );

--- a/app/components/useProfileImage.ts
+++ b/app/components/useProfileImage.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import type { Session } from "next-auth";
+
+export function useProfileImage(session: Session | null) {
+  const [profileImage, setProfileImage] = useState<string | null | undefined>(null);
+
+  useEffect(() => {
+    const fetchUserImage = async () => {
+      try {
+        const res = await fetch("/api/user/get");
+        const data = await res.json();
+        if (data.user?.image && data.user.image.trim()) {
+          setProfileImage(data.user.image + `?t=${Date.now()}`);
+        } else {
+          setProfileImage(null);
+        }
+      } catch (error) {
+        console.error("Error fetching user image:", error);
+        setProfileImage(null);
+      }
+    };
+
+    if (session?.user) {
+      fetchUserImage();
+    }
+  }, [session]);
+
+  useEffect(() => {
+    const handlePhotoUpdate = () => {
+      const fetchUserImage = async () => {
+        try {
+          const res = await fetch("/api/user/get");
+          const data = await res.json();
+          if (data.user?.image && data.user.image.trim()) {
+            setProfileImage(data.user.image + `?t=${Date.now()}`);
+          } else {
+            setProfileImage(null);
+          }
+        } catch (error) {
+          console.error("Error fetching user image:", error);
+          setProfileImage(null);
+        }
+      };
+      fetchUserImage();
+    };
+
+    window.addEventListener("photoUpdated", handlePhotoUpdate);
+    return () => window.removeEventListener("photoUpdated", handlePhotoUpdate);
+  }, []);
+
+  return profileImage;
+}

--- a/app/components/useZoomEffectForm.ts
+++ b/app/components/useZoomEffectForm.ts
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import { formatTime } from "@/app/lib/dateTimeUtils";
+import { ZoomEffect } from "../types/editor/zoom-effect";
+
+interface UseZoomEffectFormProps {
+  zoomEffects: ZoomEffect[];
+  onZoomEffectsChange: (effects: ZoomEffect[]) => void;
+  currentTime: number;
+  duration: number;
+}
+
+const parseTime = (timeString: string) => {
+  const parts = timeString.split(":").map(Number);
+  if (parts.length === 2) {
+    return parts[0] * 60 + parts[1];
+  }
+  return 0;
+};
+
+export function useZoomEffectForm({
+  zoomEffects,
+  onZoomEffectsChange,
+  currentTime,
+  duration,
+}: UseZoomEffectFormProps) {
+  const [editingEffect, setEditingEffect] = useState<ZoomEffect | null>(null);
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
+  const [zoomLevel, setZoomLevel] = useState(2.0);
+  const [centerX, setCenterX] = useState(0.5);
+  const [centerY, setCenterY] = useState(0.5);
+
+  const resetForm = () => {
+    setStartTime("");
+    setEndTime("");
+    setZoomLevel(2.0);
+    setCenterX(0.5);
+    setCenterY(0.5);
+    setEditingEffect(null);
+  };
+
+  const handleAddEffect = () => {
+    const newEffect: ZoomEffect = {
+      id: Date.now().toString(),
+      startTime: parseTime(startTime),
+      endTime: parseTime(endTime),
+      zoomLevel,
+      x: centerX,
+      y: centerY,
+    };
+
+    onZoomEffectsChange([...zoomEffects, newEffect]);
+    resetForm();
+  };
+
+  const handleEditEffect = (effect: ZoomEffect) => {
+    setEditingEffect(effect);
+    setStartTime(formatTime(effect.startTime));
+    setEndTime(formatTime(effect.endTime));
+    setZoomLevel(effect.zoomLevel);
+    setCenterX(effect.x);
+    setCenterY(effect.y);
+  };
+
+  const handleUpdateEffect = () => {
+    if (!editingEffect) {
+      return;
+    }
+
+    const updatedEffect: ZoomEffect = {
+      ...editingEffect,
+      startTime: parseTime(startTime),
+      endTime: parseTime(endTime),
+      zoomLevel,
+      x: centerX,
+      y: centerY,
+    };
+
+    const updatedEffects = zoomEffects.map((effect) =>
+      effect.id === editingEffect.id ? updatedEffect : effect
+    );
+
+    onZoomEffectsChange(updatedEffects);
+    setEditingEffect(null);
+    resetForm();
+  };
+
+  const handleDeleteEffect = (id: string) => {
+    onZoomEffectsChange(zoomEffects.filter((effect) => effect.id !== id));
+  };
+
+  const handleSetCurrentTime = () => {
+    if (editingEffect) {
+      setEndTime(formatTime(currentTime));
+    } else {
+      setStartTime(formatTime(currentTime));
+    }
+  };
+
+  const handleAddTestEffect = () => {
+    const testEffect: ZoomEffect = {
+      id: Date.now().toString(),
+      startTime: Math.max(0, currentTime - 5),
+      endTime: Math.min(duration, currentTime + 5),
+      zoomLevel: 2.0,
+      x: 0.5,
+      y: 0.5,
+    };
+
+    onZoomEffectsChange([...zoomEffects, testEffect]);
+  };
+
+  return {
+    editingEffect,
+    startTime,
+    setStartTime,
+    endTime,
+    setEndTime,
+    zoomLevel,
+    setZoomLevel,
+    centerX,
+    setCenterX,
+    centerY,
+    setCenterY,
+    resetForm,
+    handleAddEffect,
+    handleEditEffect,
+    handleUpdateEffect,
+    handleDeleteEffect,
+    handleSetCurrentTime,
+    handleAddTestEffect,
+  };
+}
+
+export type UseZoomEffectForm = ReturnType<typeof useZoomEffectForm>;


### PR DESCRIPTION
Partial Fixes #196 
## Changes

| File | Before | Technique |
|------|:-----:|-----------|
| `EditorControls.tsx` | 193 | Extracted reusable `TrimRangeSlider` (rendered for both start & end) |
| `EditorTopbar.tsx` | 180 | Extracted `useProfileImage` hook + `EditorTopbarUserMenu` sub-component |
| `ZoomEffectsPopup.tsx` | 255 | Extracted `useZoomEffectForm` hook + `ZoomEffectForm` / `ZoomEffectList` sub-components |
| `ExportSettingsModal.tsx` | 225 | Moved `EXEMPT_EMAILS` + `estimateFileSize()` to module scope; extracted `ExportQualityFrameRate` + `ExportCompression` rows |
| `CustomVideoControls.tsx` | 153 | Extracted `VideoUtilityControls` (skip / volume / fullscreen cluster) |