### PR TITLE
feat(timeline): separate Trim, Zoom, and Text into dedicated rows

### DIFF
--- a/app/components/TimeLine.tsx
+++ b/app/components/TimeLine.tsx
@@ -1285,7 +1285,7 @@ export default function TimelineRuler({
             >
               <div
                 ref={rulerRef}
-                className="relative bg-white border-y border-[#A594F9] cursor-pointer track-layers-row"
+                className="relative bg-white dark:bg-[#0a081a] border-y border-[#A594F9] dark:border-[#3e2fd9]/50 cursor-pointer track-layers-row"
                 style={{
                   width: `${baseTimelineWidth * zoomLevel}px`,
                   minWidth: `${baseTimelineWidth}px`,
@@ -1320,6 +1320,10 @@ export default function TimelineRuler({
                   setActiveSegment={setActiveSegment}
                 />
 
+                {/* Horizontal separators in background */}
+                <div className="absolute top-[72px] left-0 w-full h-[1px] border-t border-dashed border-[#A594F9]/30 dark:border-[#3e2fd9]/30 pointer-events-none" />
+                <div className="absolute top-[108px] left-0 w-full h-[1px] border-t border-dashed border-[#A594F9]/30 dark:border-[#3e2fd9]/30 pointer-events-none" />
+
                 <div
                   className="absolute top-0 h-full z-40 pointer-events-none"
                   style={{
@@ -1346,7 +1350,7 @@ export default function TimelineRuler({
                   return (
                     <div
                       key={`segment-${idx}`}
-                      className={`absolute top-0 h-[84px] mt-[50px] group cursor-grab transition-opacity track-red sequence-block-shape width-trim-block ${
+                      className={`absolute top-0 h-[32px] mt-[38px] group cursor-grab transition-opacity track-red sequence-block-shape width-trim-block ${
                         idx === activeSegment && activeSegment != -1
                           ? "bg-[#FF3939]/54 opacity-70 z-10 hover:border-2 border-black rounded-md active"
                           : "bg-[#FF3939]/35 opacity-50 hover:opacity-65 z-8"
@@ -1387,7 +1391,7 @@ export default function TimelineRuler({
                       </div>
 
                       <div
-                        className="flex items-center justify-center absolute py-1 top-0 -left-1 h-[84px] w-[23px] bg-[#FF3939]/54 rounded-l-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#FF3939]"
+                        className="flex items-center justify-center absolute py-1 top-0 -left-1 h-[32px] w-[23px] bg-[#FF3939]/54 rounded-l-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#FF3939]"
                         onMouseDown={(e) => {
                           e.stopPropagation();
                           setDragState({
@@ -1401,11 +1405,11 @@ export default function TimelineRuler({
                         aria-label="Resize start"
                         title="Drag to resize start"
                       >
-                        <div className="w-px h-[60px] bg-white/80" />
+                        <div className="w-px h-[20px] bg-white/80" />
                       </div>
 
                       <div
-                        className="flex items-center justify-center absolute py-1 top-0 -right-1 h-[84px] w-[23px] bg-[#FF3939]/54 rounded-r-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#FF3939]"
+                        className="flex items-center justify-center absolute py-1 top-0 -right-1 h-[32px] w-[23px] bg-[#FF3939]/54 rounded-r-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#FF3939]"
                         onMouseDown={(e) => {
                           e.stopPropagation();
                           setDragState({
@@ -1419,7 +1423,7 @@ export default function TimelineRuler({
                         title="Drag to resize end"
                         aria-label="Resize end"
                       >
-                        <div className="w-px h-[60px] bg-white/80" />
+                        <div className="w-px h-[20px] bg-white/80" />
                       </div>
                     </div>
                   );
@@ -1434,7 +1438,7 @@ export default function TimelineRuler({
                   return (
                     <div
                       key={`segment-${idx}`}
-                      className={`absolute top-0 h-[84px] mt-[50px] group cursor-grab transition-opacity track-green sequence-block-shape width-zoom-block ${
+                      className={`absolute top-0 h-[32px] mt-[74px] group cursor-grab transition-opacity track-green sequence-block-shape width-zoom-block ${
                         idx == activeZoomIdx
                           ? "bg-[#36B37E]/40 opacity-80 z-10 hover:border-2 border-[#36B37E] rounded-md active"
                           : "bg-[#36B37E]/25 opacity-70 hover:opacity-90 z-8"
@@ -1475,7 +1479,7 @@ export default function TimelineRuler({
                       </div>
 
                       <div
-                        className="flex items-center justify-center absolute py-1 top-0 -left-1 h-[84px] w-[23px] bg-[#36B37E]/80 rounded-l-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#36B37E]"
+                        className="flex items-center justify-center absolute py-1 top-0 -left-1 h-[32px] w-[23px] bg-[#36B37E]/80 rounded-l-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#36B37E]"
                         onMouseDown={(e) => {
                           e.stopPropagation();
                           setDragZoomState({
@@ -1489,11 +1493,11 @@ export default function TimelineRuler({
                         aria-label="Resize start"
                         title="Drag to resize start"
                       >
-                        <div className="w-px h-[60px] bg-white/80" />
+                        <div className="w-px h-[20px] bg-white/80" />
                       </div>
 
                       <div
-                        className="flex items-center justify-center absolute py-1 top-0 -right-1 h-[84px] w-[23px] bg-[#36B37E]/80 rounded-r-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#36B37E]"
+                        className="flex items-center justify-center absolute py-1 top-0 -right-1 h-[32px] w-[23px] bg-[#36B37E]/80 rounded-r-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#36B37E]"
                         onMouseDown={(e) => {
                           e.stopPropagation();
                           setDragZoomState({
@@ -1507,7 +1511,7 @@ export default function TimelineRuler({
                         title="Drag to resize end"
                         aria-label="Resize end"
                       >
-                        <div className="w-px h-[60px] bg-white/80" />
+                        <div className="w-px h-[20px] bg-white/80" />
                       </div>
                     </div>
                   );
@@ -1525,7 +1529,7 @@ export default function TimelineRuler({
                   return (
                     <div
                       key={`text-${overlay.id}`}
-                      className={`absolute top-0 h-[84px] mt-[50px] group cursor-grab transition-opacity track-yellow sequence-block-shape width-text-block ${
+                      className={`absolute top-0 h-[32px] mt-[110px] group cursor-grab transition-opacity track-yellow sequence-block-shape width-text-block ${
                         isSelected
                           ? "bg-[#FFF4A8]/85 opacity-90 z-10 hover:border-2 border-[#B38700] rounded-md active"
                           : "bg-[#FFF4A8]/65 opacity-75 hover:opacity-90 border border-[#D4A017] z-8 rounded-md"
@@ -1572,7 +1576,7 @@ export default function TimelineRuler({
                       </div>
 
                       <div
-                        className="flex items-center justify-center absolute py-1 top-0 -left-1 h-[84px] w-[23px] bg-[#D4A017]/75 rounded-l-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#B38700]"
+                        className="flex items-center justify-center absolute py-1 top-0 -left-1 h-[32px] w-[23px] bg-[#D4A017]/75 rounded-l-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#B38700]"
                         onMouseDown={(e) => {
                           e.stopPropagation();
                           setDragTextState({
@@ -1586,11 +1590,11 @@ export default function TimelineRuler({
                         aria-label="Resize text start"
                         title="Drag to resize start"
                       >
-                        <div className="w-px h-[60px] bg-white/80" />
+                        <div className="w-px h-[20px] bg-white/80" />
                       </div>
 
                       <div
-                        className="flex items-center justify-center absolute py-1 top-0 -right-1 h-[84px] w-[23px] bg-[#D4A017]/75 rounded-r-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#B38700]"
+                        className="flex items-center justify-center absolute py-1 top-0 -right-1 h-[32px] w-[23px] bg-[#D4A017]/75 rounded-r-md group-hover:opacity-100 cursor-ew-resize transition-opacity hover:bg-[#B38700]"
                         onMouseDown={(e) => {
                           e.stopPropagation();
                           setDragTextState({
@@ -1604,7 +1608,7 @@ export default function TimelineRuler({
                         aria-label="Resize text end"
                         title="Drag to resize end"
                       >
-                        <div className="w-px h-[60px] bg-white/80" />
+                        <div className="w-px h-[20px] bg-white/80" />
                       </div>
                     </div>
                   );


### PR DESCRIPTION
Closes #187

Separated the Trim, Zoom, and Text blocks into dedicated horizontal tracks in the timeline to prevent visual overlapping.