### PR TITLE
feat(ctas): add update + delete CTA API

### DIFF
--- a/app/api/ctas/[id]/route.ts
+++ b/app/api/ctas/[id]/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/lib/auth/options";
+import { z } from "zod";
+
+// Partial update: every field is optional, but at least one must be provided.
+const updateCtaSchema = z
+  .object({
+    label: z.string().min(1, "Label is required"),
+    url: z.string().url("A valid URL is required"),
+    placement: z.string().nullable(),
+    order: z.number().int(),
+  })
+  .partial()
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "Nothing to update: provide label, url, placement or order",
+  });
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session || !session.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const body = await req.json();
+    const parsed = updateCtaSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.errors[0]?.message ?? "Invalid request" },
+        { status: 400 }
+      );
+    }
+
+    // Scope the write to CTAs whose demo belongs to the logged-in user so a CTA
+    // can only be edited by its owner. count === 0 covers not-found and not-owned.
+    const result = await prisma.cta.updateMany({
+      where: { id, demo: { userId: session.user.id } },
+      data: parsed.data,
+    });
+
+    if (result.count === 0) {
+      return NextResponse.json({ error: "CTA not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true, cta: { id } });
+  } catch (error) {
+    console.error("CTA PATCH error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session || !session.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    // Scope the delete to CTAs whose demo belongs to the logged-in user.
+    const result = await prisma.cta.deleteMany({
+      where: { id, demo: { userId: session.user.id } },
+    });
+
+    if (result.count === 0) {
+      return NextResponse.json({ error: "CTA not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("CTA DELETE error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
- **PATCH `/api/ctas/[id]`** — updates `label`, `url`, `placement`, and/or `order`
  on a CTA. Body is validated with **zod** (partial update; at least one field
  required, `url` must be a valid URL, `placement` may be `null` to clear it).
- **DELETE `/api/ctas/[id]`** — deletes the CTA.
- Follows the existing ownership pattern (`app/api/demo/route.ts`): a single
  `updateMany`/`deleteMany` scoped by the relation
  `where: { id, demo: { userId: session.user.id } }`, so a CTA can only be
  edited/deleted by the owner of its parent demo.
- `401` when unauthenticated; `404` when the CTA does not exist or is not owned
  (`count === 0`); `400` on validation failure.

partial fixes #213 