### PR TITLE
refactor(video): split VideoPreview & VideoPlayerSection under 150 lines

### DIFF
--- a/app/components/RecorderVideoPlayer.tsx
+++ b/app/components/RecorderVideoPlayer.tsx
@@ -1,0 +1,207 @@
+import ReactPlayer from "react-player";
+import SimpleTimeline from "@/app/components/SimpleTimeline";
+
+const readPlayerDuration = (
+  videoPlayerRef: React.RefObject<ReactPlayer | null>,
+  setVideoDuration: (duration: number) => void
+) => {
+  const player = videoPlayerRef.current?.getInternalPlayer();
+  if (player && player.duration && isFinite(player.duration) && player.duration > 0) {
+    setVideoDuration(player.duration);
+  }
+};
+
+const scheduleDurationReads = (
+  videoPlayerRef: React.RefObject<ReactPlayer | null>,
+  setVideoDuration: (duration: number) => void
+) => {
+  setTimeout(() => readPlayerDuration(videoPlayerRef, setVideoDuration), 10);
+  setTimeout(() => readPlayerDuration(videoPlayerRef, setVideoDuration), 100);
+  setTimeout(() => readPlayerDuration(videoPlayerRef, setVideoDuration), 500);
+};
+
+interface PlayerTopBarProps {
+  volume: number;
+  onVolumeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFullscreen: () => void;
+}
+
+function PlayerTopBar({ volume, onVolumeChange, onFullscreen }: PlayerTopBarProps) {
+  return (
+    <div className="absolute top-0 right-0 z-20 flex items-center gap-2 p-4 bg-linear-to-l rounded-bl-2xl">
+      <div className="flex items-center gap-2 bg-black/40 rounded-full px-3 py-2 backdrop-blur-sm">
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          className="text-white"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+        </svg>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.1"
+          value={volume}
+          onChange={onVolumeChange}
+          className="w-20 h-1 accent-[#7C5CFC]"
+          style={{ cursor: "pointer" }}
+        />
+      </div>
+
+      <button
+        onClick={onFullscreen}
+        className="bg-black/40 hover:bg-black/60 text-white rounded-full p-2 transition backdrop-blur-sm"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+interface RecorderVideoPlayerProps {
+  url: string;
+  isUploaded?: boolean;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  volume: number;
+  onVolumeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFullscreen: () => void;
+  videoPlaying: boolean;
+  setVideoPlaying: (playing: boolean) => void;
+  videoCurrentTime: number;
+  setVideoCurrentTime: (time: number) => void;
+  videoDuration: number;
+  setVideoDuration: (duration: number) => void;
+  recordingDuration: number;
+  videoPlayerRef: React.RefObject<ReactPlayer | null>;
+}
+
+export default function RecorderVideoPlayer({
+  url,
+  isUploaded = false,
+  containerRef,
+  volume,
+  onVolumeChange,
+  onFullscreen,
+  videoPlaying,
+  setVideoPlaying,
+  videoCurrentTime,
+  setVideoCurrentTime,
+  videoDuration,
+  setVideoDuration,
+  recordingDuration,
+  videoPlayerRef,
+}: RecorderVideoPlayerProps) {
+  return (
+    <div className="w-full max-w-[900px] mx-auto">
+      <div
+        ref={containerRef}
+        className="video-box bg-white rounded-2xl shadow-md flex flex-col transition-all duration-300 overflow-hidden"
+      >
+        <div className="video-top w-full h-8 flex items-center px-4 gap-1.5 bg-[#f5f5f7] border-b border-[#ede7fa]">
+          <div className="circle w-2 h-2 rounded-full bg-gray-300"></div>
+          <div className="circle w-2 h-2 rounded-full bg-gray-300"></div>
+          <div className="circle w-2 h-2 rounded-full bg-gray-300"></div>
+        </div>
+
+        <div className="screen relative w-full h-auto aspect-video bg-white overflow-hidden group">
+          <PlayerTopBar
+            volume={volume}
+            onVolumeChange={onVolumeChange}
+            onFullscreen={onFullscreen}
+          />
+          <ReactPlayer
+            ref={videoPlayerRef}
+            url={url}
+            playing={videoPlaying}
+            controls={false}
+            muted={false}
+            width="100%"
+            height="100%"
+            style={{
+              objectFit: "contain",
+              borderRadius: "1.25rem",
+              background: "#F6F3FF",
+            }}
+            progressInterval={50}
+            onProgress={({ playedSeconds }) => {
+              if (playedSeconds === 0) {
+                setVideoCurrentTime(0);
+              } else {
+                setVideoCurrentTime(playedSeconds);
+              }
+            }}
+            onDuration={(dur) => {
+              if (
+                isUploaded &&
+                recordingDuration === 0 &&
+                isFinite(dur) &&
+                !isNaN(dur) &&
+                dur > 0
+              ) {
+                setVideoDuration(dur);
+              } else if (!isUploaded && isFinite(dur) && !isNaN(dur) && dur > 0) {
+                setVideoDuration(dur);
+              }
+            }}
+            onStart={() => {
+              setVideoCurrentTime(0);
+            }}
+            onPlay={() => {
+              setVideoCurrentTime(0);
+            }}
+            onEnded={() => setVideoPlaying(false)}
+            onReady={() => {
+              console.log("Video loaded in recorder");
+              if ((isUploaded && recordingDuration === 0) || !isUploaded) {
+                scheduleDurationReads(videoPlayerRef, setVideoDuration);
+              }
+            }}
+            config={{
+              file: {
+                attributes: {
+                  preload: "metadata",
+                },
+              },
+            }}
+          />
+
+          {!videoPlaying && (
+            <button
+              onClick={() => setVideoPlaying(true)}
+              className="absolute inset-0 flex items-center justify-center bg-black/40 hover:bg-black/50 transition-colors"
+            >
+              <div className="play-circle bg-white hover:bg-gray-100 rounded-full p-4 transition-all shadow-lg text-[#7C5CFC]">
+                <svg className="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </div>
+            </button>
+          )}
+        </div>
+        <SimpleTimeline
+          videoPlaying={videoPlaying}
+          setVideoPlaying={setVideoPlaying}
+          videoCurrentTime={videoCurrentTime}
+          setVideoCurrentTime={setVideoCurrentTime}
+          videoDuration={videoDuration}
+          recordingDuration={recordingDuration}
+          videoPlayerRef={videoPlayerRef}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/components/VideoPlayerSection.tsx
+++ b/app/components/VideoPlayerSection.tsx
@@ -1,9 +1,9 @@
 import ReactPlayer from "react-player";
 import Image from "next/image";
 import VideoPreview from "@/app/components/VideoPreview";
-import SimpleTimeline from "@/app/components/SimpleTimeline";
 import RecordingTimeline from "@/app/components/RecordingTimeline";
-import React, { useRef, useState } from "react";
+import RecorderVideoPlayer from "@/app/components/RecorderVideoPlayer";
+import { useRef, useState } from "react";
 
 interface VideoPlayerSectionProps {
   uploadedFileType: string | null;
@@ -65,221 +65,22 @@ export default function VideoPlayerSection({
   };
 
   const renderVideoPlayer = (url: string, isUploaded: boolean = false) => (
-    <div className="w-full max-w-[900px] mx-auto">
-      <div
-        ref={containerRef}
-        className="video-box bg-white rounded-2xl shadow-md flex flex-col transition-all duration-300 overflow-hidden"
-      >
-        <div className="video-top w-full h-8 flex items-center px-4 gap-1.5 bg-[#f5f5f7] border-b border-[#ede7fa]">
-          <div className="circle w-2 h-2 rounded-full bg-gray-300"></div>
-          <div className="circle w-2 h-2 rounded-full bg-gray-300"></div>
-          <div className="circle w-2 h-2 rounded-full bg-gray-300"></div>
-        </div>
-
-        <div className="screen relative w-full h-auto aspect-video bg-white overflow-hidden group">
-          <div className="absolute top-0 right-0 z-20 flex items-center gap-2 p-4 bg-linear-to-l rounded-bl-2xl">
-            <div className="flex items-center gap-2 bg-black/40 rounded-full px-3 py-2 backdrop-blur-sm">
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                className="text-white"
-                stroke="currentColor"
-                strokeWidth="2"
-              >
-                <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
-              </svg>
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.1"
-                value={volume}
-                onChange={handleVolumeChange}
-                className="w-20 h-1 accent-[#7C5CFC]"
-                style={{ cursor: "pointer" }}
-              />
-            </div>
-
-            <button
-              onClick={handleFullscreen}
-              className="bg-black/40 hover:bg-black/60 text-white rounded-full p-2 transition backdrop-blur-sm"
-            >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-              >
-                <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
-              </svg>
-            </button>
-          </div>
-          <ReactPlayer
-            ref={videoPlayerRef}
-            url={url}
-            playing={videoPlaying}
-            controls={false}
-            muted={false}
-            width="100%"
-            height="100%"
-            style={{
-              objectFit: "contain",
-              borderRadius: "1.25rem",
-              background: "#F6F3FF",
-            }}
-            progressInterval={50}
-            onProgress={({ playedSeconds }) => {
-              if (playedSeconds === 0) {
-                setVideoCurrentTime(0);
-              } else {
-                setVideoCurrentTime(playedSeconds);
-              }
-            }}
-            onDuration={(dur) => {
-              if (
-                isUploaded &&
-                recordingDuration === 0 &&
-                isFinite(dur) &&
-                !isNaN(dur) &&
-                dur > 0
-              ) {
-                setVideoDuration(dur);
-              } else if (!isUploaded && isFinite(dur) && !isNaN(dur) && dur > 0) {
-                setVideoDuration(dur);
-              }
-            }}
-            onStart={() => {
-              setVideoCurrentTime(0);
-            }}
-            onPlay={() => {
-              setVideoCurrentTime(0);
-            }}
-            onEnded={() => setVideoPlaying(false)}
-            onReady={() => {
-              console.log("Video loaded in recorder");
-              if (isUploaded && recordingDuration === 0) {
-                setTimeout(() => {
-                  if (videoPlayerRef.current) {
-                    const player = videoPlayerRef.current.getInternalPlayer();
-                    if (
-                      player &&
-                      player.duration &&
-                      isFinite(player.duration) &&
-                      player.duration > 0
-                    ) {
-                      setVideoDuration(player.duration);
-                    }
-                  }
-                }, 10);
-
-                setTimeout(() => {
-                  if (videoPlayerRef.current) {
-                    const player = videoPlayerRef.current.getInternalPlayer();
-                    if (
-                      player &&
-                      player.duration &&
-                      isFinite(player.duration) &&
-                      player.duration > 0
-                    ) {
-                      setVideoDuration(player.duration);
-                    }
-                  }
-                }, 100);
-
-                setTimeout(() => {
-                  if (videoPlayerRef.current) {
-                    const player = videoPlayerRef.current.getInternalPlayer();
-                    if (
-                      player &&
-                      player.duration &&
-                      isFinite(player.duration) &&
-                      player.duration > 0
-                    ) {
-                      setVideoDuration(player.duration);
-                    }
-                  }
-                }, 500);
-              } else if (!isUploaded) {
-                setTimeout(() => {
-                  if (videoPlayerRef.current) {
-                    const player = videoPlayerRef.current.getInternalPlayer();
-                    if (
-                      player &&
-                      player.duration &&
-                      isFinite(player.duration) &&
-                      player.duration > 0
-                    ) {
-                      setVideoDuration(player.duration);
-                    }
-                  }
-                }, 10);
-
-                setTimeout(() => {
-                  if (videoPlayerRef.current) {
-                    const player = videoPlayerRef.current.getInternalPlayer();
-                    if (
-                      player &&
-                      player.duration &&
-                      isFinite(player.duration) &&
-                      player.duration > 0
-                    ) {
-                      setVideoDuration(player.duration);
-                    }
-                  }
-                }, 100);
-
-                setTimeout(() => {
-                  if (videoPlayerRef.current) {
-                    const player = videoPlayerRef.current.getInternalPlayer();
-                    if (
-                      player &&
-                      player.duration &&
-                      isFinite(player.duration) &&
-                      player.duration > 0
-                    ) {
-                      setVideoDuration(player.duration);
-                    }
-                  }
-                }, 500);
-              }
-            }}
-            config={{
-              file: {
-                attributes: {
-                  preload: "metadata",
-                },
-              },
-            }}
-          />
-
-          {!videoPlaying && (
-            <button
-              onClick={() => setVideoPlaying(true)}
-              className="absolute inset-0 flex items-center justify-center bg-black/40 hover:bg-black/50 transition-colors"
-            >
-              <div className="play-circle bg-white hover:bg-gray-100 rounded-full p-4 transition-all shadow-lg text-[#7C5CFC]">
-                <svg className="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M8 5v14l11-7z" />
-                </svg>
-              </div>
-            </button>
-          )}
-        </div>
-        <SimpleTimeline
-          videoPlaying={videoPlaying}
-          setVideoPlaying={setVideoPlaying}
-          videoCurrentTime={videoCurrentTime}
-          setVideoCurrentTime={setVideoCurrentTime}
-          videoDuration={videoDuration}
-          recordingDuration={recordingDuration}
-          videoPlayerRef={videoPlayerRef}
-        />
-      </div>
-    </div>
+    <RecorderVideoPlayer
+      url={url}
+      isUploaded={isUploaded}
+      containerRef={containerRef}
+      volume={volume}
+      onVolumeChange={handleVolumeChange}
+      onFullscreen={handleFullscreen}
+      videoPlaying={videoPlaying}
+      setVideoPlaying={setVideoPlaying}
+      videoCurrentTime={videoCurrentTime}
+      setVideoCurrentTime={setVideoCurrentTime}
+      videoDuration={videoDuration}
+      setVideoDuration={setVideoDuration}
+      recordingDuration={recordingDuration}
+      videoPlayerRef={videoPlayerRef}
+    />
   );
 
   return (

--- a/app/components/VideoPreview.tsx
+++ b/app/components/VideoPreview.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import React, { useRef, useState, useEffect } from "react";
-import Image from "next/image";
+import { useRef } from "react";
 import ReactPlayer from "react-player";
-import { formatTime } from "@/app/lib/dateTimeUtils";
+import { useVideoPreviewPlayback } from "./video-preview/useVideoPreviewPlayback";
+import { useRecordedVideoDuration } from "./video-preview/useRecordedVideoDuration";
+import { ScreenStreamVideo, PreviewReactPlayer } from "./video-preview/VideoPreviewSurface";
+import {
+  PlayOverlayButton,
+  VideoPreviewControls,
+  VideoPreviewTopBar,
+} from "./video-preview/VideoPreviewControls";
 
 interface VideoPreviewProps {
   videoUrl: string | null;
@@ -25,373 +31,32 @@ export default function VideoPreview({
   const playerRef = useRef<ReactPlayer>(null!);
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [duration, setDuration] = useState(0);
-  const [playing, setPlaying] = useState(!isRecording);
-  const [dragging, setDragging] = useState(false);
-  const [dragValue, setDragValue] = useState(0);
-  const [volume, setVolume] = useState(1);
 
-  const handlePlayPause = () => {
-    if (isRecording) {
-      return;
-    }
-    setPlaying((prev) => {
-      if (screenStream && videoRef.current) {
-        if (prev) {
-          videoRef.current.pause();
-        } else {
-          videoRef.current.play();
-        }
-      } else {
-        if (prev) {
-          playerRef.current?.getInternalPlayer()?.pause?.();
-        } else {
-          playerRef.current?.getInternalPlayer()?.play?.();
-        }
-      }
-      return !prev;
-    });
-  };
+  const {
+    currentTime,
+    setCurrentTime,
+    duration,
+    setDuration,
+    playing,
+    dragging,
+    dragValue,
+    volume,
+    handlePlayPause,
+    handleSeekStart,
+    handleSeek,
+    handleSeekEnd,
+    handleFullscreen,
+    handleVolumeChange,
+  } = useVideoPreviewPlayback({
+    isRecording,
+    screenStream,
+    onTimeChange,
+    playerRef,
+    videoRef,
+    containerRef,
+  });
 
-  const handleSeekStart = () => {
-    if (isRecording) {
-      return;
-    }
-    setDragging(true);
-    setDragValue(currentTime);
-  };
-
-  const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (isRecording) {
-      return;
-    }
-    setDragValue(Number(e.target.value));
-  };
-
-  const handleSeekEnd = (e: React.PointerEvent<HTMLInputElement>) => {
-    if (isRecording) {
-      return;
-    }
-    const value = Number((e.target as HTMLInputElement).value);
-    setCurrentTime(value);
-    if (screenStream && videoRef.current) {
-      videoRef.current.currentTime = value;
-    } else {
-      playerRef.current?.seekTo(value, "seconds");
-    }
-    onTimeChange?.(value);
-    setDragging(false);
-  };
-
-  const handleFullscreen = () => {
-    if (containerRef.current) {
-      if (!document.fullscreenElement) {
-        containerRef.current.requestFullscreen().catch(() => {
-          console.log("Fullscreen request failed");
-        });
-      } else {
-        document.exitFullscreen();
-      }
-    }
-  };
-
-  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newVolume = Number(e.target.value);
-    setVolume(newVolume);
-    if (videoRef.current) {
-      videoRef.current.volume = newVolume;
-    }
-    if (playerRef.current) {
-      const player = playerRef.current.getInternalPlayer();
-      if (player && player.volume !== undefined) {
-        player.volume = newVolume;
-      }
-    }
-  };
-
-  // Set srcObject when screenStream changes
-  useEffect(() => {
-    if (videoRef.current && screenStream) {
-      videoRef.current.srcObject = screenStream;
-    }
-  }, [screenStream]);
-
-  // Monitor duration for recorded videos
-  useEffect(() => {
-    if (videoUrl && !screenStream) {
-      const checkDuration = () => {
-        if (
-          videoRef.current &&
-          videoRef.current.duration &&
-          isFinite(videoRef.current.duration) &&
-          videoRef.current.duration > 0
-        ) {
-          setDuration(videoRef.current.duration);
-        }
-      };
-
-      checkDuration();
-
-      // Multiple attempts to get duration with different delays - FASTER
-      const timers = [
-        setTimeout(checkDuration, 10),
-        setTimeout(checkDuration, 50),
-        setTimeout(checkDuration, 100),
-        setTimeout(checkDuration, 200),
-        setTimeout(checkDuration, 300),
-      ];
-
-      const getDurationFromBlob = async () => {
-        try {
-          const response = await fetch(videoUrl);
-          const blob = await response.blob();
-          const tempVideo = document.createElement("video");
-          tempVideo.src = URL.createObjectURL(blob);
-          tempVideo.preload = "metadata";
-
-          tempVideo.onloadedmetadata = () => {
-            if (tempVideo.duration && isFinite(tempVideo.duration) && tempVideo.duration > 0) {
-              setDuration(tempVideo.duration);
-            }
-            URL.revokeObjectURL(tempVideo.src);
-          };
-
-          tempVideo.onerror = () => {
-            URL.revokeObjectURL(tempVideo.src);
-          };
-
-          // Also try to load the video to trigger metadata loading
-          tempVideo.load();
-        } catch (error) {
-          console.error("Error getting duration from blob:", error);
-        }
-      };
-
-      // Try blob method with multiple delays - FASTER
-      const blobTimers = [
-        setTimeout(getDurationFromBlob, 20),
-        setTimeout(getDurationFromBlob, 80),
-        setTimeout(getDurationFromBlob, 150),
-      ];
-
-      // Additional method: try to get duration from the video element directly
-      const getDurationFromVideoElement = () => {
-        if (videoRef.current) {
-          videoRef.current.load();
-          videoRef.current.addEventListener(
-            "loadedmetadata",
-            () => {
-              if (
-                videoRef.current &&
-                videoRef.current.duration &&
-                isFinite(videoRef.current.duration) &&
-                videoRef.current.duration > 0
-              ) {
-                setDuration(videoRef.current.duration);
-              }
-            },
-            { once: true }
-          );
-        }
-      };
-
-      const videoElementTimers = [
-        setTimeout(getDurationFromVideoElement, 30),
-        setTimeout(getDurationFromVideoElement, 90),
-        setTimeout(getDurationFromVideoElement, 180),
-      ];
-
-      // Force metadata loading immediately
-      const forceMetadataLoad = () => {
-        if (videoRef.current) {
-          videoRef.current.load();
-          videoRef.current.preload = "metadata";
-        }
-      };
-
-      // Try to force metadata loading immediately - FASTER
-      forceMetadataLoad();
-      const metadataTimers = [
-        setTimeout(forceMetadataLoad, 15),
-        setTimeout(forceMetadataLoad, 60),
-        setTimeout(forceMetadataLoad, 120),
-      ];
-
-      // Force metadata loading for ReactPlayer
-      const forceReactPlayerMetadata = () => {
-        if (playerRef.current) {
-          const player = playerRef.current.getInternalPlayer();
-          if (player) {
-            player.preload = "metadata";
-            player.load();
-          }
-        }
-      };
-
-      const reactPlayerTimers = [
-        setTimeout(forceReactPlayerMetadata, 25),
-        setTimeout(forceReactPlayerMetadata, 70),
-        setTimeout(forceReactPlayerMetadata, 140),
-      ];
-
-      // Try to get duration by playing a small portion (this often triggers metadata loading)
-      const getDurationByPlaying = () => {
-        if (playerRef.current) {
-          const player = playerRef.current.getInternalPlayer();
-          if (player) {
-            const wasPlaying = !player.paused;
-            player.currentTime = 0.1; // Seek to 0.1 seconds
-            player
-              .play()
-              .then(() => {
-                setTimeout(() => {
-                  if (player.duration && isFinite(player.duration) && player.duration > 0) {
-                    setDuration(player.duration);
-                  }
-                  if (!wasPlaying) {
-                    player.pause();
-                    player.currentTime = 0;
-                  }
-                }, 50);
-              })
-              .catch(() => {
-                // If play fails, just try to get duration anyway
-                if (player.duration && isFinite(player.duration) && player.duration > 0) {
-                  setDuration(player.duration);
-                }
-              });
-          }
-        }
-      };
-
-      const playTimers = [
-        setTimeout(getDurationByPlaying, 100),
-        setTimeout(getDurationByPlaying, 200),
-      ];
-
-      // Create a hidden video element to force metadata loading
-      const createHiddenVideo = () => {
-        const hiddenVideo = document.createElement("video");
-        hiddenVideo.style.display = "none";
-        hiddenVideo.preload = "metadata";
-        hiddenVideo.muted = true;
-        hiddenVideo.src = videoUrl;
-
-        hiddenVideo.onloadedmetadata = () => {
-          if (hiddenVideo.duration && isFinite(hiddenVideo.duration) && hiddenVideo.duration > 0) {
-            setDuration(hiddenVideo.duration);
-          }
-          document.body.removeChild(hiddenVideo);
-        };
-
-        hiddenVideo.onerror = () => {
-          document.body.removeChild(hiddenVideo);
-        };
-
-        document.body.appendChild(hiddenVideo);
-        hiddenVideo.load();
-      };
-
-      const hiddenVideoTimers = [
-        setTimeout(createHiddenVideo, 5),
-        setTimeout(createHiddenVideo, 40),
-        setTimeout(createHiddenVideo, 100),
-      ];
-
-      // Try to get duration by seeking to end of video
-      const getDurationBySeeking = () => {
-        if (playerRef.current) {
-          const player = playerRef.current.getInternalPlayer();
-          if (player) {
-            const wasPlaying = !player.paused;
-            const wasTime = player.currentTime;
-
-            // Try to seek to a large number to trigger duration detection
-            player.currentTime = 999999;
-
-            setTimeout(() => {
-              if (player.duration && isFinite(player.duration) && player.duration > 0) {
-                setDuration(player.duration);
-              }
-              // Restore original state
-              player.currentTime = wasTime;
-              if (wasPlaying) {
-                player.play();
-              }
-            }, 100);
-          }
-        }
-      };
-
-      const seekTimers = [
-        setTimeout(getDurationBySeeking, 80),
-        setTimeout(getDurationBySeeking, 160),
-      ];
-
-      // Try to get duration with different MIME types
-      const getDurationWithMimeTypes = async () => {
-        try {
-          const response = await fetch(videoUrl);
-          const blob = await response.blob();
-
-          const mimeTypes = [
-            "video/webm",
-            "video/mp4",
-            "video/ogg",
-            "video/quicktime",
-            "video/x-msvideo",
-          ];
-
-          for (const mimeType of mimeTypes) {
-            const tempVideo = document.createElement("video");
-            tempVideo.preload = "metadata";
-            tempVideo.muted = true;
-
-            const newBlob = new Blob([blob], { type: mimeType });
-            tempVideo.src = URL.createObjectURL(newBlob);
-
-            tempVideo.onloadedmetadata = () => {
-              if (tempVideo.duration && isFinite(tempVideo.duration) && tempVideo.duration > 0) {
-                setDuration(tempVideo.duration);
-                URL.revokeObjectURL(tempVideo.src);
-                return;
-              }
-              URL.revokeObjectURL(tempVideo.src);
-            };
-
-            tempVideo.onerror = () => {
-              URL.revokeObjectURL(tempVideo.src);
-            };
-
-            tempVideo.load();
-
-            // Wait a bit before trying next MIME type - FASTER
-            await new Promise((resolve) => setTimeout(resolve, 20));
-          }
-        } catch (error) {
-          console.error("Error getting duration with MIME types:", error);
-        }
-      };
-
-      const mimeTypeTimers = [
-        setTimeout(getDurationWithMimeTypes, 120),
-        setTimeout(getDurationWithMimeTypes, 250),
-      ];
-
-      return () => {
-        timers.forEach((timer) => clearTimeout(timer));
-        blobTimers.forEach((timer) => clearTimeout(timer));
-        videoElementTimers.forEach((timer) => clearTimeout(timer));
-        metadataTimers.forEach((timer) => clearTimeout(timer));
-        reactPlayerTimers.forEach((timer) => clearTimeout(timer));
-        playTimers.forEach((timer) => clearTimeout(timer));
-        hiddenVideoTimers.forEach((timer) => clearTimeout(timer));
-        seekTimers.forEach((timer) => clearTimeout(timer));
-        mimeTypeTimers.forEach((timer) => clearTimeout(timer));
-      };
-    }
-  }, [videoUrl, screenStream]);
+  useRecordedVideoDuration({ videoUrl, screenStream, videoRef, playerRef, setDuration });
 
   return (
     <div
@@ -417,305 +82,56 @@ export default function VideoPreview({
       >
         {/* Top Control Bar - Only show when not recording */}
         {!isRecording && (
-          <div className="absolute top-0 right-0 z-20 flex items-center gap-2 p-4 bg-linear-to-l from-black/60 to-transparent rounded-bl-2xl">
-            {/* Volume Control */}
-            <div className="flex items-center gap-2 bg-black/40 rounded-full px-3 py-2 backdrop-blur-sm">
-              <Image src="/icons/volume.svg" alt="volume" width={18} height={18} />
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.1"
-                value={volume}
-                onChange={handleVolumeChange}
-                className="w-20 h-1 accent-[#7C5CFC]"
-                style={{ cursor: "pointer" }}
-              />
-            </div>
-
-            {/* Fullscreen Button */}
-            <button
-              onClick={handleFullscreen}
-              className="bg-black/40 hover:bg-black/60 text-white rounded-full p-2 transition backdrop-blur-sm"
-            >
-              <Image src="/icons/fullscreen.svg" alt="fullscreen" width={20} height={20} />
-            </button>
-          </div>
+          <VideoPreviewTopBar
+            volume={volume}
+            onVolumeChange={handleVolumeChange}
+            onFullscreen={handleFullscreen}
+          />
         )}
         {/* Play/Pause Button Overlay - Only show when not recording and video is paused */}
-        {!isRecording && !playing && (
-          <button
-            onClick={handlePlayPause}
-            className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 rounded-full bg-black/50 hover:bg-black/70 text-white p-2 transition-all duration-200"
-            style={{
-              backdropFilter: "blur(4px)",
-            }}
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-              <path d="M8 5V19L19 12L8 5Z" fill="currentColor" />
-            </svg>
-          </button>
-        )}
+        {!isRecording && !playing && <PlayOverlayButton onClick={handlePlayPause} />}
         {screenStream ? (
-          <video
-            ref={videoRef}
-            autoPlay
-            muted={isRecording}
-            playsInline
-            style={{
-              width: "100%",
-              height: "100%",
-              objectFit: "contain",
-              borderRadius: "1.25rem",
-              background: "#F6F3FF",
-            }}
-            onLoadedMetadata={() => {
-              if (
-                videoRef.current &&
-                videoRef.current.duration &&
-                isFinite(videoRef.current.duration) &&
-                videoRef.current.duration > 0
-              ) {
-                setDuration(videoRef.current.duration);
-              }
-            }}
-            onCanPlay={() => {
-              if (
-                videoRef.current &&
-                videoRef.current.duration &&
-                isFinite(videoRef.current.duration) &&
-                videoRef.current.duration > 0
-              ) {
-                setDuration(videoRef.current.duration);
-              }
-            }}
-            onTimeUpdate={() => {
-              if (videoRef.current) {
-                setCurrentTime(videoRef.current.currentTime);
-                onTimeChange?.(videoRef.current.currentTime);
-              }
-            }}
+          <ScreenStreamVideo
+            videoRef={videoRef}
+            isRecording={isRecording}
+            setDuration={setDuration}
+            setCurrentTime={setCurrentTime}
+            onTimeChange={onTimeChange}
           />
         ) : (
-          <ReactPlayer
-            ref={playerRef}
-            url={videoUrl || undefined}
+          <PreviewReactPlayer
+            playerRef={playerRef}
+            videoUrl={videoUrl}
             playing={playing}
-            controls={false}
-            muted={isRecording}
+            isRecording={isRecording}
             volume={volume}
-            width="100%"
-            height="100%"
-            style={{
-              objectFit: "contain",
-              borderRadius: "1.25rem",
-              background: "#F6F3FF",
-            }}
-            onError={(e) => console.error("Video failed to load", e)}
-            onStart={() => {
-              // Ensure currentTime starts from 0 when video starts
-              setCurrentTime(0);
-              onTimeChange?.(0);
-            }}
-            onPlay={() => {
-              // Ensure currentTime is 0 when video starts playing
-              setCurrentTime(0);
-              onTimeChange?.(0);
-            }}
-            onDuration={(dur) => {
-              if (isFinite(dur) && !isNaN(dur) && dur > 0) {
-                setDuration(dur);
-              }
-            }}
-            onReady={() => {
-              console.log("Video loaded");
-              // Try to get duration again when video is ready - FASTER
-              setTimeout(() => {
-                if (playerRef.current) {
-                  const player = playerRef.current.getInternalPlayer();
-                  if (
-                    player &&
-                    player.duration &&
-                    isFinite(player.duration) &&
-                    player.duration > 0
-                  ) {
-                    setDuration(player.duration);
-                  }
-                }
-              }, 10);
-
-              // Additional attempt after a longer delay - FASTER
-              setTimeout(() => {
-                if (playerRef.current) {
-                  const player = playerRef.current.getInternalPlayer();
-                  if (
-                    player &&
-                    player.duration &&
-                    isFinite(player.duration) &&
-                    player.duration > 0
-                  ) {
-                    setDuration(player.duration);
-                  }
-                }
-              }, 100);
-            }}
-            progressInterval={50}
-            onProgress={({ playedSeconds }) => {
-              // Ensure currentTime starts from 0 immediately
-              if (playedSeconds === 0) {
-                setCurrentTime(0);
-                onTimeChange?.(0);
-              } else {
-                setCurrentTime(playedSeconds);
-                onTimeChange?.(playedSeconds);
-              }
-
-              // Try to get duration when video starts playing (this often triggers metadata loading) - FASTER
-              if (playedSeconds > 0 && duration === 0) {
-                setTimeout(() => {
-                  if (playerRef.current) {
-                    const player = playerRef.current.getInternalPlayer();
-                    if (
-                      player &&
-                      player.duration &&
-                      isFinite(player.duration) &&
-                      player.duration > 0
-                    ) {
-                      setDuration(player.duration);
-                    }
-                  }
-                }, 10);
-              }
-            }}
-            config={{
-              file: {
-                attributes: {
-                  preload: "metadata",
-                },
-              },
-            }}
+            duration={duration}
+            setDuration={setDuration}
+            setCurrentTime={setCurrentTime}
+            onTimeChange={onTimeChange}
           />
         )}
       </div>
 
       {/* Custom Video Controls */}
       {showControls && (
-        <div className="w-full px-6 pb-4 pt-2 flex flex-col gap-2">
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handlePlayPause}
-              disabled={isRecording}
-              className="rounded-full bg-[#E6E1FA] text-[#7C5CFC] hover:bg-[#7C5CFC] hover:text-white p-2 transition disabled:opacity-50"
-            >
-              {playing ? (
-                <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <rect x="3" y="3" width="4" height="12" rx="2" fill="currentColor" />
-                  <rect x="11" y="3" width="4" height="12" rx="2" fill="currentColor" />
-                </svg>
-              ) : (
-                <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path d="M4 3V15L15 9L4 3Z" fill="currentColor" />
-                </svg>
-              )}
-            </button>
-            <input
-              type="range"
-              min={0}
-              max={duration}
-              step={0.01}
-              value={dragging ? dragValue : currentTime}
-              onPointerDown={handleSeekStart}
-              onChange={handleSeek}
-              onPointerUp={handleSeekEnd}
-              disabled={isRecording}
-              className="flex-1 accent-[#A594F9] h-2 rounded-lg bg-linear-to-r from-[#A594F9] to-[#7C5CFC] disabled:opacity-50"
-              style={{
-                background: "linear-gradient(90deg, #A594F9 0%, #7C5CFC 100%)",
-                height: 8,
-                borderRadius: 8,
-              }}
-            />
-            <span className="text-xs text-[#A594F9] font-mono min-w-[60px] text-right">
-              {formatTime(currentTime)} / {duration > 0 ? formatTime(duration) : "0:00"}
-            </span>
-          </div>
-
-          {/* 5-second skip buttons */}
-          <div className="flex items-center justify-between mt-2 px-2 w-full">
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => {
-                  if (isRecording) {
-                    return;
-                  }
-                  const newTime = Math.max(0, currentTime - 5);
-                  setCurrentTime(newTime);
-                  if (screenStream && videoRef.current) {
-                    videoRef.current.currentTime = newTime;
-                  } else {
-                    playerRef.current?.seekTo(newTime, "seconds");
-                  }
-                  onTimeChange?.(newTime);
-                }}
-                disabled={isRecording}
-                className="rounded-full bg-[#7C5CFC] text-white hover:bg-[#6356D7] p-1.5 transition disabled:opacity-50 shadow-sm"
-                title="Back 5 seconds"
-              >
-                <svg width="16" height="16" fill="none" viewBox="0 0 20 20">
-                  <path
-                    d="M10 2v2.06A8 8 0 1 0 18 10"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M7 9l-3 3 3 3"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </button>
-              <button
-                onClick={() => {
-                  if (isRecording) {
-                    return;
-                  }
-                  const newTime = Math.min(duration, currentTime + 5);
-                  setCurrentTime(newTime);
-                  if (screenStream && videoRef.current) {
-                    videoRef.current.currentTime = newTime;
-                  } else {
-                    playerRef.current?.seekTo(newTime, "seconds");
-                  }
-                  onTimeChange?.(newTime);
-                }}
-                disabled={isRecording}
-                className="rounded-full bg-[#7C5CFC] text-white hover:bg-[#6356D7] p-1.5 transition disabled:opacity-50 shadow-sm"
-                title="Forward 5 seconds"
-              >
-                <svg width="16" height="16" fill="none" viewBox="0 0 20 20">
-                  <path
-                    d="M10 2v2.06A8 8 0 1 1 2 10"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M13 11l3-3-3-3"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </button>
-            </div>
-          </div>
-        </div>
+        <VideoPreviewControls
+          playing={playing}
+          isRecording={isRecording}
+          currentTime={currentTime}
+          duration={duration}
+          dragging={dragging}
+          dragValue={dragValue}
+          screenStream={screenStream}
+          videoRef={videoRef}
+          playerRef={playerRef}
+          setCurrentTime={setCurrentTime}
+          onTimeChange={onTimeChange}
+          onPlayPause={handlePlayPause}
+          onSeekStart={handleSeekStart}
+          onSeek={handleSeek}
+          onSeekEnd={handleSeekEnd}
+        />
       )}
     </div>
   );

--- a/app/components/video-preview/VideoPreviewControls.tsx
+++ b/app/components/video-preview/VideoPreviewControls.tsx
@@ -1,0 +1,221 @@
+import Image from "next/image";
+import ReactPlayer from "react-player";
+import { formatTime } from "@/app/lib/dateTimeUtils";
+
+interface VideoPreviewTopBarProps {
+  volume: number;
+  onVolumeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFullscreen: () => void;
+}
+
+export function VideoPreviewTopBar({
+  volume,
+  onVolumeChange,
+  onFullscreen,
+}: VideoPreviewTopBarProps) {
+  return (
+    <div className="absolute top-0 right-0 z-20 flex items-center gap-2 p-4 bg-linear-to-l from-black/60 to-transparent rounded-bl-2xl">
+      {/* Volume Control */}
+      <div className="flex items-center gap-2 bg-black/40 rounded-full px-3 py-2 backdrop-blur-sm">
+        <Image src="/icons/volume.svg" alt="volume" width={18} height={18} />
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.1"
+          value={volume}
+          onChange={onVolumeChange}
+          className="w-20 h-1 accent-[#7C5CFC]"
+          style={{ cursor: "pointer" }}
+        />
+      </div>
+
+      {/* Fullscreen Button */}
+      <button
+        onClick={onFullscreen}
+        className="bg-black/40 hover:bg-black/60 text-white rounded-full p-2 transition backdrop-blur-sm"
+      >
+        <Image src="/icons/fullscreen.svg" alt="fullscreen" width={20} height={20} />
+      </button>
+    </div>
+  );
+}
+
+interface PlayOverlayButtonProps {
+  onClick: () => void;
+}
+
+export function PlayOverlayButton({ onClick }: PlayOverlayButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 rounded-full bg-black/50 hover:bg-black/70 text-white p-2 transition-all duration-200"
+      style={{
+        backdropFilter: "blur(4px)",
+      }}
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+        <path d="M8 5V19L19 12L8 5Z" fill="currentColor" />
+      </svg>
+    </button>
+  );
+}
+
+interface VideoPreviewControlsProps {
+  playing: boolean;
+  isRecording: boolean;
+  currentTime: number;
+  duration: number;
+  dragging: boolean;
+  dragValue: number;
+  screenStream: MediaStream | null;
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  playerRef: React.RefObject<ReactPlayer>;
+  setCurrentTime: (time: number) => void;
+  onTimeChange?: (time: number) => void;
+  onPlayPause: () => void;
+  onSeekStart: () => void;
+  onSeek: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSeekEnd: (e: React.PointerEvent<HTMLInputElement>) => void;
+}
+
+export function VideoPreviewControls({
+  playing,
+  isRecording,
+  currentTime,
+  duration,
+  dragging,
+  dragValue,
+  screenStream,
+  videoRef,
+  playerRef,
+  setCurrentTime,
+  onTimeChange,
+  onPlayPause,
+  onSeekStart,
+  onSeek,
+  onSeekEnd,
+}: VideoPreviewControlsProps) {
+  const skipBackward = () => {
+    if (isRecording) {
+      return;
+    }
+    const newTime = Math.max(0, currentTime - 5);
+    setCurrentTime(newTime);
+    if (screenStream && videoRef.current) {
+      videoRef.current.currentTime = newTime;
+    } else {
+      playerRef.current?.seekTo(newTime, "seconds");
+    }
+    onTimeChange?.(newTime);
+  };
+
+  const skipForward = () => {
+    if (isRecording) {
+      return;
+    }
+    const newTime = Math.min(duration, currentTime + 5);
+    setCurrentTime(newTime);
+    if (screenStream && videoRef.current) {
+      videoRef.current.currentTime = newTime;
+    } else {
+      playerRef.current?.seekTo(newTime, "seconds");
+    }
+    onTimeChange?.(newTime);
+  };
+
+  return (
+    <div className="w-full px-6 pb-4 pt-2 flex flex-col gap-2">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onPlayPause}
+          disabled={isRecording}
+          className="rounded-full bg-[#E6E1FA] text-[#7C5CFC] hover:bg-[#7C5CFC] hover:text-white p-2 transition disabled:opacity-50"
+        >
+          {playing ? (
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <rect x="3" y="3" width="4" height="12" rx="2" fill="currentColor" />
+              <rect x="11" y="3" width="4" height="12" rx="2" fill="currentColor" />
+            </svg>
+          ) : (
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <path d="M4 3V15L15 9L4 3Z" fill="currentColor" />
+            </svg>
+          )}
+        </button>
+        <input
+          type="range"
+          min={0}
+          max={duration}
+          step={0.01}
+          value={dragging ? dragValue : currentTime}
+          onPointerDown={onSeekStart}
+          onChange={onSeek}
+          onPointerUp={onSeekEnd}
+          disabled={isRecording}
+          className="flex-1 accent-[#A594F9] h-2 rounded-lg bg-linear-to-r from-[#A594F9] to-[#7C5CFC] disabled:opacity-50"
+          style={{
+            background: "linear-gradient(90deg, #A594F9 0%, #7C5CFC 100%)",
+            height: 8,
+            borderRadius: 8,
+          }}
+        />
+        <span className="text-xs text-[#A594F9] font-mono min-w-[60px] text-right">
+          {formatTime(currentTime)} / {duration > 0 ? formatTime(duration) : "0:00"}
+        </span>
+      </div>
+
+      {/* 5-second skip buttons */}
+      <div className="flex items-center justify-between mt-2 px-2 w-full">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={skipBackward}
+            disabled={isRecording}
+            className="rounded-full bg-[#7C5CFC] text-white hover:bg-[#6356D7] p-1.5 transition disabled:opacity-50 shadow-sm"
+            title="Back 5 seconds"
+          >
+            <svg width="16" height="16" fill="none" viewBox="0 0 20 20">
+              <path
+                d="M10 2v2.06A8 8 0 1 0 18 10"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M7 9l-3 3 3 3"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+          <button
+            onClick={skipForward}
+            disabled={isRecording}
+            className="rounded-full bg-[#7C5CFC] text-white hover:bg-[#6356D7] p-1.5 transition disabled:opacity-50 shadow-sm"
+            title="Forward 5 seconds"
+          >
+            <svg width="16" height="16" fill="none" viewBox="0 0 20 20">
+              <path
+                d="M10 2v2.06A8 8 0 1 1 2 10"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M13 11l3-3-3-3"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/video-preview/VideoPreviewSurface.tsx
+++ b/app/components/video-preview/VideoPreviewSurface.tsx
@@ -1,0 +1,169 @@
+import ReactPlayer from "react-player";
+
+interface ScreenStreamVideoProps {
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  isRecording: boolean;
+  setDuration: (duration: number) => void;
+  setCurrentTime: (time: number) => void;
+  onTimeChange?: (time: number) => void;
+}
+
+export function ScreenStreamVideo({
+  videoRef,
+  isRecording,
+  setDuration,
+  setCurrentTime,
+  onTimeChange,
+}: ScreenStreamVideoProps) {
+  return (
+    <video
+      ref={videoRef}
+      autoPlay
+      muted={isRecording}
+      playsInline
+      style={{
+        width: "100%",
+        height: "100%",
+        objectFit: "contain",
+        borderRadius: "1.25rem",
+        background: "#F6F3FF",
+      }}
+      onLoadedMetadata={() => {
+        if (
+          videoRef.current &&
+          videoRef.current.duration &&
+          isFinite(videoRef.current.duration) &&
+          videoRef.current.duration > 0
+        ) {
+          setDuration(videoRef.current.duration);
+        }
+      }}
+      onCanPlay={() => {
+        if (
+          videoRef.current &&
+          videoRef.current.duration &&
+          isFinite(videoRef.current.duration) &&
+          videoRef.current.duration > 0
+        ) {
+          setDuration(videoRef.current.duration);
+        }
+      }}
+      onTimeUpdate={() => {
+        if (videoRef.current) {
+          setCurrentTime(videoRef.current.currentTime);
+          onTimeChange?.(videoRef.current.currentTime);
+        }
+      }}
+    />
+  );
+}
+
+interface PreviewReactPlayerProps {
+  playerRef: React.RefObject<ReactPlayer>;
+  videoUrl: string | null;
+  playing: boolean;
+  isRecording: boolean;
+  volume: number;
+  duration: number;
+  setDuration: (duration: number) => void;
+  setCurrentTime: (time: number) => void;
+  onTimeChange?: (time: number) => void;
+}
+
+export function PreviewReactPlayer({
+  playerRef,
+  videoUrl,
+  playing,
+  isRecording,
+  volume,
+  duration,
+  setDuration,
+  setCurrentTime,
+  onTimeChange,
+}: PreviewReactPlayerProps) {
+  return (
+    <ReactPlayer
+      ref={playerRef}
+      url={videoUrl || undefined}
+      playing={playing}
+      controls={false}
+      muted={isRecording}
+      volume={volume}
+      width="100%"
+      height="100%"
+      style={{
+        objectFit: "contain",
+        borderRadius: "1.25rem",
+        background: "#F6F3FF",
+      }}
+      onError={(e) => console.error("Video failed to load", e)}
+      onStart={() => {
+        // Ensure currentTime starts from 0 when video starts
+        setCurrentTime(0);
+        onTimeChange?.(0);
+      }}
+      onPlay={() => {
+        // Ensure currentTime is 0 when video starts playing
+        setCurrentTime(0);
+        onTimeChange?.(0);
+      }}
+      onDuration={(dur) => {
+        if (isFinite(dur) && !isNaN(dur) && dur > 0) {
+          setDuration(dur);
+        }
+      }}
+      onReady={() => {
+        console.log("Video loaded");
+        // Try to get duration again when video is ready - FASTER
+        setTimeout(() => {
+          if (playerRef.current) {
+            const player = playerRef.current.getInternalPlayer();
+            if (player && player.duration && isFinite(player.duration) && player.duration > 0) {
+              setDuration(player.duration);
+            }
+          }
+        }, 10);
+
+        // Additional attempt after a longer delay - FASTER
+        setTimeout(() => {
+          if (playerRef.current) {
+            const player = playerRef.current.getInternalPlayer();
+            if (player && player.duration && isFinite(player.duration) && player.duration > 0) {
+              setDuration(player.duration);
+            }
+          }
+        }, 100);
+      }}
+      progressInterval={50}
+      onProgress={({ playedSeconds }) => {
+        // Ensure currentTime starts from 0 immediately
+        if (playedSeconds === 0) {
+          setCurrentTime(0);
+          onTimeChange?.(0);
+        } else {
+          setCurrentTime(playedSeconds);
+          onTimeChange?.(playedSeconds);
+        }
+
+        // Try to get duration when video starts playing - FASTER
+        if (playedSeconds > 0 && duration === 0) {
+          setTimeout(() => {
+            if (playerRef.current) {
+              const player = playerRef.current.getInternalPlayer();
+              if (player && player.duration && isFinite(player.duration) && player.duration > 0) {
+                setDuration(player.duration);
+              }
+            }
+          }, 10);
+        }
+      }}
+      config={{
+        file: {
+          attributes: {
+            preload: "metadata",
+          },
+        },
+      }}
+    />
+  );
+}

--- a/app/components/video-preview/useRecordedVideoDuration.ts
+++ b/app/components/video-preview/useRecordedVideoDuration.ts
@@ -1,0 +1,278 @@
+import { useEffect } from "react";
+import ReactPlayer from "react-player";
+
+type SetDuration = (duration: number) => void;
+
+const readVideoDuration = (
+  videoRef: React.RefObject<HTMLVideoElement | null>,
+  setDuration: SetDuration
+) => {
+  if (
+    videoRef.current &&
+    videoRef.current.duration &&
+    isFinite(videoRef.current.duration) &&
+    videoRef.current.duration > 0
+  ) {
+    setDuration(videoRef.current.duration);
+  }
+};
+
+const readDurationFromBlob = async (videoUrl: string, setDuration: SetDuration) => {
+  try {
+    const response = await fetch(videoUrl);
+    const blob = await response.blob();
+    const tempVideo = document.createElement("video");
+    tempVideo.src = URL.createObjectURL(blob);
+    tempVideo.preload = "metadata";
+
+    tempVideo.onloadedmetadata = () => {
+      if (tempVideo.duration && isFinite(tempVideo.duration) && tempVideo.duration > 0) {
+        setDuration(tempVideo.duration);
+      }
+      URL.revokeObjectURL(tempVideo.src);
+    };
+
+    tempVideo.onerror = () => {
+      URL.revokeObjectURL(tempVideo.src);
+    };
+
+    // Also try to load the video to trigger metadata loading
+    tempVideo.load();
+  } catch (error) {
+    console.error("Error getting duration from blob:", error);
+  }
+};
+
+const readDurationFromVideoElement = (
+  videoRef: React.RefObject<HTMLVideoElement | null>,
+  setDuration: SetDuration
+) => {
+  if (videoRef.current) {
+    videoRef.current.load();
+    videoRef.current.addEventListener(
+      "loadedmetadata",
+      () => {
+        if (
+          videoRef.current &&
+          videoRef.current.duration &&
+          isFinite(videoRef.current.duration) &&
+          videoRef.current.duration > 0
+        ) {
+          setDuration(videoRef.current.duration);
+        }
+      },
+      { once: true }
+    );
+  }
+};
+
+const forceVideoMetadataLoad = (videoRef: React.RefObject<HTMLVideoElement | null>) => {
+  if (videoRef.current) {
+    videoRef.current.load();
+    videoRef.current.preload = "metadata";
+  }
+};
+
+const forcePlayerMetadataLoad = (playerRef: React.RefObject<ReactPlayer>) => {
+  if (playerRef.current) {
+    const player = playerRef.current.getInternalPlayer();
+    if (player) {
+      player.preload = "metadata";
+      player.load();
+    }
+  }
+};
+
+const readDurationByPlaying = (
+  playerRef: React.RefObject<ReactPlayer>,
+  setDuration: SetDuration
+) => {
+  if (playerRef.current) {
+    const player = playerRef.current.getInternalPlayer();
+    if (player) {
+      const wasPlaying = !player.paused;
+      player.currentTime = 0.1; // Seek to 0.1 seconds
+      player
+        .play()
+        .then(() => {
+          setTimeout(() => {
+            if (player.duration && isFinite(player.duration) && player.duration > 0) {
+              setDuration(player.duration);
+            }
+            if (!wasPlaying) {
+              player.pause();
+              player.currentTime = 0;
+            }
+          }, 50);
+        })
+        .catch(() => {
+          // If play fails, just try to get duration anyway
+          if (player.duration && isFinite(player.duration) && player.duration > 0) {
+            setDuration(player.duration);
+          }
+        });
+    }
+  }
+};
+
+const readDurationFromHiddenVideo = (videoUrl: string, setDuration: SetDuration) => {
+  const hiddenVideo = document.createElement("video");
+  hiddenVideo.style.display = "none";
+  hiddenVideo.preload = "metadata";
+  hiddenVideo.muted = true;
+  hiddenVideo.src = videoUrl;
+
+  hiddenVideo.onloadedmetadata = () => {
+    if (hiddenVideo.duration && isFinite(hiddenVideo.duration) && hiddenVideo.duration > 0) {
+      setDuration(hiddenVideo.duration);
+    }
+    document.body.removeChild(hiddenVideo);
+  };
+
+  hiddenVideo.onerror = () => {
+    document.body.removeChild(hiddenVideo);
+  };
+
+  document.body.appendChild(hiddenVideo);
+  hiddenVideo.load();
+};
+
+const readDurationBySeeking = (
+  playerRef: React.RefObject<ReactPlayer>,
+  setDuration: SetDuration
+) => {
+  if (playerRef.current) {
+    const player = playerRef.current.getInternalPlayer();
+    if (player) {
+      const wasPlaying = !player.paused;
+      const wasTime = player.currentTime;
+
+      // Try to seek to a large number to trigger duration detection
+      player.currentTime = 999999;
+
+      setTimeout(() => {
+        if (player.duration && isFinite(player.duration) && player.duration > 0) {
+          setDuration(player.duration);
+        }
+        // Restore original state
+        player.currentTime = wasTime;
+        if (wasPlaying) {
+          player.play();
+        }
+      }, 100);
+    }
+  }
+};
+
+const readDurationWithMimeTypes = async (videoUrl: string, setDuration: SetDuration) => {
+  try {
+    const response = await fetch(videoUrl);
+    const blob = await response.blob();
+
+    const mimeTypes = [
+      "video/webm",
+      "video/mp4",
+      "video/ogg",
+      "video/quicktime",
+      "video/x-msvideo",
+    ];
+
+    for (const mimeType of mimeTypes) {
+      const tempVideo = document.createElement("video");
+      tempVideo.preload = "metadata";
+      tempVideo.muted = true;
+
+      const newBlob = new Blob([blob], { type: mimeType });
+      tempVideo.src = URL.createObjectURL(newBlob);
+
+      tempVideo.onloadedmetadata = () => {
+        if (tempVideo.duration && isFinite(tempVideo.duration) && tempVideo.duration > 0) {
+          setDuration(tempVideo.duration);
+          URL.revokeObjectURL(tempVideo.src);
+          return;
+        }
+        URL.revokeObjectURL(tempVideo.src);
+      };
+
+      tempVideo.onerror = () => {
+        URL.revokeObjectURL(tempVideo.src);
+      };
+
+      tempVideo.load();
+
+      // Wait a bit before trying next MIME type - FASTER
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  } catch (error) {
+    console.error("Error getting duration with MIME types:", error);
+  }
+};
+
+interface UseRecordedVideoDurationProps {
+  videoUrl: string | null;
+  screenStream: MediaStream | null;
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  playerRef: React.RefObject<ReactPlayer>;
+  setDuration: SetDuration;
+}
+
+// Aggressively probes a recorded video's duration through many strategies and
+// staggered timers; preserves the original timing schedule exactly.
+export function useRecordedVideoDuration({
+  videoUrl,
+  screenStream,
+  videoRef,
+  playerRef,
+  setDuration,
+}: UseRecordedVideoDurationProps) {
+  useEffect(() => {
+    if (videoUrl && !screenStream) {
+      const checkDuration = () => readVideoDuration(videoRef, setDuration);
+      const getDurationFromBlob = () => readDurationFromBlob(videoUrl, setDuration);
+      const getDurationFromVideoElement = () => readDurationFromVideoElement(videoRef, setDuration);
+      const forceMetadataLoad = () => forceVideoMetadataLoad(videoRef);
+      const forceReactPlayerMetadata = () => forcePlayerMetadataLoad(playerRef);
+      const getDurationByPlaying = () => readDurationByPlaying(playerRef, setDuration);
+      const createHiddenVideo = () => readDurationFromHiddenVideo(videoUrl, setDuration);
+      const getDurationBySeeking = () => readDurationBySeeking(playerRef, setDuration);
+      const getDurationWithMimeTypes = () => readDurationWithMimeTypes(videoUrl, setDuration);
+
+      // Force metadata loading immediately (after an initial direct read)
+      checkDuration();
+      forceMetadataLoad();
+
+      const timers = [
+        setTimeout(checkDuration, 10),
+        setTimeout(checkDuration, 50),
+        setTimeout(checkDuration, 100),
+        setTimeout(checkDuration, 200),
+        setTimeout(checkDuration, 300),
+        setTimeout(getDurationFromBlob, 20),
+        setTimeout(getDurationFromBlob, 80),
+        setTimeout(getDurationFromBlob, 150),
+        setTimeout(getDurationFromVideoElement, 30),
+        setTimeout(getDurationFromVideoElement, 90),
+        setTimeout(getDurationFromVideoElement, 180),
+        setTimeout(forceMetadataLoad, 15),
+        setTimeout(forceMetadataLoad, 60),
+        setTimeout(forceMetadataLoad, 120),
+        setTimeout(forceReactPlayerMetadata, 25),
+        setTimeout(forceReactPlayerMetadata, 70),
+        setTimeout(forceReactPlayerMetadata, 140),
+        setTimeout(getDurationByPlaying, 100),
+        setTimeout(getDurationByPlaying, 200),
+        setTimeout(createHiddenVideo, 5),
+        setTimeout(createHiddenVideo, 40),
+        setTimeout(createHiddenVideo, 100),
+        setTimeout(getDurationBySeeking, 80),
+        setTimeout(getDurationBySeeking, 160),
+        setTimeout(getDurationWithMimeTypes, 120),
+        setTimeout(getDurationWithMimeTypes, 250),
+      ];
+
+      return () => {
+        timers.forEach((timer) => clearTimeout(timer));
+      };
+    }
+  }, [videoUrl, screenStream, videoRef, playerRef, setDuration]);
+}

--- a/app/components/video-preview/useVideoPreviewPlayback.ts
+++ b/app/components/video-preview/useVideoPreviewPlayback.ts
@@ -1,0 +1,129 @@
+import { useEffect, useState } from "react";
+import ReactPlayer from "react-player";
+
+interface UseVideoPreviewPlaybackProps {
+  isRecording: boolean;
+  screenStream: MediaStream | null;
+  onTimeChange?: (time: number) => void;
+  playerRef: React.RefObject<ReactPlayer>;
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export function useVideoPreviewPlayback({
+  isRecording,
+  screenStream,
+  onTimeChange,
+  playerRef,
+  videoRef,
+  containerRef,
+}: UseVideoPreviewPlaybackProps) {
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [playing, setPlaying] = useState(!isRecording);
+  const [dragging, setDragging] = useState(false);
+  const [dragValue, setDragValue] = useState(0);
+  const [volume, setVolume] = useState(1);
+
+  const handlePlayPause = () => {
+    if (isRecording) {
+      return;
+    }
+    setPlaying((prev) => {
+      if (screenStream && videoRef.current) {
+        if (prev) {
+          videoRef.current.pause();
+        } else {
+          videoRef.current.play();
+        }
+      } else {
+        if (prev) {
+          playerRef.current?.getInternalPlayer()?.pause?.();
+        } else {
+          playerRef.current?.getInternalPlayer()?.play?.();
+        }
+      }
+      return !prev;
+    });
+  };
+
+  const handleSeekStart = () => {
+    if (isRecording) {
+      return;
+    }
+    setDragging(true);
+    setDragValue(currentTime);
+  };
+
+  const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (isRecording) {
+      return;
+    }
+    setDragValue(Number(e.target.value));
+  };
+
+  const handleSeekEnd = (e: React.PointerEvent<HTMLInputElement>) => {
+    if (isRecording) {
+      return;
+    }
+    const value = Number((e.target as HTMLInputElement).value);
+    setCurrentTime(value);
+    if (screenStream && videoRef.current) {
+      videoRef.current.currentTime = value;
+    } else {
+      playerRef.current?.seekTo(value, "seconds");
+    }
+    onTimeChange?.(value);
+    setDragging(false);
+  };
+
+  const handleFullscreen = () => {
+    if (containerRef.current) {
+      if (!document.fullscreenElement) {
+        containerRef.current.requestFullscreen().catch(() => {
+          console.log("Fullscreen request failed");
+        });
+      } else {
+        document.exitFullscreen();
+      }
+    }
+  };
+
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newVolume = Number(e.target.value);
+    setVolume(newVolume);
+    if (videoRef.current) {
+      videoRef.current.volume = newVolume;
+    }
+    if (playerRef.current) {
+      const player = playerRef.current.getInternalPlayer();
+      if (player && player.volume !== undefined) {
+        player.volume = newVolume;
+      }
+    }
+  };
+
+  // Set srcObject when screenStream changes
+  useEffect(() => {
+    if (videoRef.current && screenStream) {
+      videoRef.current.srcObject = screenStream;
+    }
+  }, [screenStream, videoRef]);
+
+  return {
+    currentTime,
+    setCurrentTime,
+    duration,
+    setDuration,
+    playing,
+    dragging,
+    dragValue,
+    volume,
+    handlePlayPause,
+    handleSeekStart,
+    handleSeek,
+    handleSeekEnd,
+    handleFullscreen,
+    handleVolumeChange,
+  };
+}


### PR DESCRIPTION
VideoPreview:
- Extract playback state + handlers into useVideoPreviewPlayback hook.
- Move the staggered duration-detection effect into useRecordedVideoDuration hook, with its detection strategies pulled to module-scope helpers; the exact setTimeout schedule (and same-delay ordering) is preserved.
- Extract presentational sub-components (VideoPreviewTopBar, PlayOverlayButton, VideoPreviewControls, ScreenStreamVideo, PreviewReactPlayer).

VideoPlayerSection:
- Extract the player box into RecorderVideoPlayer (with PlayerTopBar and a module-scope duration-read helper); volume/fullscreen state stay in the parent and are passed down, preserving cross-source state.

Stable refs/setters added to the new hooks' dep arrays to avoid introducing exhaustive-deps warnings (identity-stable, so no timing change).

PARTIAL FIXES #196 