### PR TITLE
feat(ctas): add list + create CTA API for a demo

### DIFF
--- a/app/api/demos/[id]/ctas/route.ts
+++ b/app/api/demos/[id]/ctas/route.ts
@@ -1,0 +1,99 @@
+import { prisma } from "@/app/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/lib/auth/options";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+async function resolveOwnedDemo(id: string) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return {
+      error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const demo = await prisma.demo.findFirst({
+    where: {
+      id,
+      userId: session.user.id,
+    },
+    select: { id: true },
+  });
+
+  if (!demo) {
+    return {
+      error: NextResponse.json({ error: "Demo not found" }, { status: 404 }),
+    };
+  }
+
+  return { demo };
+}
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const owned = await resolveOwnedDemo(id);
+  if ("error" in owned) {
+    return owned.error;
+  }
+
+  const ctas = await prisma.cta.findMany({
+    where: { demoId: id },
+    orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+  });
+
+  return NextResponse.json({ success: true, ctas });
+}
+
+const createCtaSchema = z.object({
+  label: z.string().trim().min(1, "label is required"),
+  url: z.string().trim().min(1, "url is required"),
+  placement: z.string().optional(),
+  order: z.number().int().optional(),
+});
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const owned = await resolveOwnedDemo(id);
+  if ("error" in owned) {
+    return owned.error;
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = createCtaSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { label, url, placement, order } = parsed.data;
+
+  // Default order to one past the current highest order on this demo.
+  let nextOrder = order;
+  if (typeof nextOrder !== "number") {
+    const max = await prisma.cta.aggregate({
+      where: { demoId: id },
+      _max: { order: true },
+    });
+    nextOrder = (max._max.order ?? -1) + 1;
+  }
+
+  const cta = await prisma.cta.create({
+    data: {
+      demoId: id,
+      label,
+      url,
+      placement: placement ?? null,
+      order: nextOrder,
+    },
+  });
+
+  return NextResponse.json({ success: true, cta }, { status: 201 });
+}


### PR DESCRIPTION
Adds `app/api/demos/[id]/ctas/route.ts` with owner-scoped list + create endpoints for a demo's CTAs.

- **GET** — returns the demo's CTAs ordered by `order` asc, then `createdAt` asc.
- **POST** — creates a CTA `{ label, url, placement?, order? }`; validates `label`/`url` as non-empty strings via zod; defaults `order` to `max(existing order) + 1`.
- Ownership/errors mirror `app/api/demo/route.ts`: 401 unauthenticated, 404 not found/not owned, 400 invalid body.

partial Fixes #213
