### PR TITLE
feat(editor): manage demo CTAs from the editor sidebar

### DIFF
--- a/app/(signed)/editor/apiTypes.ts
+++ b/app/(signed)/editor/apiTypes.ts
@@ -4,6 +4,8 @@ import type { useZoomEditor } from "./hooks/useZoomEditor";
 import type { useSubtitles } from "./hooks/useSubtitles";
 import type { useExportFlow } from "./hooks/useExportFlow";
 
+export type { CtaItem } from "./hooks/useEditorState";
+
 export type EditorState = ReturnType<typeof useEditorState>;
 export type TextOverlaysApi = ReturnType<typeof useTextOverlays>;
 export type ZoomEditorApi = ReturnType<typeof useZoomEditor>;

--- a/app/(signed)/editor/components/EditorSidebarRegion.tsx
+++ b/app/(signed)/editor/components/EditorSidebarRegion.tsx
@@ -1,9 +1,12 @@
 import { X } from "lucide-react";
+import axios from "axios";
+import { toast } from "react-hot-toast";
 
 import EditorSidebar from "@/app/components/EditorSidebar";
 import SidemenuDashboard from "@/app/components/SidemenuDashboard";
 import ZoomModal from "@/app/components/ZoomModal";
 import type {
+  CtaItem,
   EditorState,
   ExportFlowApi,
   SubtitlesApi,
@@ -31,6 +34,107 @@ export default function EditorSidebarRegion({
   const toggleDashboardMenu = () =>
     editorState.setIsDashboardMenuOpen(!editorState.isDashboardMenuOpen);
   const closeDashboardMenu = () => editorState.setIsDashboardMenuOpen(false);
+
+  // CTA CRUD. Definitions live in the Cta table (not demo.editing) and are
+  // managed over HTTP. Local state is updated optimistically and rolled back on
+  // failure. The API enforces ownership (401 anon / 404 non-owner).
+  const { savedDemoId, ctas, setCtas } = editorState;
+
+  const handleAddCta = async (data: { label: string; url: string; placement?: string }) => {
+    if (!savedDemoId) {
+      toast.error("Save the demo before adding a call to action");
+      return;
+    }
+    const placement = data.placement?.trim() ? data.placement.trim() : null;
+    const tempId = `temp-${Date.now()}`;
+    const optimistic: CtaItem = {
+      id: tempId,
+      label: data.label,
+      url: data.url,
+      placement,
+      order: ctas.length,
+    };
+    setCtas([...ctas, optimistic]);
+    try {
+      const res = await axios.post(`/api/demos/${savedDemoId}/ctas`, {
+        label: data.label,
+        url: data.url,
+        ...(placement ? { placement } : {}),
+      });
+      const created = res.data?.cta;
+      setCtas((prev) =>
+        prev.map((c) =>
+          c.id === tempId
+            ? {
+                id: String(created?.id ?? tempId),
+                label: String(created?.label ?? optimistic.label),
+                url: String(created?.url ?? optimistic.url),
+                placement: created?.placement ?? optimistic.placement,
+                order: typeof created?.order === "number" ? created.order : optimistic.order,
+              }
+            : c
+        )
+      );
+      toast.success("Call to action added");
+    } catch {
+      setCtas((prev) => prev.filter((c) => c.id !== tempId));
+      toast.error("Failed to add call to action");
+    }
+  };
+
+  const handleUpdateCta = async (
+    id: string,
+    data: { label?: string; url?: string; placement?: string | null }
+  ) => {
+    const prevCtas = ctas;
+    setCtas((prev) => prev.map((c) => (c.id === id ? { ...c, ...data } : c)));
+    try {
+      await axios.patch(`/api/ctas/${id}`, data);
+      toast.success("Call to action updated");
+    } catch {
+      setCtas(prevCtas);
+      toast.error("Failed to update call to action");
+    }
+  };
+
+  const handleDeleteCta = async (id: string) => {
+    const prevCtas = ctas;
+    setCtas((prev) => prev.filter((c) => c.id !== id));
+    try {
+      await axios.delete(`/api/ctas/${id}`);
+      toast.success("Call to action removed");
+    } catch {
+      setCtas(prevCtas);
+      toast.error("Failed to remove call to action");
+    }
+  };
+
+  const handleReorderCta = async (id: string, direction: "up" | "down") => {
+    const index = ctas.findIndex((c) => c.id === id);
+    if (index === -1) {
+      return;
+    }
+    const swapWith = direction === "up" ? index - 1 : index + 1;
+    if (swapWith < 0 || swapWith >= ctas.length) {
+      return;
+    }
+    const prevCtas = ctas;
+    const current = ctas[index];
+    const neighbour = ctas[swapWith];
+    const reordered = [...ctas];
+    reordered[index] = { ...neighbour, order: current.order };
+    reordered[swapWith] = { ...current, order: neighbour.order };
+    setCtas(reordered);
+    try {
+      await Promise.all([
+        axios.patch(`/api/ctas/${current.id}`, { order: neighbour.order }),
+        axios.patch(`/api/ctas/${neighbour.id}`, { order: current.order }),
+      ]);
+    } catch {
+      setCtas(prevCtas);
+      toast.error("Failed to reorder call to action");
+    }
+  };
 
   const sidebarProps = {
     title: editorState.sidebarTitle,
@@ -67,6 +171,11 @@ export default function EditorSidebarRegion({
     savingDemo: editorState.savingDemo,
     demoSaved: editorState.demoSaved,
     onToggleDashboardMenu: toggleDashboardMenu,
+    ctas: editorState.ctas,
+    onAddCta: handleAddCta,
+    onUpdateCta: handleUpdateCta,
+    onDeleteCta: handleDeleteCta,
+    onReorderCta: handleReorderCta,
   };
 
   return (

--- a/app/(signed)/editor/hooks/useDemoLoader.ts
+++ b/app/(signed)/editor/hooks/useDemoLoader.ts
@@ -53,6 +53,7 @@ export function useDemoLoader({
     setBrowserFrameMode,
     setBrowserFrameDrawShadow,
     setBrowserFrameDrawBorder,
+    setCtas,
   } = editorState;
 
   const restoreDemoEditing = (ed: DemoEditing) => {
@@ -155,6 +156,42 @@ export function useDemoLoader({
       isMounted = false;
     };
   }, [savedDemoId, params]);
+
+  // CTAs live in the Cta table, not in demo.editing, so load them separately.
+  // Degrades gracefully: a missing/empty endpoint just leaves the list empty.
+  useEffect(() => {
+    const demoId = savedDemoId || params?.get("demoId");
+    if (!demoId) {
+      return;
+    }
+    let isMounted = true;
+    axios
+      .get(`/api/demos/${demoId}/ctas`)
+      .then((res) => {
+        if (!isMounted) {
+          return;
+        }
+        const list = res.data?.ctas;
+        if (!Array.isArray(list)) {
+          return;
+        }
+        setCtas(
+          list.map((c) => ({
+            id: String(c.id),
+            label: String(c.label ?? ""),
+            url: String(c.url ?? ""),
+            placement: c.placement ?? null,
+            order: typeof c.order === "number" ? c.order : 0,
+          }))
+        );
+      })
+      .catch(() => {
+        // CTAs are optional; ignore load failures (e.g. endpoint not yet deployed).
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [savedDemoId, params, setCtas]);
 
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);

--- a/app/(signed)/editor/hooks/useEditorState.ts
+++ b/app/(signed)/editor/hooks/useEditorState.ts
@@ -9,6 +9,14 @@ export interface Segment {
 
 export type BrowserFrameMode = "default" | "minimal" | "hidden";
 
+export interface CtaItem {
+  id: string;
+  label: string;
+  url: string;
+  placement?: string | null;
+  order: number;
+}
+
 export function useEditorState() {
   const [params, setParams] = useState<URLSearchParams | null>(null);
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
@@ -28,6 +36,9 @@ export function useEditorState() {
   // Sidebar state
   const [sidebarTitle, setSidebarTitle] = useState("");
   const [sidebarDescription, setSidebarDescription] = useState("");
+
+  // CTA state (definitions live in the Cta table, not in demo.editing)
+  const [ctas, setCtas] = useState<CtaItem[]>([]);
 
   // Modal state
   const [showSaveDemoModal, setShowSaveDemoModal] = useState(false);
@@ -95,6 +106,8 @@ export function useEditorState() {
     setSidebarTitle,
     sidebarDescription,
     setSidebarDescription,
+    ctas,
+    setCtas,
     showSaveDemoModal,
     setShowSaveDemoModal,
     savingDemo,

--- a/app/components/EditorSidebar.tsx
+++ b/app/components/EditorSidebar.tsx
@@ -3,6 +3,8 @@ import { MainTab } from "./editorSidebar/backgroundOptions";
 import SidebarHeader from "./editorSidebar/SidebarHeader";
 import BackgroundPanel from "./editorSidebar/BackgroundPanel";
 import ToolsPanel from "./editorSidebar/ToolsPanel";
+import CtaPanel from "./editorSidebar/CtaPanel";
+import type { CtaItem } from "@/app/(signed)/editor/apiTypes";
 
 interface EditorSidebarProps {
   title: string;
@@ -43,6 +45,14 @@ interface EditorSidebarProps {
   savingDemo?: boolean;
   demoSaved?: boolean;
   onToggleDashboardMenu?: () => void;
+  ctas?: CtaItem[];
+  onAddCta?: (data: { label: string; url: string; placement?: string }) => void | Promise<void>;
+  onUpdateCta?: (
+    id: string,
+    data: { label?: string; url?: string; placement?: string | null }
+  ) => void | Promise<void>;
+  onDeleteCta?: (id: string) => void | Promise<void>;
+  onReorderCta?: (id: string, direction: "up" | "down") => void | Promise<void>;
 }
 
 const EditorSidebar: React.FC<EditorSidebarProps> = ({
@@ -79,6 +89,11 @@ const EditorSidebar: React.FC<EditorSidebarProps> = ({
   savingDemo = false,
   demoSaved = false,
   onToggleDashboardMenu,
+  ctas,
+  onAddCta,
+  onUpdateCta,
+  onDeleteCta,
+  onReorderCta,
 }) => {
   const [activeTab, setActiveTab] = React.useState<MainTab>("background");
 
@@ -131,6 +146,16 @@ const EditorSidebar: React.FC<EditorSidebarProps> = ({
           onClearSubtitles={onClearSubtitles}
           subtitlesLoading={subtitlesLoading}
           hasSubtitles={hasSubtitles}
+        />
+      )}
+
+      {activeTab === "cta" && (
+        <CtaPanel
+          ctas={ctas}
+          onAddCta={onAddCta}
+          onUpdateCta={onUpdateCta}
+          onDeleteCta={onDeleteCta}
+          onReorderCta={onReorderCta}
         />
       )}
     </aside>

--- a/app/components/editorSidebar/CtaPanel.tsx
+++ b/app/components/editorSidebar/CtaPanel.tsx
@@ -1,0 +1,263 @@
+import React, { useState } from "react";
+import { Check, ChevronDown, ChevronUp, Pencil, Trash2, X } from "lucide-react";
+import type { CtaItem } from "@/app/(signed)/editor/apiTypes";
+
+interface CtaPanelProps {
+  ctas?: CtaItem[];
+  onAddCta?: (data: { label: string; url: string; placement?: string }) => void | Promise<void>;
+  onUpdateCta?: (
+    id: string,
+    data: { label?: string; url?: string; placement?: string | null }
+  ) => void | Promise<void>;
+  onDeleteCta?: (id: string) => void | Promise<void>;
+  onReorderCta?: (id: string, direction: "up" | "down") => void | Promise<void>;
+}
+
+const inputClass =
+  "w-full border border-[#ede7fa] bg-[#F6F3FF] rounded-lg px-3 py-2 text-sm text-[#7C5CFC] placeholder:text-[#B0A5D3] focus:outline-none focus:ring-2 focus:ring-[#A594F9]";
+
+const iconBtnClass =
+  "p-1.5 rounded-md text-[#7C5CFC] hover:bg-[#EDE7FA] transition disabled:opacity-40 disabled:cursor-not-allowed";
+
+const CtaPanel: React.FC<CtaPanelProps> = ({
+  ctas = [],
+  onAddCta,
+  onUpdateCta,
+  onDeleteCta,
+  onReorderCta,
+}) => {
+  const [label, setLabel] = useState("");
+  const [url, setUrl] = useState("");
+  const [placement, setPlacement] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editLabel, setEditLabel] = useState("");
+  const [editUrl, setEditUrl] = useState("");
+  const [editPlacement, setEditPlacement] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
+
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const canAdd = label.trim().length > 0 && url.trim().length > 0 && !adding;
+
+  const handleAdd = async () => {
+    if (!canAdd) {
+      return;
+    }
+    setAdding(true);
+    try {
+      await onAddCta?.({
+        label: label.trim(),
+        url: url.trim(),
+        placement: placement.trim() || undefined,
+      });
+      setLabel("");
+      setUrl("");
+      setPlacement("");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const startEdit = (cta: CtaItem) => {
+    setConfirmDeleteId(null);
+    setEditingId(cta.id);
+    setEditLabel(cta.label);
+    setEditUrl(cta.url);
+    setEditPlacement(cta.placement ?? "");
+  };
+
+  const saveEdit = async (id: string) => {
+    if (!editLabel.trim() || !editUrl.trim() || savingEdit) {
+      return;
+    }
+    setSavingEdit(true);
+    try {
+      await onUpdateCta?.(id, {
+        label: editLabel.trim(),
+        url: editUrl.trim(),
+        placement: editPlacement.trim() ? editPlacement.trim() : null,
+      });
+      setEditingId(null);
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="control-block-label text-lg font-bold text-[#A594F9] mb-4">
+          Call to action
+        </h2>
+
+        <div className="space-y-2">
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Button label (e.g. Book a demo)"
+            className={inputClass}
+          />
+          <input
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://example.com"
+            className={inputClass}
+          />
+          <input
+            type="text"
+            value={placement}
+            onChange={(e) => setPlacement(e.target.value)}
+            placeholder="Placement (optional)"
+            className={inputClass}
+          />
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={!canAdd}
+            className="w-full rounded-lg bg-[#8A76FC] text-white py-2 text-sm font-semibold hover:bg-[#7C5CFC] transition disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {adding ? "Adding..." : "Add call to action"}
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-semibold text-[#6B6B6B] mb-2">Your call to actions</h3>
+        {ctas.length === 0 ? (
+          <p className="text-sm text-gray-400">No call to actions yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {ctas.map((cta, index) => (
+              <li key={cta.id} className="rounded-lg border border-[#ede7fa] bg-[#F6F3FF] p-3">
+                {editingId === cta.id ? (
+                  <div className="space-y-2">
+                    <input
+                      type="text"
+                      value={editLabel}
+                      onChange={(e) => setEditLabel(e.target.value)}
+                      placeholder="Button label"
+                      className={inputClass}
+                    />
+                    <input
+                      type="url"
+                      value={editUrl}
+                      onChange={(e) => setEditUrl(e.target.value)}
+                      placeholder="https://example.com"
+                      className={inputClass}
+                    />
+                    <input
+                      type="text"
+                      value={editPlacement}
+                      onChange={(e) => setEditPlacement(e.target.value)}
+                      placeholder="Placement (optional)"
+                      className={inputClass}
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => saveEdit(cta.id)}
+                        disabled={!editLabel.trim() || !editUrl.trim() || savingEdit}
+                        className="flex flex-1 items-center justify-center gap-1 rounded-lg bg-[#8A76FC] text-white py-1.5 text-sm font-semibold hover:bg-[#7C5CFC] transition disabled:opacity-60 disabled:cursor-not-allowed"
+                      >
+                        <Check size={16} />
+                        {savingEdit ? "Saving..." : "Save"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setEditingId(null)}
+                        className="flex flex-1 items-center justify-center gap-1 rounded-lg border border-[#8A76FC] text-[#8A76FC] py-1.5 text-sm font-semibold hover:bg-[#EDE7FA] transition"
+                      >
+                        <X size={16} />
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="flex items-start gap-2">
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-semibold text-[#7C5CFC] truncate">
+                          {cta.label}
+                        </div>
+                        <div className="text-xs text-gray-500 truncate">{cta.url}</div>
+                        {cta.placement ? (
+                          <div className="text-[11px] text-gray-400 truncate">{cta.placement}</div>
+                        ) : null}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-0.5">
+                        <button
+                          type="button"
+                          aria-label="Move up"
+                          disabled={index === 0}
+                          onClick={() => onReorderCta?.(cta.id, "up")}
+                          className={iconBtnClass}
+                        >
+                          <ChevronUp size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Move down"
+                          disabled={index === ctas.length - 1}
+                          onClick={() => onReorderCta?.(cta.id, "down")}
+                          className={iconBtnClass}
+                        >
+                          <ChevronDown size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Edit call to action"
+                          onClick={() => startEdit(cta)}
+                          className={iconBtnClass}
+                        >
+                          <Pencil size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Delete call to action"
+                          onClick={() => setConfirmDeleteId(cta.id)}
+                          className={`${iconBtnClass} hover:text-red-600`}
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    </div>
+                    {confirmDeleteId === cta.id ? (
+                      <div className="mt-2 flex items-center justify-between gap-2 border-t border-[#ede7fa] pt-2">
+                        <span className="text-xs text-gray-600">Delete this CTA?</span>
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setConfirmDeleteId(null);
+                              onDeleteCta?.(cta.id);
+                            }}
+                            className="rounded-md bg-red-500 text-white px-2 py-1 text-xs font-semibold hover:bg-red-600 transition"
+                          >
+                            Delete
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmDeleteId(null)}
+                            className="rounded-md border border-gray-300 text-gray-600 px-2 py-1 text-xs font-semibold hover:bg-gray-100 transition"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CtaPanel;

--- a/app/components/editorSidebar/SidebarHeader.tsx
+++ b/app/components/editorSidebar/SidebarHeader.tsx
@@ -91,6 +91,14 @@ const SidebarHeader: React.FC<SidebarHeaderProps> = ({
         >
           Tools
         </button>
+        <button
+          className={`tab-item flex-1 cursor-pointer py-2 rounded-lg text-sm font-semibold ${
+            activeTab === "cta" ? "active bg-white text-[#7C5CFC] shadow" : "text-gray-600"
+          }`}
+          onClick={() => setActiveTab("cta")}
+        >
+          CTA
+        </button>
       </div>
     </>
   );

--- a/app/components/editorSidebar/backgroundOptions.ts
+++ b/app/components/editorSidebar/backgroundOptions.ts
@@ -1,4 +1,4 @@
-export type MainTab = "background" | "tools";
+export type MainTab = "background" | "tools" | "cta";
 export type BgSubTab = "image" | "gradient" | "color" | "hidden";
 
 export interface ImageBackgroundOption {


### PR DESCRIPTION
partial fixes #213 

## Summary
Lets a demo owner manage a demo's Call-To-Actions from the editor. A new **CTA**
tab in the sidebar provides full CRUD (add / list / inline-edit / reorder / delete).
CTAs live in the separate `Cta` table and are managed entirely over HTTP — they are
**not** read from or written to `demo.editing`.

## Changes
- **State** — added `ctas`/`setCtas` and a `CtaItem` type to `useEditorState.ts`;
  re-exported `CtaItem` from `apiTypes.ts`.
- **Load** — `useDemoLoader.ts` now `GET`s `/api/demos/[id]/ctas` after the demo
  loads and populates the list. Degrades gracefully: a missing/erroring endpoint
  just leaves the list empty (no crash).
- **UI** — new `CtaPanel` (under the new "CTA" sidebar tab, plumbed through
  `EditorSidebarRegion` like the other sidebar props). Supports:
  - Add (label + url + optional placement) → `POST /api/demos/[id]/ctas`
  - Inline edit → `PATCH /api/ctas/[id]`
  - Delete with a small inline confirm → `DELETE /api/ctas/[id]`
  - Up/down reorder updating `order` → `PATCH /api/ctas/[id]`
  - Optimistic local updates with rollback; `react-hot-toast` success/failure.
- Works in both the desktop and mobile sidebar variants (same component renders in
  both), and matches existing sidebar styling.