### PR TITLE
feat(share): render demo CTAs and track clicks on public share page

### DIFF
--- a/app/share/[slug]/ShareVideoPageClient.tsx
+++ b/app/share/[slug]/ShareVideoPageClient.tsx
@@ -7,6 +7,7 @@ import { useViewTracking } from "./hooks/useViewTracking";
 import { getPreviewStage } from "./utils/previewStage";
 import ShareHeader from "./components/ShareHeader";
 import ShareSignupCTA from "./components/ShareSignupCTA";
+import ShareCtaButtons, { type ShareCta } from "./components/ShareCtaButtons";
 
 type ShareVideoPageClientProps = {
   title: string;
@@ -16,6 +17,7 @@ type ShareVideoPageClientProps = {
   aspectRatio: string;
   demoId?: string;
   videoId?: string;
+  ctas?: ShareCta[];
 };
 
 export default function ShareVideoPageClient({
@@ -26,6 +28,7 @@ export default function ShareVideoPageClient({
   aspectRatio,
   demoId,
   videoId,
+  ctas = [],
 }: ShareVideoPageClientProps) {
   const videoRef = useViewTracking(demoId, videoId);
 
@@ -78,6 +81,8 @@ export default function ShareVideoPageClient({
             </div>
           </div>
         </div>
+
+        <ShareCtaButtons ctas={ctas} demoId={demoId} />
 
         {!isLoggedIn && <ShareSignupCTA />}
       </section>

--- a/app/share/[slug]/components/ShareCtaButtons.tsx
+++ b/app/share/[slug]/components/ShareCtaButtons.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+export type ShareCta = {
+  id: string;
+  label: string;
+  url: string;
+  order: number;
+};
+
+function fireCtaClick(cta: ShareCta, demoId: string) {
+  const payload = JSON.stringify({
+    ctaId: cta.id,
+    demoId,
+    label: cta.label,
+    referrer: document.referrer,
+  });
+
+  try {
+    if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+      const blob = new Blob([payload], { type: "application/json" });
+      if (navigator.sendBeacon("/api/cta-clicks", blob)) {
+        return;
+      }
+    }
+  } catch {
+    // fall through to fetch below
+  }
+
+  // Keep the request alive across the navigation triggered by the link click.
+  fetch("/api/cta-clicks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+    keepalive: true,
+  }).catch(() => {});
+}
+
+export default function ShareCtaButtons({ ctas, demoId }: { ctas: ShareCta[]; demoId?: string }) {
+  if (!ctas.length || !demoId) {
+    return null;
+  }
+
+  return (
+    <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+      {ctas.map((cta) => (
+        <a
+          key={cta.id}
+          href={cta.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => fireCtaClick(cta, demoId)}
+          className="rounded-full bg-[#2A1D5C] px-6 py-2.5 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(42,29,92,0.28)] transition hover:bg-[#3A2A78]"
+        >
+          {cta.label}
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/app/share/[slug]/page.tsx
+++ b/app/share/[slug]/page.tsx
@@ -116,6 +116,10 @@ export default async function SharePage({ params }: PageProps) {
       videoUrl: true,
       exportedUrl: true,
       editing: true,
+      ctas: {
+        select: { id: true, label: true, url: true, order: true },
+        orderBy: { order: "asc" },
+      },
     },
   });
 
@@ -135,6 +139,7 @@ export default async function SharePage({ params }: PageProps) {
           : "16:9"
       }
       demoId={demo.id}
+      ctas={demo.ctas}
     />
   );
 }


### PR DESCRIPTION
- app/share/[slug]/page.tsx: add ctas (id, label, url, order; ordered by order asc) to the Prisma select and pass them to ShareVideoPageClient.
- ShareVideoPageClient.tsx: accept a ctas prop and render ShareCtaButtons below the video, above ShareSignupCTA.
- New components/ShareCtaButtons.tsx: renders each CTA as a button (target="_blank", rel="noopener noreferrer") in order; on click only, posts { ctaId, demoId, label, referrer } to /api/cta-clicks via sendBeacon (fetch keepalive fallback) without delaying navigation. Renders nothing when there are no CTAs.
- Does not touch /api/views, the view cookie, or shareCount.

partial fixes #213 