### PR TITLE
refactor(#150): move recorder UI state into recorderStore

### DIFF
--- a/app/(signed)/recorder/RecorderClient.tsx
+++ b/app/(signed)/recorder/RecorderClient.tsx
@@ -20,33 +20,19 @@ export default function RecorderPage() {
   const videoPlayerRef = useRef<ReactPlayer>(null);
 
   const {
-    uploadMessage,
-    setUploadMessage,
     uploadedFileUrl,
-    setUploadedFileUrl,
-    uploadedFileType,
-    setUploadedFileType,
-    saveMessage,
-    recordingTimer,
     setRecordingTimer,
     showSavePopup,
     setShowSavePopup,
     processingDownload,
     setProcessingDownload,
-    videoPlaying,
-    setVideoPlaying,
-    videoCurrentTime,
-    setVideoCurrentTime,
     videoDuration,
     setVideoDuration,
-    sidebarOpen,
-    setSidebarOpen,
-
     fileInputRef,
     recordingIntervalRef,
   } = useRecorderState();
 
-  const { setBlob, blob, title, setTitle } = useBlobStore();
+  const { blob, title } = useBlobStore();
 
   const {
     stopRecording,
@@ -87,33 +73,16 @@ export default function RecorderPage() {
         isUploaded={isUploaded}
         onBack={handleBack}
         onEditVideo={handleEditVideo}
-        uploadedFileType={uploadedFileType}
-        uploadedFileUrl={uploadedFileUrl}
         videoUrl={videoUrl}
         screenStream={screenStream}
         recording={recording}
-        videoPlaying={videoPlaying}
-        setVideoPlaying={setVideoPlaying}
-        videoCurrentTime={videoCurrentTime}
-        setVideoCurrentTime={setVideoCurrentTime}
-        videoDuration={videoDuration}
-        setVideoDuration={setVideoDuration}
         recordingDuration={recordingDuration}
-        recordingTimer={recordingTimer}
         videoPlayerRef={videoPlayerRef}
-        saveMessage={saveMessage}
         startScreenShare={startScreenShare}
         stopRecording={stopRecording}
-        setUploadedFileUrl={setUploadedFileUrl}
-        setUploadedFileType={setUploadedFileType}
-        setBlob={setBlob}
         reset={reset}
         fileInputRef={fileInputRef}
-        showSavePopup={showSavePopup}
-        setShowSavePopup={setShowSavePopup}
         onPopupDownload={handlePopupDownload}
-        title={title}
-        processingDownload={processingDownload}
         isProcessingRef={isProcessingRef}
       />
     );
@@ -128,15 +97,6 @@ export default function RecorderPage() {
       <RecorderTopbar onBack={handleBack} userInitials={initials} />
 
       <InitialRecorderView
-        sidebarOpen={sidebarOpen}
-        setSidebarOpen={setSidebarOpen}
-        title={title}
-        setTitle={setTitle}
-        uploadedFileUrl={uploadedFileUrl}
-        setUploadedFileUrl={setUploadedFileUrl}
-        setUploadedFileType={setUploadedFileType}
-        setUploadMessage={setUploadMessage}
-        uploadMessage={uploadMessage}
         fileInputRef={fileInputRef}
         startScreenShare={startScreenShare}
         toggleMic={toggleMic}

--- a/app/(signed)/recorder/RecorderWorkspaceView.tsx
+++ b/app/(signed)/recorder/RecorderWorkspaceView.tsx
@@ -1,79 +1,89 @@
 import ReactPlayer from "react-player";
 import { toast } from "sonner";
+import { useShallow } from "zustand/react/shallow";
 import RecorderTopbar from "@/app/components/RecorderTopbar";
 import SavePopupForm from "@/app/components/SavePopupForm";
 import VideoPlayerSection from "@/app/components/VideoPlayerSection";
 import RecordingControls from "@/app/components/RecordingControls";
+import { useRecorderStore } from "@/app/store/recorderStore";
+import { useBlobStore } from "@/app/store/blobStore";
 
 interface RecorderWorkspaceViewProps {
   initials: string;
   isUploaded: boolean;
   onBack: () => void;
   onEditVideo: () => void;
-  uploadedFileType: string | null;
-  uploadedFileUrl: string | null;
   videoUrl: string | null;
   screenStream: MediaStream | null;
   recording: boolean;
-  videoPlaying: boolean;
-  setVideoPlaying: (playing: boolean) => void;
-  videoCurrentTime: number;
-  setVideoCurrentTime: (time: number) => void;
-  videoDuration: number;
-  setVideoDuration: (duration: number) => void;
   recordingDuration: number;
-  recordingTimer: number;
   videoPlayerRef: React.RefObject<ReactPlayer | null>;
-  saveMessage: string;
   startScreenShare: () => void;
   stopRecording: () => void;
-  setUploadedFileUrl: (url: string | null) => void;
-  setUploadedFileType: (type: string | null) => void;
-  setBlob: (blob: Blob | null) => void;
   reset: () => void;
   fileInputRef: React.RefObject<HTMLInputElement | null>;
-  showSavePopup: boolean;
-  setShowSavePopup: (open: boolean) => void;
   onPopupDownload: (data: { title: string; format: string }) => void;
-  title: string;
-  processingDownload: boolean;
   isProcessingRef: React.MutableRefObject<boolean>;
 }
+
+// saveMessage was always "" (no setter was ever exposed); kept for parity.
+const saveMessage = "";
 
 export default function RecorderWorkspaceView({
   initials,
   isUploaded,
   onBack,
   onEditVideo,
-  uploadedFileType,
-  uploadedFileUrl,
   videoUrl,
   screenStream,
   recording,
-  videoPlaying,
-  setVideoPlaying,
-  videoCurrentTime,
-  setVideoCurrentTime,
-  videoDuration,
-  setVideoDuration,
   recordingDuration,
-  recordingTimer,
   videoPlayerRef,
-  saveMessage,
   startScreenShare,
   stopRecording,
-  setUploadedFileUrl,
-  setUploadedFileType,
-  setBlob,
   reset,
   fileInputRef,
-  showSavePopup,
-  setShowSavePopup,
   onPopupDownload,
-  title,
-  processingDownload,
   isProcessingRef,
 }: RecorderWorkspaceViewProps) {
+  const {
+    uploadedFileType,
+    uploadedFileUrl,
+    videoPlaying,
+    setVideoPlaying,
+    videoCurrentTime,
+    setVideoCurrentTime,
+    videoDuration,
+    setVideoDuration,
+    recordingTimer,
+    showSavePopup,
+    setShowSavePopup,
+    processingDownload,
+    setUploadedFileUrl,
+    setUploadedFileType,
+  } = useRecorderStore(
+    useShallow((s) => ({
+      uploadedFileType: s.uploadedFileType,
+      uploadedFileUrl: s.uploadedFileUrl,
+      videoPlaying: s.videoPlaying,
+      setVideoPlaying: s.setVideoPlaying,
+      videoCurrentTime: s.videoCurrentTime,
+      setVideoCurrentTime: s.setVideoCurrentTime,
+      videoDuration: s.videoDuration,
+      setVideoDuration: s.setVideoDuration,
+      recordingTimer: s.recordingTimer,
+      showSavePopup: s.showSavePopup,
+      setShowSavePopup: s.setShowSavePopup,
+      processingDownload: s.processingDownload,
+      setUploadedFileUrl: s.setUploadedFileUrl,
+      setUploadedFileType: s.setUploadedFileType,
+    }))
+  );
+
+  const { setBlob, title } = useBlobStore(
+    useShallow((s) => ({ setBlob: s.setBlob, title: s.title }))
+  );
+
   return (
     <div
       className="page flex flex-col h-screen w-full overflow-hidden"

--- a/app/(signed)/recorder/hooks/useRecorderState.ts
+++ b/app/(signed)/recorder/hooks/useRecorderState.ts
@@ -1,51 +1,52 @@
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useRecorderStore } from "@/app/store/recorderStore";
 
+/**
+ * Thin shim over the recorderStore (strangler pattern). Returns the same shape
+ * the god-hook used to expose so existing consumers keep working untouched, but
+ * the UI state now lives in the Zustand store. Refs stay local to the caller.
+ */
 export function useRecorderState() {
-  const [uploadMessage, setUploadMessage] = useState<string>("");
-  const [uploadedFileUrl, setUploadedFileUrl] = useState<string | null>(null);
-  const [uploadedFileType, setUploadedFileType] = useState<string | null>(null);
-  const [format, setFormat] = useState<"webm" | "mp4">("webm");
-  const [saveMessage] = useState<string>("");
-  const [recordingTimer, setRecordingTimer] = useState(0);
-  const [showSavePopup, setShowSavePopup] = useState(false);
-  const [processingDownload, setProcessingDownload] = useState(false);
+  const state = useRecorderStore(
+    useShallow((s) => ({
+      uploadMessage: s.uploadMessage,
+      setUploadMessage: s.setUploadMessage,
+      uploadedFileUrl: s.uploadedFileUrl,
+      setUploadedFileUrl: s.setUploadedFileUrl,
+      uploadedFileType: s.uploadedFileType,
+      setUploadedFileType: s.setUploadedFileType,
+      format: s.format,
+      setFormat: s.setFormat,
+      recordingTimer: s.recordingTimer,
+      setRecordingTimer: s.setRecordingTimer,
+      showSavePopup: s.showSavePopup,
+      setShowSavePopup: s.setShowSavePopup,
+      processingDownload: s.processingDownload,
+      setProcessingDownload: s.setProcessingDownload,
+      videoPlaying: s.videoPlaying,
+      setVideoPlaying: s.setVideoPlaying,
+      videoCurrentTime: s.videoCurrentTime,
+      setVideoCurrentTime: s.setVideoCurrentTime,
+      videoDuration: s.videoDuration,
+      setVideoDuration: s.setVideoDuration,
+      sidebarOpen: s.sidebarOpen,
+      setSidebarOpen: s.setSidebarOpen,
+      isSavePublishDisabled: s.isSavePublishDisabled,
+      setIsSavePublishDisabled: s.setIsSavePublishDisabled,
+    }))
+  );
 
-  // Video controls state
-  const [videoPlaying, setVideoPlaying] = useState(false);
-  const [videoCurrentTime, setVideoCurrentTime] = useState(0);
-  const [videoDuration, setVideoDuration] = useState(0);
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [isSavePublishDisabled, setIsSavePublishDisabled] = useState(false);
+  // saveMessage was always "" (no setter was ever exposed); keep it for parity.
+  const saveMessage = "";
 
+  // Refs stay as refs — they do not belong in the store.
   const fileInputRef = useRef<HTMLInputElement>(null);
   const recordingIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   return {
-    uploadMessage,
-    setUploadMessage,
-    uploadedFileUrl,
-    setUploadedFileUrl,
-    uploadedFileType,
-    setUploadedFileType,
-    format,
-    setFormat,
+    ...state,
     saveMessage,
-    recordingTimer,
-    setRecordingTimer,
-    showSavePopup,
-    setShowSavePopup,
-    processingDownload,
-    setProcessingDownload,
-    videoPlaying,
-    setVideoPlaying,
-    videoCurrentTime,
-    setVideoCurrentTime,
-    videoDuration,
-    setVideoDuration,
-    sidebarOpen,
-    setSidebarOpen,
-    isSavePublishDisabled,
-    setIsSavePublishDisabled,
     fileInputRef,
     recordingIntervalRef,
   };

--- a/app/components/InitialRecorderView.tsx
+++ b/app/components/InitialRecorderView.tsx
@@ -1,19 +1,12 @@
 import { Menu } from "lucide-react";
 import { toast } from "sonner";
+import { useShallow } from "zustand/react/shallow";
 import { useBlobStore } from "@/app/store/blobStore";
+import { useRecorderStore } from "@/app/store/recorderStore";
 import RecorderSettingsDialog from "@/app/components/RecorderSettingsDialog";
 import RecorderMainPanel from "@/app/components/RecorderMainPanel";
 
 interface InitialRecorderViewProps {
-  sidebarOpen: boolean;
-  setSidebarOpen: (open: boolean) => void;
-  title: string;
-  setTitle: (title: string) => void;
-  uploadedFileUrl: string | null;
-  setUploadedFileUrl: (url: string | null) => void;
-  setUploadedFileType: (type: string | null) => void;
-  setUploadMessage: (message: string) => void;
-  uploadMessage: string;
   fileInputRef: React.RefObject<HTMLInputElement | null>;
   startScreenShare: () => void;
   toggleMic: () => void;
@@ -21,21 +14,34 @@ interface InitialRecorderViewProps {
 }
 
 export default function InitialRecorderView({
-  sidebarOpen,
-  setSidebarOpen,
-  title,
-  setTitle,
-  uploadedFileUrl,
-  setUploadedFileUrl,
-  setUploadedFileType,
-  setUploadMessage,
-  uploadMessage,
   fileInputRef,
   startScreenShare,
   toggleMic,
   micEnabled,
 }: InitialRecorderViewProps) {
-  const { setBlob } = useBlobStore();
+  const { setBlob, title, setTitle } = useBlobStore(
+    useShallow((s) => ({ setBlob: s.setBlob, title: s.title, setTitle: s.setTitle }))
+  );
+
+  const {
+    sidebarOpen,
+    setSidebarOpen,
+    uploadedFileUrl,
+    setUploadedFileUrl,
+    setUploadedFileType,
+    setUploadMessage,
+    uploadMessage,
+  } = useRecorderStore(
+    useShallow((s) => ({
+      sidebarOpen: s.sidebarOpen,
+      setSidebarOpen: s.setSidebarOpen,
+      uploadedFileUrl: s.uploadedFileUrl,
+      setUploadedFileUrl: s.setUploadedFileUrl,
+      setUploadedFileType: s.setUploadedFileType,
+      setUploadMessage: s.setUploadMessage,
+      uploadMessage: s.uploadMessage,
+    }))
+  );
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/app/store/recorderStore.ts
+++ b/app/store/recorderStore.ts
@@ -1,0 +1,75 @@
+import { create } from "zustand";
+
+type RecorderFormat = "webm" | "mp4";
+
+interface RecorderStore {
+  // Upload state
+  uploadMessage: string;
+  uploadedFileUrl: string | null;
+  uploadedFileType: string | null;
+  format: RecorderFormat;
+
+  // Recording / save flow
+  recordingTimer: number;
+  showSavePopup: boolean;
+  processingDownload: boolean;
+
+  // Video playback
+  videoPlaying: boolean;
+  videoCurrentTime: number;
+  videoDuration: number;
+
+  // Layout
+  sidebarOpen: boolean;
+  isSavePublishDisabled: boolean;
+
+  // Setters
+  setUploadMessage: (uploadMessage: string) => void;
+  setUploadedFileUrl: (uploadedFileUrl: string | null) => void;
+  setUploadedFileType: (uploadedFileType: string | null) => void;
+  setFormat: (format: RecorderFormat) => void;
+  setRecordingTimer: (value: number | ((prev: number) => number)) => void;
+  setShowSavePopup: (showSavePopup: boolean) => void;
+  setProcessingDownload: (processingDownload: boolean) => void;
+  setVideoPlaying: (videoPlaying: boolean) => void;
+  setVideoCurrentTime: (videoCurrentTime: number) => void;
+  setVideoDuration: (videoDuration: number) => void;
+  setSidebarOpen: (sidebarOpen: boolean) => void;
+  setIsSavePublishDisabled: (isSavePublishDisabled: boolean) => void;
+  reset: () => void;
+}
+
+const initialState = {
+  uploadMessage: "",
+  uploadedFileUrl: null,
+  uploadedFileType: null,
+  format: "webm" as RecorderFormat,
+  recordingTimer: 0,
+  showSavePopup: false,
+  processingDownload: false,
+  videoPlaying: false,
+  videoCurrentTime: 0,
+  videoDuration: 0,
+  sidebarOpen: false,
+  isSavePublishDisabled: false,
+};
+
+export const useRecorderStore = create<RecorderStore>((set) => ({
+  ...initialState,
+  setUploadMessage: (uploadMessage) => set({ uploadMessage }),
+  setUploadedFileUrl: (uploadedFileUrl) => set({ uploadedFileUrl }),
+  setUploadedFileType: (uploadedFileType) => set({ uploadedFileType }),
+  setFormat: (format) => set({ format }),
+  setRecordingTimer: (value) =>
+    set((state) => ({
+      recordingTimer: typeof value === "function" ? value(state.recordingTimer) : value,
+    })),
+  setShowSavePopup: (showSavePopup) => set({ showSavePopup }),
+  setProcessingDownload: (processingDownload) => set({ processingDownload }),
+  setVideoPlaying: (videoPlaying) => set({ videoPlaying }),
+  setVideoCurrentTime: (videoCurrentTime) => set({ videoCurrentTime }),
+  setVideoDuration: (videoDuration) => set({ videoDuration }),
+  setSidebarOpen: (sidebarOpen) => set({ sidebarOpen }),
+  setIsSavePublishDisabled: (isSavePublishDisabled) => set({ isSavePublishDisabled }),
+  reset: () => set({ ...initialState }),
+}));


### PR DESCRIPTION
### changes
- **New store** `app/store/recorderStore.ts` (mirrors `blobStore` conventions) holding the recorder's non-ref UI state — upload fields, save-flow, video playback, and layout — with granular setters + `reset`.
- **`useRecorderState`** converted into a thin store-backed shim (strangler pattern): same return shape, but state now lives in the store; refs stay as local `useRef`s. `useRecordingTimer` untouched.
- **`RecorderClient`** no longer prop-drills into its child views — keeps only the fields it uses directly.
- **`RecorderWorkspaceView`** & **`InitialRecorderView`** now read state from `recorderStore` (and `title`/`setBlob` from `blobStore`) via `useShallow` selectors. Grandchild components are unchanged.

### Removed
- 14 `useState` calls from `useRecorderState` (moved to store).
- ~18 drilled props from `RecorderWorkspaceView`, ~10 from `InitialRecorderView`.
- `saveMessage` kept as a local const (was always `""`, no setter) — intentionally not stored.

partial fixes #150 
