### PR TITLE
feat(cta): add CTA click endpoint with anonymous session cookie

### DIFF
--- a/app/api/cta-clicks/route.ts
+++ b/app/api/cta-clicks/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/lib/auth/options";
+
+// Anonymous identity cookie: a random session-id VALUE (not a presence flag).
+const SID_COOKIE = "mv_sid";
+const SID_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+export async function POST(req: NextRequest) {
+  try {
+    const { ctaId, demoId, label, referrer } = await req.json();
+
+    if (!ctaId || !demoId || !label) {
+      return NextResponse.json({ error: "ctaId, demoId and label are required" }, { status: 400 });
+    }
+
+    // Read the anonymous session id; generate one if this browser doesn't have it yet.
+    let sessionId = req.cookies.get(SID_COOKIE)?.value;
+    const isNewSession = !sessionId;
+    if (!sessionId) {
+      sessionId = crypto.randomUUID();
+    }
+
+    // Logged-in viewers also get their userId stored alongside the anon session id.
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id ?? null;
+
+    await prisma.ctaClick.create({
+      data: {
+        ctaId,
+        demoId,
+        label,
+        pageType: "demo",
+        sessionId,
+        userId,
+        referrer: referrer || req.headers.get("referer") || null,
+      },
+    });
+
+    const response = NextResponse.json({ success: true });
+
+    // Only set the cookie when we generated a fresh id so repeated calls reuse mv_sid.
+    if (isNewSession) {
+      response.cookies.set(SID_COOKIE, sessionId, {
+        maxAge: SID_MAX_AGE,
+        path: "/",
+        httpOnly: false,
+      });
+    }
+
+    return response;
+  } catch (error) {
+    console.error("Error recording CTA click:", error);
+    return NextResponse.json({ error: "Failed to record CTA click" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
partial fixes #213 
Adds `POST /api/cta-clicks` to record CTA clicks. Each call inserts exactly one `CtaClick` row, giving total click counts.
- **Body**: `{ ctaId, demoId, label, referrer? }` — returns `400` if `ctaId`, `demoId`, or `label` is missing.
- **Anonymous identity**: reads a random `mv_sid` cookie value; if absent, generates one with `crypto.randomUUID()` and sets it on the response (1-year `maxAge`, `path "/"`, not `httpOnly`). Stored as `sessionId`. Repeated clicks reuse the same `mv_sid`.
- **Authenticated viewers**: also stores `userId` from `getServerSession(authOptions)` (null when anonymous).
- Sets `pageType = "demo"`; captures `referrer` from the body, falling back to the `Referer` header.
