### PR TITLE
feat(analytics): add CTA metrics, cards, and top CTA panel

### DIFF
--- a/app/(signed)/analytics/AnalyticsClient.tsx
+++ b/app/(signed)/analytics/AnalyticsClient.tsx
@@ -6,8 +6,12 @@ type AnalyticsClientProps = {
   avgDuration: string;
   completionRate: string;
   activeShares: number;
-  topDemos: { title: string; views: number }[];
+  topDemos: { title: string; views: number; ctaClicks: number; hasCta: boolean }[];
   viewsOverTime: { date: string; views: number }[];
+  totalCtaClicks: number;
+  uniqueCtaClicks: number;
+  ctaClickRate: string;
+  topCtas: { label: string; clicks: number }[];
 };
 
 const AnalyticsPage = (props: AnalyticsClientProps) => {

--- a/app/(signed)/analytics/page.tsx
+++ b/app/(signed)/analytics/page.tsx
@@ -46,6 +46,7 @@ export default async function Page() {
       exportedVideo: {
         include: { views: true },
       },
+      _count: { select: { ctas: true, ctaClicks: true } },
     },
   });
   const topDemos = demos
@@ -55,7 +56,12 @@ export default async function Page() {
         ...d.views.map((v) => v.id),
         ...(d.exportedVideo?.views.map((v) => v.id) || []),
       ]);
-      return { title: d.title, views: allViewIds.size };
+      return {
+        title: d.title,
+        views: allViewIds.size,
+        ctaClicks: d._count.ctaClicks,
+        hasCta: d._count.ctas > 0,
+      };
     })
     .sort((a, b) => b.views - a.views)
     .slice(0, 5);
@@ -69,6 +75,32 @@ export default async function Page() {
     .map(([date, count]) => ({ date, views: count }))
     .sort((a, b) => a.date.localeCompare(b.date));
 
+  // CTA analytics (clicks for the logged-in user's demos)
+  const ctaClickRows = await prisma.ctaClick.findMany({
+    where: { demo: { userId } },
+    select: { userId: true, sessionId: true },
+  });
+  const totalCtaClicks = ctaClickRows.length;
+  // unique clicks = COUNT(DISTINCT COALESCE(userId, sessionId)); nulls are not counted
+  const uniqueCtaClicks = new Set(
+    ctaClickRows.map((c) => c.userId ?? c.sessionId).filter((id): id is string => Boolean(id))
+  ).size;
+  // CTA click rate = unique clicks (per browser) ÷ total views; guard divide-by-zero
+  const ctaClickRate = totalViews ? `${Math.round((uniqueCtaClicks / totalViews) * 100)}%` : "0%";
+
+  // top performing CTA(s): group clicks by label, ordered by click count
+  const ctaByLabel = await prisma.ctaClick.groupBy({
+    by: ["label"],
+    where: { demo: { userId } },
+    _count: { label: true },
+    orderBy: { _count: { label: "desc" } },
+    take: 5,
+  });
+  const topCtas = ctaByLabel.map((g) => ({
+    label: g.label,
+    clicks: g._count.label,
+  }));
+
   return (
     <AnalyticsClient
       totalViews={totalViews}
@@ -77,6 +109,10 @@ export default async function Page() {
       activeShares={activeShares}
       topDemos={topDemos}
       viewsOverTime={viewsOverTime}
+      totalCtaClicks={totalCtaClicks}
+      uniqueCtaClicks={uniqueCtaClicks}
+      ctaClickRate={ctaClickRate}
+      topCtas={topCtas}
     />
   );
 }

--- a/app/components/AnalyticsMain.tsx
+++ b/app/components/AnalyticsMain.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import AnalyticsStatCards from "./analytics/AnalyticsStatCards";
 import ViewsOverTimePanel from "./analytics/ViewsOverTimePanel";
 import TopDemosPanel from "./analytics/TopDemosPanel";
+import TopCtaPanel from "./analytics/TopCtaPanel";
 
 export const metadata = {
   title: "Settings",
@@ -15,8 +16,12 @@ type AnalyticsMainProps = {
   avgDuration?: string;
   completionRate?: string;
   activeShares?: number;
-  topDemos?: { title: string; views: number }[];
+  topDemos?: { title: string; views: number; ctaClicks: number; hasCta: boolean }[];
   viewsOverTime?: { date: string; views: number }[];
+  totalCtaClicks?: number;
+  uniqueCtaClicks?: number;
+  ctaClickRate?: string;
+  topCtas?: { label: string; clicks: number }[];
 };
 
 const AnalyticsMain = ({
@@ -26,7 +31,12 @@ const AnalyticsMain = ({
   activeShares = 0,
   topDemos = [],
   viewsOverTime = [],
+  totalCtaClicks = 0,
+  uniqueCtaClicks = 0,
+  ctaClickRate = "0%",
+  topCtas = [],
 }: AnalyticsMainProps) => {
+  const topCta = topCtas[0] ?? null;
   const [isVisible, setIsVisible] = useState(false);
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
 
@@ -53,6 +63,10 @@ const AnalyticsMain = ({
         avgDuration={avgDuration}
         completionRate={completionRate}
         activeShares={activeShares}
+        totalCtaClicks={totalCtaClicks}
+        uniqueCtaClicks={uniqueCtaClicks}
+        ctaClickRate={ctaClickRate}
+        topCta={topCta}
         isVisible={isVisible}
         hoveredCard={hoveredCard}
         onHover={handleCardHover}
@@ -60,8 +74,11 @@ const AnalyticsMain = ({
       />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <ViewsOverTimePanel viewsOverTime={viewsOverTime} />
+        <div className="lg:col-span-2">
+          <ViewsOverTimePanel viewsOverTime={viewsOverTime} />
+        </div>
         <TopDemosPanel topDemos={topDemos} />
+        <TopCtaPanel topCtas={topCtas} />
       </div>
     </div>
   );

--- a/app/components/analytics/AnalyticsStatCards.tsx
+++ b/app/components/analytics/AnalyticsStatCards.tsx
@@ -1,11 +1,20 @@
 import React from "react";
-import { Eye, CheckCircle, Clock, Share2 } from "lucide-react";
+import {
+  Eye,
+  CheckCircle,
+  Clock,
+  Share2,
+  MousePointerClick,
+  Users,
+  Percent,
+  Trophy,
+} from "lucide-react";
 
 interface AnalyticsCard {
   id: string;
   label: string;
   value: string;
-  trend: string;
+  trend?: string;
   trendLabel: string;
   icon: React.ReactNode;
   bgColor: string;
@@ -19,6 +28,10 @@ interface AnalyticsStatCardsProps {
   avgDuration: string;
   completionRate: string;
   activeShares: number;
+  totalCtaClicks: number;
+  uniqueCtaClicks: number;
+  ctaClickRate: string;
+  topCta: { label: string; clicks: number } | null;
   isVisible: boolean;
   hoveredCard: string | null;
   onHover: (cardId: string) => void;
@@ -30,6 +43,10 @@ const AnalyticsStatCards = ({
   avgDuration,
   completionRate,
   activeShares,
+  totalCtaClicks,
+  uniqueCtaClicks,
+  ctaClickRate,
+  topCta,
   isVisible,
   hoveredCard,
   onHover,
@@ -79,6 +96,50 @@ const AnalyticsStatCards = ({
       trend: "+8.3%",
       trendLabel: "vs last month",
       icon: <Share2 className="w-6 h-6 md:w-7 md:h-7 text-[#E33629]" />,
+      bgColor: "bg-[#DE610E]/10",
+      hoverColor: "from-[#F9E6E6] to-[#E33629]",
+      shadow: "shadow-[#E33629]/50",
+      textColor: "text-[#261753]",
+    },
+    {
+      id: "ctaClicks",
+      label: "CTA Clicks",
+      value: totalCtaClicks.toString(),
+      trendLabel: "total clicks",
+      icon: <MousePointerClick className="w-6 h-6 md:w-7 md:h-7 text-[#8A76FC]" />,
+      bgColor: "bg-[#C5B6F1]/19",
+      hoverColor: "from-[#C5B6F1] to-[#8A76FC]",
+      shadow: "shadow-[#8A76FC]/50",
+      textColor: "text-[#261753]",
+    },
+    {
+      id: "uniqueClicks",
+      label: "Unique Clicks (per browser)",
+      value: uniqueCtaClicks.toString(),
+      trendLabel: "distinct viewers",
+      icon: <Users className="w-6 h-6 md:w-7 md:h-7 text-[#2F80EC]" />,
+      bgColor: "bg-[#9BE1F8]/14",
+      hoverColor: "from-[#9BE1F8] to-[#2F80EC]",
+      shadow: "shadow-[#2F80EC]/50",
+      textColor: "text-[#261753]",
+    },
+    {
+      id: "ctaRate",
+      label: "CTA Click Rate (per browser)",
+      value: ctaClickRate,
+      trendLabel: "unique clicks ÷ views",
+      icon: <Percent className="w-6 h-6 md:w-7 md:h-7 text-[#6356D7]" />,
+      bgColor: "bg-[#261753]/6",
+      hoverColor: "from-[#E6E1FA] to-[#C5B6F1]",
+      shadow: "shadow-[#6356D7]/50",
+      textColor: "text-[#261753]",
+    },
+    {
+      id: "topCta",
+      label: "Top CTA",
+      value: topCta?.label ?? "—",
+      trendLabel: topCta ? `${topCta.clicks} clicks` : "no clicks yet",
+      icon: <Trophy className="w-6 h-6 md:w-7 md:h-7 text-[#E33629]" />,
       bgColor: "bg-[#DE610E]/10",
       hoverColor: "from-[#F9E6E6] to-[#E33629]",
       shadow: "shadow-[#E33629]/50",
@@ -156,24 +217,28 @@ const AnalyticsStatCard = ({
     </div>
     <div className="stat-label text-sm md:text-lg font-medium text-[#261753]">{card.label}</div>
     <div
-      className={`stat-value text-2xl md:text-3xl font-bold text-[#261753] ${
+      className={`stat-value text-2xl md:text-3xl font-bold text-[#261753] truncate max-w-full ${
         hoveredCard === card.id ? card.textColor : ""
       }`}
     >
       {card.value}
     </div>
     <div className="trend text-sm text-green-600 font-semibold mt-1 flex items-center">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="w-5 h-5 mr-1 text-green-600"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" d="M3 17l6-6 4 4 8-8" />
-      </svg>
-      <strong>{card.trend}</strong>{" "}
+      {card.trend ? (
+        <>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="w-5 h-5 mr-1 text-green-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 17l6-6 4 4 8-8" />
+          </svg>
+          <strong>{card.trend}</strong>{" "}
+        </>
+      ) : null}
       <span className="text-gray-500 font-normal ml-1">{card.trendLabel}</span>
     </div>
   </div>

--- a/app/components/analytics/TopCtaPanel.tsx
+++ b/app/components/analytics/TopCtaPanel.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { MousePointerClick } from "lucide-react";
+
+interface TopCtaPanelProps {
+  topCtas: { label: string; clicks: number }[];
+}
+
+const TopCtaPanel = ({ topCtas }: TopCtaPanelProps) => (
+  <motion.div
+    initial={{ opacity: 0, scale: 0.9 }}
+    animate={{ opacity: 1, scale: 1 }}
+    whileHover={{ scale: 1.01 }}
+    transition={{ duration: 0.6, ease: "easeOut", delay: 0.5 }}
+    className="panel bg-[#FBF9FF] rounded-[20px] p-8 shadow-sm min-h-[350px] flex flex-col"
+  >
+    <div className="mb-6">
+      <h2 className="text-[22px] font-semibold text-[#2D2154] leading-tight">Top performing CTA</h2>
+      <p className="text-base text-[#8C82B4] mt-1">Your most clicked calls-to-action</p>
+    </div>
+    <div className="flex-1 flex flex-col gap-3">
+      {topCtas.length > 0 ? (
+        topCtas.map((cta, i) => (
+          <div
+            key={i}
+            className="cta-item flex justify-between items-center bg-white border border-[#E5DCFF] rounded-xl p-4 shadow-sm hover:shadow-md transition-shadow"
+          >
+            <div className="flex items-center gap-3">
+              <div className="rank w-8 h-8 rounded-full bg-[#EAE5FB] flex items-center justify-center text-[#8A76FC] font-semibold">
+                {i + 1}
+              </div>
+              <p className="cta-name font-medium text-[#2D2154] truncate max-w-[200px] md:max-w-[250px]">
+                {cta.label}
+              </p>
+            </div>
+            <div className="clicks flex items-center gap-1.5 text-[#6356D7] bg-[#F4F1FD] px-3 py-1 rounded-full">
+              <MousePointerClick size={14} />
+              <span className="font-semibold text-sm">{cta.clicks} clicks</span>
+            </div>
+          </div>
+        ))
+      ) : (
+        <div className="flex-1 flex flex-col items-center justify-center text-center gap-3">
+          <div className="bg-[#F6F3FF] p-4 rounded-full">
+            <MousePointerClick className="w-5 h-5 md:w-6 md:h-6 text-[#8A76FC]" />
+          </div>
+          <p className="no-data text-[#7569A5] font-semibold text-base">No CTA clicks yet</p>
+          <p className="text-base text-[#8C82B4]">
+            Add CTAs to your demos to start tracking clicks
+          </p>
+        </div>
+      )}
+    </div>
+  </motion.div>
+);
+
+export default TopCtaPanel;

--- a/app/components/analytics/TopDemosPanel.tsx
+++ b/app/components/analytics/TopDemosPanel.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { motion } from "framer-motion";
 import Image from "next/image";
-import { Eye } from "lucide-react";
+import { Eye, MousePointerClick } from "lucide-react";
 
 interface TopDemosPanelProps {
-  topDemos: { title: string; views: number }[];
+  topDemos: { title: string; views: number; ctaClicks: number; hasCta: boolean }[];
 }
 
 const TopDemosPanel = ({ topDemos }: TopDemosPanelProps) => (
@@ -32,13 +32,25 @@ const TopDemosPanel = ({ topDemos }: TopDemosPanelProps) => (
               <div className="rank w-8 h-8 rounded-full bg-[#EAE5FB] flex items-center justify-center text-[#8A76FC] font-semibold">
                 {i + 1}
               </div>
-              <p className="demo-name font-medium text-[#2D2154] truncate max-w-[200px] md:max-w-[250px]">
+              <p className="demo-name font-medium text-[#2D2154] truncate max-w-[120px] md:max-w-[180px]">
                 {demo.title}
               </p>
             </div>
-            <div className="views flex items-center gap-1.5 text-[#6356D7] bg-[#F4F1FD] px-3 py-1 rounded-full">
-              <Eye size={14} />
-              <span className="font-semibold text-sm">{demo.views} views</span>
+            <div className="flex items-center gap-2">
+              <div className="views flex items-center gap-1.5 text-[#6356D7] bg-[#F4F1FD] px-3 py-1 rounded-full">
+                <Eye size={14} />
+                <span className="font-semibold text-sm">{demo.views} views</span>
+              </div>
+              {demo.hasCta ? (
+                <div className="cta-clicks flex items-center gap-1.5 text-[#8A76FC] bg-[#EAE5FB] px-3 py-1 rounded-full">
+                  <MousePointerClick size={14} />
+                  <span className="font-semibold text-sm">{demo.ctaClicks} clicks</span>
+                </div>
+              ) : (
+                <span className="text-xs text-[#8C82B4] max-w-[160px] text-right">
+                  No CTA added yet. Add a CTA to start tracking clicks.
+                </span>
+              )}
             </div>
           </div>
         ))


### PR DESCRIPTION
partial fixes #213 
Add CTA analytics to the analytics page for the logged-in user's demos: total CTA clicks, unique clicks (distinct COALESCE(userId, sessionId)), CTA click rate (unique ÷ total views, guarded), and top performing CTAs.

- Compute metrics + per-demo CTA click counts and hasCta in page.tsx; thread props through AnalyticsClient and AnalyticsMain.
- Add CTA stat cards (total, unique per browser, rate per browser, top CTA) to AnalyticsStatCards, matching existing card style/animation.
- Show per-demo CTA click count next to views in TopDemosPanel, with the no-CTA empty-state copy.
- Add TopCtaPanel with a graceful empty state.