### PR TITLE
refactor(#150): back useScreenRecorder with a recording store

### DIFF
--- a/app/hooks/useScreenRecorder.ts
+++ b/app/hooks/useScreenRecorder.ts
@@ -1,6 +1,8 @@
 "use client";
-import { useRef, useState } from "react";
+import { useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useBlobStore } from "../store/blobStore";
+import { useRecordingStore } from "../store/recordingStore";
 import { toast } from "sonner";
 
 // Build a combined screen + audio MediaStream. A silent oscillator is added
@@ -85,13 +87,27 @@ export const useScreenRecorder = () => {
   const chunksRef = useRef<Blob[]>([]);
   const hasFinalizedRef = useRef(false);
   const recorderMimeTypeRef = useRef("video/webm");
-  const [recording, setRecording] = useState(false);
-  const [videoUrl, setVideoUrl] = useState<string | null>(null);
-  const [micEnabled, setMicEnabled] = useState(false);
-  const [screenStream, setScreenStream] = useState<MediaStream | null>(null);
-  const [recordingDuration, setRecordingDuration] = useState(0);
-  const [showScreenShareModal, setShowScreenShareModal] = useState(false);
   const recordingStartTimeRef = useRef<number>(0);
+
+  const { recording, videoUrl, micEnabled, screenStream, recordingDuration, showScreenShareModal } =
+    useRecordingStore(
+      useShallow((state) => ({
+        recording: state.recording,
+        videoUrl: state.videoUrl,
+        micEnabled: state.micEnabled,
+        screenStream: state.screenStream,
+        recordingDuration: state.recordingDuration,
+        showScreenShareModal: state.showScreenShareModal,
+      }))
+    );
+  const setRecording = useRecordingStore((state) => state.setRecording);
+  const setVideoUrl = useRecordingStore((state) => state.setVideoUrl);
+  const toggleMic = useRecordingStore((state) => state.toggleMic);
+  const setScreenStream = useRecordingStore((state) => state.setScreenStream);
+  const setRecordingDuration = useRecordingStore((state) => state.setRecordingDuration);
+  const setShowScreenShareModal = useRecordingStore((state) => state.setShowScreenShareModal);
+  const resetRecordingState = useRecordingStore((state) => state.reset);
+
   const setBlob = useBlobStore((state) => state.setBlob);
   const setSourceDuration = useBlobStore((state) => state.setSourceDuration);
 
@@ -122,8 +138,6 @@ export const useScreenRecorder = () => {
     setScreenStream(null);
     setRecording(false);
   };
-
-  const toggleMic = () => setMicEnabled((prev) => !prev);
 
   const startRecording = async () => {
     try {
@@ -203,10 +217,8 @@ export const useScreenRecorder = () => {
   };
 
   const reset = () => {
-    setVideoUrl(null);
-    setScreenStream(null);
+    resetRecordingState();
     screenStreamRef.current = null;
-    setRecordingDuration(0);
     setSourceDuration(0);
   };
 

--- a/app/store/recordingStore.ts
+++ b/app/store/recordingStore.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+
+// Recording-engine value/boolean state extracted from useScreenRecorder.
+// MediaRecorder instances and other refs stay in the hook; only the
+// serializable UI/value state lives here.
+export const useRecordingStore = create<{
+  recording: boolean;
+  videoUrl: string | null;
+  micEnabled: boolean;
+  screenStream: MediaStream | null;
+  recordingDuration: number;
+  showScreenShareModal: boolean;
+  setRecording: (recording: boolean) => void;
+  setVideoUrl: (videoUrl: string | null) => void;
+  setMicEnabled: (micEnabled: boolean) => void;
+  toggleMic: () => void;
+  setScreenStream: (screenStream: MediaStream | null) => void;
+  setRecordingDuration: (seconds: number) => void;
+  setShowScreenShareModal: (show: boolean) => void;
+  reset: () => void;
+}>((set) => ({
+  recording: false,
+  videoUrl: null,
+  micEnabled: false,
+  screenStream: null,
+  recordingDuration: 0,
+  showScreenShareModal: false,
+  setRecording: (recording) => set({ recording }),
+  setVideoUrl: (videoUrl) => set({ videoUrl }),
+  setMicEnabled: (micEnabled) => set({ micEnabled }),
+  toggleMic: () => set((state) => ({ micEnabled: !state.micEnabled })),
+  setScreenStream: (screenStream) => set({ screenStream }),
+  setRecordingDuration: (recordingDuration) => set({ recordingDuration }),
+  setShowScreenShareModal: (showScreenShareModal) => set({ showScreenShareModal }),
+  reset: () => set({ videoUrl: null, screenStream: null, recordingDuration: 0 }),
+}));


### PR DESCRIPTION
partial fixes #150 
### changes
Moves `useScreenRecorder`'s recording-engine value/boolean state out of local `useState` and into a dedicated Zustand store
(`app/store/recordingStore.ts`), following the strangler pattern.

- New `app/store/recordingStore.ts` mirrors the existing `blobStore.ts` convention:
  granular selectors, a `toggleMic` action, and a `reset` scoped to store-owned fields.
- `useScreenRecorder` now reads state from the store via `useShallow`
  (from `zustand/react/shallow`) and writes via store setters.
- All MediaRecorder logic and `useRef`s stay in the hook.

### useState / props removed
Six `useState` removed from `app/hooks/useScreenRecorder.ts`, now backed by the store:
- `recording`
- `videoUrl`
- `micEnabled` (the `toggleMic` action moved into the store)
- `screenStream`
- `recordingDuration`
- `showScreenShareModal`
