### PR TITLE
fix(schema): preserve CtaClick history on CTA delete via SetNull

### DIFF
--- a/prisma/migrations/20260622104220_cta_click_setnull_on_cta_delete/migration.sql
+++ b/prisma/migrations/20260622104220_cta_click_setnull_on_cta_delete/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "CtaClick" DROP CONSTRAINT "CtaClick_ctaId_fkey";
+
+-- AlterTable
+ALTER TABLE "CtaClick" ALTER COLUMN "ctaId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "CtaClick" ADD CONSTRAINT "CtaClick_ctaId_fkey" FOREIGN KEY ("ctaId") REFERENCES "Cta"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -200,7 +200,7 @@ model Cta {
 
 model CtaClick {
   id        String   @id @default(cuid())
-  ctaId     String
+  ctaId     String?
   demoId    String
   label     String
   pageType  String   @default("demo")
@@ -208,7 +208,7 @@ model CtaClick {
   userId    String?
   referrer  String?
   timestamp DateTime @default(now())
-  cta       Cta      @relation(fields: [ctaId], references: [id], onDelete: Cascade)
+  cta       Cta?     @relation(fields: [ctaId], references: [id], onDelete: SetNull)
   demo      Demo     @relation(fields: [demoId], references: [id])
 
   @@index([demoId, timestamp])


### PR DESCRIPTION

### Changes
- `prisma/schema.prisma`: `ctaId String` → `String?`; `cta Cta @relation(... onDelete: Cascade)` → `cta Cta? @relation(... onDelete: SetNull)`
- New migration `*_cta_click_setnull_on_cta_delete` — alters only the FK constraint + column nullability, nothing else.


partial Fixes #213 
