### PR TITLE
refactor(#150): move editor state into editorStore, drop prop-drilling

### DIFF
--- a/app/(signed)/editor/EditorClient.tsx
+++ b/app/(signed)/editor/EditorClient.tsx
@@ -134,15 +134,14 @@ export default function EditorPage() {
   return (
     <main className="editor-page flex flex-col min-h-screen w-full bg-gray-50 overflow-hidden">
       <EditorModals
-        editorState={editorState}
         exportFlow={exportFlow}
         onSaveDemo={onSaveDemo}
         resolvedDuration={resolvedDuration}
+        playerRef={editorState.playerRef}
       />
 
       <div className="flex flex-1 min-h-0 overflow-hidden relative">
         <EditorSidebarRegion
-          editorState={editorState}
           text={text}
           zoom={zoom}
           subtitles={subtitles}
@@ -151,10 +150,12 @@ export default function EditorPage() {
         />
 
         <EditorPreviewRegion
-          editorState={editorState}
           text={text}
           zoom={zoom}
           subtitles={subtitles}
+          playerRef={editorState.playerRef}
+          canvasRef={editorState.canvasRef}
+          videoContainerRef={editorState.videoContainerRef}
           isDark={isDark}
           processing={processing}
           nativeAspectRatio={nativeAspectRatio}

--- a/app/(signed)/editor/components/EditorModals.tsx
+++ b/app/(signed)/editor/components/EditorModals.tsx
@@ -1,25 +1,55 @@
 import axios from "axios";
 import { Toaster } from "react-hot-toast";
+import { useShallow } from "zustand/react/shallow";
 
 import ExportResultModal from "@/app/components/ExportResultModal";
 import ExportSettingsModal from "@/app/components/ExportSettingsModal";
 import SaveDemoModal from "@/app/components/SaveDemoModal";
 import ZoomEffectsPopup from "@/app/components/ZoomEffectsPopup";
+import { useEditorStore } from "@/app/store/editor/editorStore";
 import type { EditorState, ExportFlowApi } from "../apiTypes";
 
 interface EditorModalsProps {
-  editorState: EditorState;
   exportFlow: ExportFlowApi;
   onSaveDemo: (data: { title: string; description: string }) => Promise<void>;
   resolvedDuration: number;
+  playerRef: EditorState["playerRef"];
 }
 
 export default function EditorModals({
-  editorState,
   exportFlow,
   onSaveDemo,
   resolvedDuration,
+  playerRef,
 }: EditorModalsProps) {
+  const {
+    isZoomPopupOpen,
+    setIsZoomPopupOpen,
+    zoomEffects,
+    setZoomEffects,
+    currentTime,
+    showSaveDemoModal,
+    setShowSaveDemoModal,
+    sidebarTitle,
+    sidebarDescription,
+    savingDemo,
+    demoSaved,
+  } = useEditorStore(
+    useShallow((s) => ({
+      isZoomPopupOpen: s.isZoomPopupOpen,
+      setIsZoomPopupOpen: s.setIsZoomPopupOpen,
+      zoomEffects: s.zoomEffects,
+      setZoomEffects: s.setZoomEffects,
+      currentTime: s.currentTime,
+      showSaveDemoModal: s.showSaveDemoModal,
+      setShowSaveDemoModal: s.setShowSaveDemoModal,
+      sidebarTitle: s.sidebarTitle,
+      sidebarDescription: s.sidebarDescription,
+      savingDemo: s.savingDemo,
+      demoSaved: s.demoSaved,
+    }))
+  );
+
   const { pendingExport, shareLinkSaved, setShowExportResultModal, setPendingExport } = exportFlow;
 
   return (
@@ -75,32 +105,32 @@ export default function EditorModals({
       />
 
       <ZoomEffectsPopup
-        isOpen={editorState.isZoomPopupOpen}
-        onClose={() => editorState.setIsZoomPopupOpen(false)}
-        zoomEffects={editorState.zoomEffects}
-        onZoomEffectsChange={editorState.setZoomEffects}
-        currentTime={editorState.currentTime}
+        isOpen={isZoomPopupOpen}
+        onClose={() => setIsZoomPopupOpen(false)}
+        zoomEffects={zoomEffects}
+        onZoomEffectsChange={setZoomEffects}
+        currentTime={currentTime}
         duration={resolvedDuration}
         onSeek={(time) => {
-          if (editorState.playerRef.current) {
-            const player = editorState.playerRef.current.getInternalPlayer();
+          if (playerRef.current) {
+            const player = playerRef.current.getInternalPlayer();
             if (player) {
               player.currentTime = time;
               player.dispatchEvent(new Event("seeking"));
-              editorState.playerRef.current.seekTo(time, "seconds");
+              playerRef.current.seekTo(time, "seconds");
             }
           }
         }}
       />
 
       <SaveDemoModal
-        isOpen={editorState.showSaveDemoModal}
-        onClose={() => editorState.setShowSaveDemoModal(false)}
+        isOpen={showSaveDemoModal}
+        onClose={() => setShowSaveDemoModal(false)}
         onSave={onSaveDemo}
-        initialTitle={editorState.sidebarTitle}
-        initialDescription={editorState.sidebarDescription}
-        processing={editorState.savingDemo}
-        isSaved={editorState.demoSaved}
+        initialTitle={sidebarTitle}
+        initialDescription={sidebarDescription}
+        processing={savingDemo}
+        isSaved={demoSaved}
       />
     </>
   );

--- a/app/(signed)/editor/components/EditorPreviewRegion.tsx
+++ b/app/(signed)/editor/components/EditorPreviewRegion.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useShallow } from "zustand/react/shallow";
 
 import CustomVideoControls from "@/app/components/CustomVideoControls";
+import { useEditorStore } from "@/app/store/editor/editorStore";
 import EditorTimelineSection from "./EditorTimelineSection";
 import EditorVideoStage from "./EditorVideoStage";
 import TextColorToolbar from "./TextColorToolbar";
@@ -10,10 +12,12 @@ import type { EditorState, SubtitlesApi, TextOverlaysApi, ZoomEditorApi } from "
 type EditorMode = "main" | "trim" | "zoom" | "text";
 
 interface EditorPreviewRegionProps {
-  editorState: EditorState;
   text: TextOverlaysApi;
   zoom: ZoomEditorApi;
   subtitles: SubtitlesApi;
+  playerRef: EditorState["playerRef"];
+  canvasRef: EditorState["canvasRef"];
+  videoContainerRef: EditorState["videoContainerRef"];
   isDark: boolean;
   processing: boolean;
   nativeAspectRatio: string;
@@ -38,20 +42,60 @@ interface EditorPreviewRegionProps {
 }
 
 export default function EditorPreviewRegion(props: EditorPreviewRegionProps) {
-  const { editorState, text, zoom, subtitles, isDark, processing, nativeAspectRatio } = props;
+  const { text, zoom, subtitles, isDark, processing, nativeAspectRatio } = props;
+  const { playerRef, canvasRef, videoContainerRef } = props;
   const { resolvedDuration, playbackSpeed, setPlaybackSpeed, mode, setMode } = props;
   const { segments, setSegments, childHandleProgress, setChildHandleProgress } = props;
   const { handleMouseDown, handleMouseUp, handleFullscreen, getBackgroundStyle } = props;
   const { handleTimelineChange, handleResetTimeline } = props;
   const { zoomFocusStageRef, lastInteractionRef, isDraggingTimelineRef } = props;
-  const { videoUrl, selectedBackground, isFullscreen, tool, playerRef } = editorState;
+
+  const {
+    videoUrl,
+    selectedBackground,
+    isFullscreen,
+    tool,
+    aspectRatio,
+    browserFrameDrawBorder,
+    browserFrameDrawShadow,
+    currentTime,
+    setCurrentTime,
+    playing,
+    setPlaying,
+    volume,
+    setVolume,
+    textColor,
+    setTextColor,
+    textFont,
+    setTextFont,
+  } = useEditorStore(
+    useShallow((s) => ({
+      videoUrl: s.videoUrl,
+      selectedBackground: s.selectedBackground,
+      isFullscreen: s.isFullscreen,
+      tool: s.tool,
+      aspectRatio: s.aspectRatio,
+      browserFrameDrawBorder: s.browserFrameDrawBorder,
+      browserFrameDrawShadow: s.browserFrameDrawShadow,
+      currentTime: s.currentTime,
+      setCurrentTime: s.setCurrentTime,
+      playing: s.playing,
+      setPlaying: s.setPlaying,
+      volume: s.volume,
+      setVolume: s.setVolume,
+      textColor: s.textColor,
+      setTextColor: s.setTextColor,
+      textFont: s.textFont,
+      setTextFont: s.setTextFont,
+    }))
+  );
 
   const layout = computePreviewLayout({
     selectedBackground,
-    aspectRatio: editorState.aspectRatio,
+    aspectRatio,
     nativeAspectRatio,
-    browserFrameDrawBorder: editorState.browserFrameDrawBorder,
-    browserFrameDrawShadow: editorState.browserFrameDrawShadow,
+    browserFrameDrawBorder,
+    browserFrameDrawShadow,
     isFullscreen,
   });
   const { hasCanvasBackground, previewObjectFit, previewFrameAspectRatio } = layout;
@@ -63,7 +107,7 @@ export default function EditorPreviewRegion(props: EditorPreviewRegionProps) {
 
       <div className="flex flex-col items-center w-full max-w-[1200px] mx-auto rounded-2xl bg-transparent">
         <div
-          ref={editorState.videoContainerRef}
+          ref={videoContainerRef}
           className={`monitor-viewport relative w-full max-w-[1120px] sm:h-auto rounded-2xl border ${
             isFullscreen ? "border-[#7C5CFC] shadow-lg" : "border-[#E6E1FA]"
           } flex flex-col items-center justify-center mb-1 transition-all duration-300`}
@@ -101,10 +145,11 @@ export default function EditorPreviewRegion(props: EditorPreviewRegionProps) {
             }}
           >
             <EditorVideoStage
-              editorState={editorState}
               text={text}
               zoom={zoom}
               subtitles={subtitles}
+              canvasRef={canvasRef}
+              playerRef={playerRef}
               hasCanvasBackground={hasCanvasBackground}
               previewObjectFit={previewObjectFit}
               playbackSpeed={playbackSpeed}
@@ -123,16 +168,16 @@ export default function EditorPreviewRegion(props: EditorPreviewRegionProps) {
               <CustomVideoControls
                 playerRef={playerRef}
                 duration={resolvedDuration}
-                currentTime={editorState.currentTime}
+                currentTime={currentTime}
                 setCurrentTime={(t) => {
                   lastInteractionRef.current = Date.now();
-                  editorState.setCurrentTime(t);
+                  setCurrentTime(t);
                   playerRef.current?.seekTo(t, "seconds");
                 }}
-                setPlaying={editorState.setPlaying}
-                playing={editorState.playing}
-                volume={editorState.volume}
-                setVolume={editorState.setVolume}
+                setPlaying={setPlaying}
+                playing={playing}
+                volume={volume}
+                setVolume={setVolume}
                 playbackSpeed={playbackSpeed}
                 handleFullscreen={handleFullscreen}
               />
@@ -142,19 +187,19 @@ export default function EditorPreviewRegion(props: EditorPreviewRegionProps) {
       </div>
       {tool === "text" && (
         <TextColorToolbar
-          textColor={editorState.textColor}
-          setTextColor={editorState.setTextColor}
-          textFont={editorState.textFont}
-          setTextFont={editorState.setTextFont}
+          textColor={textColor}
+          setTextColor={setTextColor}
+          textFont={textFont}
+          setTextFont={setTextFont}
         />
       )}
 
       {videoUrl && (
         <div className="mr-2 mt-8 mb-5 pr-8 sm:mr-0 mx-4 sm:mx-8">
           <EditorTimelineSection
-            editorState={editorState}
             zoom={zoom}
             text={text}
+            playerRef={playerRef}
             resolvedDuration={resolvedDuration}
             playbackSpeed={playbackSpeed}
             setPlaybackSpeed={setPlaybackSpeed}

--- a/app/(signed)/editor/components/EditorSidebarRegion.tsx
+++ b/app/(signed)/editor/components/EditorSidebarRegion.tsx
@@ -1,13 +1,14 @@
 import { X } from "lucide-react";
 import axios from "axios";
 import { toast } from "react-hot-toast";
+import { useShallow } from "zustand/react/shallow";
 
 import EditorSidebar from "@/app/components/EditorSidebar";
 import SidemenuDashboard from "@/app/components/SidemenuDashboard";
 import ZoomModal from "@/app/components/ZoomModal";
+import { useEditorStore } from "@/app/store/editor/editorStore";
 import type {
   CtaItem,
-  EditorState,
   ExportFlowApi,
   SubtitlesApi,
   TextOverlaysApi,
@@ -15,7 +16,6 @@ import type {
 } from "../apiTypes";
 
 interface EditorSidebarRegionProps {
-  editorState: EditorState;
   text: TextOverlaysApi;
   zoom: ZoomEditorApi;
   subtitles: SubtitlesApi;
@@ -24,22 +24,74 @@ interface EditorSidebarRegionProps {
 }
 
 export default function EditorSidebarRegion({
-  editorState,
   text,
   zoom,
   subtitles,
   exportFlow,
   thumbnailUrl,
 }: EditorSidebarRegionProps) {
-  const toggleDashboardMenu = () =>
-    editorState.setIsDashboardMenuOpen(!editorState.isDashboardMenuOpen);
-  const closeDashboardMenu = () => editorState.setIsDashboardMenuOpen(false);
+  const {
+    isSidebarOpen,
+    setIsSidebarOpen,
+    isDashboardMenuOpen,
+    setIsDashboardMenuOpen,
+    savedDemoId,
+    ctas,
+    setCtas,
+    sidebarTitle,
+    selectedBackground,
+    setSelectedBackground,
+    backgroundType,
+    setBackgroundType,
+    customBackground,
+    setCustomBackground,
+    aspectRatio,
+    setAspectRatio,
+    browserFrameMode,
+    setBrowserFrameMode,
+    browserFrameDrawShadow,
+    setBrowserFrameDrawShadow,
+    browserFrameDrawBorder,
+    setBrowserFrameDrawBorder,
+    savingDemo,
+    demoSaved,
+    setShowSaveDemoModal,
+  } = useEditorStore(
+    useShallow((s) => ({
+      isSidebarOpen: s.isSidebarOpen,
+      setIsSidebarOpen: s.setIsSidebarOpen,
+      isDashboardMenuOpen: s.isDashboardMenuOpen,
+      setIsDashboardMenuOpen: s.setIsDashboardMenuOpen,
+      savedDemoId: s.savedDemoId,
+      ctas: s.ctas,
+      setCtas: s.setCtas,
+      sidebarTitle: s.sidebarTitle,
+      selectedBackground: s.selectedBackground,
+      setSelectedBackground: s.setSelectedBackground,
+      backgroundType: s.backgroundType,
+      setBackgroundType: s.setBackgroundType,
+      customBackground: s.customBackground,
+      setCustomBackground: s.setCustomBackground,
+      aspectRatio: s.aspectRatio,
+      setAspectRatio: s.setAspectRatio,
+      browserFrameMode: s.browserFrameMode,
+      setBrowserFrameMode: s.setBrowserFrameMode,
+      browserFrameDrawShadow: s.browserFrameDrawShadow,
+      setBrowserFrameDrawShadow: s.setBrowserFrameDrawShadow,
+      browserFrameDrawBorder: s.browserFrameDrawBorder,
+      setBrowserFrameDrawBorder: s.setBrowserFrameDrawBorder,
+      savingDemo: s.savingDemo,
+      demoSaved: s.demoSaved,
+      setShowSaveDemoModal: s.setShowSaveDemoModal,
+    }))
+  );
+
+  const toggleDashboardMenu = () => setIsDashboardMenuOpen(!isDashboardMenuOpen);
+  const closeDashboardMenu = () => setIsDashboardMenuOpen(false);
 
   // CTA CRUD. Definitions live in the Cta table (not demo.editing) and are
   // managed over HTTP. Local state is updated optimistically and rolled back on
   // failure. The API enforces ownership (401 anon / 404 non-owner).
-  const { savedDemoId, ctas, setCtas } = editorState;
-
   const handleAddCta = async (data: { label: string; url: string; placement?: string }) => {
     if (!savedDemoId) {
       toast.error("Save the demo before adding a call to action");
@@ -137,23 +189,23 @@ export default function EditorSidebarRegion({
   };
 
   const sidebarProps = {
-    title: editorState.sidebarTitle,
+    title: sidebarTitle,
     onExportWebM: () => exportFlow.setShowExportSettings(true),
     thumbnailUrl: thumbnailUrl || undefined,
-    selectedBackground: editorState.selectedBackground,
-    setSelectedBackground: editorState.setSelectedBackground,
-    backgroundType: editorState.backgroundType,
-    setBackgroundType: editorState.setBackgroundType,
-    customBackground: editorState.customBackground,
-    setCustomBackground: editorState.setCustomBackground,
-    aspectRatio: editorState.aspectRatio,
-    setAspectRatio: editorState.setAspectRatio,
-    browserFrameMode: editorState.browserFrameMode,
-    setBrowserFrameMode: editorState.setBrowserFrameMode,
-    browserFrameDrawShadow: editorState.browserFrameDrawShadow,
-    setBrowserFrameDrawShadow: editorState.setBrowserFrameDrawShadow,
-    browserFrameDrawBorder: editorState.browserFrameDrawBorder,
-    setBrowserFrameDrawBorder: editorState.setBrowserFrameDrawBorder,
+    selectedBackground: selectedBackground,
+    setSelectedBackground: setSelectedBackground,
+    backgroundType: backgroundType,
+    setBackgroundType: setBackgroundType,
+    customBackground: customBackground,
+    setCustomBackground: setCustomBackground,
+    aspectRatio: aspectRatio,
+    setAspectRatio: setAspectRatio,
+    browserFrameMode: browserFrameMode,
+    setBrowserFrameMode: setBrowserFrameMode,
+    browserFrameDrawShadow: browserFrameDrawShadow,
+    setBrowserFrameDrawShadow: setBrowserFrameDrawShadow,
+    browserFrameDrawBorder: browserFrameDrawBorder,
+    setBrowserFrameDrawBorder: setBrowserFrameDrawBorder,
     textOverlayInput: text.textOverlayInput,
     setTextOverlayInput: text.handleTextOverlayInputChange,
     textOverlayFontFamily: text.textOverlayFontFamily,
@@ -167,11 +219,11 @@ export default function EditorSidebarRegion({
     onClearSubtitles: subtitles.handleSkipSubtitles,
     subtitlesLoading: subtitles.subtitlesLoading,
     hasSubtitles: subtitles.subtitleCues.length > 0,
-    onOpenSaveDemo: () => editorState.setShowSaveDemoModal(true),
-    savingDemo: editorState.savingDemo,
-    demoSaved: editorState.demoSaved,
+    onOpenSaveDemo: () => setShowSaveDemoModal(true),
+    savingDemo: savingDemo,
+    demoSaved: demoSaved,
     onToggleDashboardMenu: toggleDashboardMenu,
-    ctas: editorState.ctas,
+    ctas: ctas,
     onAddCta: handleAddCta,
     onUpdateCta: handleUpdateCta,
     onDeleteCta: handleDeleteCta,
@@ -196,16 +248,16 @@ export default function EditorSidebarRegion({
         </div>
       </div>
 
-      {editorState.isSidebarOpen && (
+      {isSidebarOpen && (
         <div className="fixed inset-0 z-50 flex md:hidden">
           <div
             className="fixed inset-0 bg-black bg-opacity-40"
-            onClick={() => editorState.setIsSidebarOpen(false)}
+            onClick={() => setIsSidebarOpen(false)}
           />
           <div className="relative w-full max-w-xs h-full bg-white shadow-lg z-50 animate-slide-in-left">
             <button
               className="absolute top-4 right-4 text-[#7C5CFC]"
-              onClick={() => editorState.setIsSidebarOpen(false)}
+              onClick={() => setIsSidebarOpen(false)}
               aria-label="Close sidebar"
             >
               <X size={28} />
@@ -215,7 +267,7 @@ export default function EditorSidebarRegion({
         </div>
       )}
 
-      {editorState.isDashboardMenuOpen && (
+      {isDashboardMenuOpen && (
         <div className="fixed inset-0 z-50 flex">
           <div
             className="fixed inset-0 bg-black/10"

--- a/app/(signed)/editor/components/EditorTimelineSection.tsx
+++ b/app/(signed)/editor/components/EditorTimelineSection.tsx
@@ -1,14 +1,16 @@
 import React from "react";
+import { useShallow } from "zustand/react/shallow";
 
 import TimelineRuler from "@/app/components/TimeLine";
+import { useEditorStore } from "@/app/store/editor/editorStore";
 import type { EditorState, TextOverlaysApi, ZoomEditorApi } from "../apiTypes";
 
 type EditorMode = "main" | "trim" | "zoom" | "text";
 
 interface EditorTimelineSectionProps {
-  editorState: EditorState;
   zoom: ZoomEditorApi;
   text: TextOverlaysApi;
+  playerRef: EditorState["playerRef"];
   resolvedDuration: number;
   playbackSpeed: number;
   setPlaybackSpeed: (speed: number) => void;
@@ -25,9 +27,9 @@ interface EditorTimelineSectionProps {
 }
 
 export default function EditorTimelineSection({
-  editorState,
   zoom,
   text,
+  playerRef,
   resolvedDuration,
   playbackSpeed,
   setPlaybackSpeed,
@@ -47,12 +49,22 @@ export default function EditorTimelineSection({
     setCurrentTime,
     playing,
     setPlaying,
-    playerRef,
     timelineStartTime,
     timelineEndTime,
     setTimelineStartTime,
     setTimelineEndTime,
-  } = editorState;
+  } = useEditorStore(
+    useShallow((s) => ({
+      currentTime: s.currentTime,
+      setCurrentTime: s.setCurrentTime,
+      playing: s.playing,
+      setPlaying: s.setPlaying,
+      timelineStartTime: s.timelineStartTime,
+      timelineEndTime: s.timelineEndTime,
+      setTimelineStartTime: s.setTimelineStartTime,
+      setTimelineEndTime: s.setTimelineEndTime,
+    }))
+  );
 
   if (resolvedDuration <= 0) {
     return (

--- a/app/(signed)/editor/components/EditorVideoStage.tsx
+++ b/app/(signed)/editor/components/EditorVideoStage.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { useShallow } from "zustand/react/shallow";
 
+import { useEditorStore } from "@/app/store/editor/editorStore";
 import SubtitleOverlay from "./SubtitleOverlay";
 import TextOverlayLayer from "./TextOverlayLayer";
 import VideoPreviewPlayer from "./VideoPreviewPlayer";
@@ -9,10 +11,11 @@ import type { EditorState, SubtitlesApi, TextOverlaysApi, ZoomEditorApi } from "
 type EditorMode = "main" | "trim" | "zoom" | "text";
 
 interface EditorVideoStageProps {
-  editorState: EditorState;
   text: TextOverlaysApi;
   zoom: ZoomEditorApi;
   subtitles: SubtitlesApi;
+  canvasRef: EditorState["canvasRef"];
+  playerRef: EditorState["playerRef"];
   hasCanvasBackground: boolean;
   previewObjectFit: "contain";
   playbackSpeed: number;
@@ -26,10 +29,11 @@ interface EditorVideoStageProps {
 }
 
 export default function EditorVideoStage({
-  editorState,
   text,
   zoom,
   subtitles,
+  canvasRef,
+  playerRef,
   hasCanvasBackground,
   previewObjectFit,
   playbackSpeed,
@@ -41,8 +45,30 @@ export default function EditorVideoStage({
   lastInteractionRef,
   isDraggingTimelineRef,
 }: EditorVideoStageProps) {
-  const { videoUrl, playing, volume, tool, canvasRef, playerRef, currentTime, duration } =
-    editorState;
+  const {
+    videoUrl,
+    playing,
+    volume,
+    tool,
+    currentTime,
+    duration,
+    setCurrentTime,
+    setDuration,
+    setPlaying,
+  } = useEditorStore(
+    useShallow((s) => ({
+      videoUrl: s.videoUrl,
+      playing: s.playing,
+      volume: s.volume,
+      tool: s.tool,
+      currentTime: s.currentTime,
+      duration: s.duration,
+      setCurrentTime: s.setCurrentTime,
+      setDuration: s.setDuration,
+      setPlaying: s.setPlaying,
+    }))
+  );
+
   const { isDraggingZoomTarget, handleZoomTargetMouseDown, preview } = zoom;
   const {
     shouldApplyZoomPreview,
@@ -84,10 +110,10 @@ export default function EditorVideoStage({
           hasCanvasBackground={hasCanvasBackground}
           isDraggingTimelineRef={isDraggingTimelineRef}
           lastInteractionRef={lastInteractionRef}
-          setCurrentTime={editorState.setCurrentTime}
+          setCurrentTime={setCurrentTime}
           childHandleProgress={childHandleProgress}
-          setDuration={editorState.setDuration}
-          setPlaying={editorState.setPlaying}
+          setDuration={setDuration}
+          setPlaying={setPlaying}
           duration={duration}
         />
       </div>

--- a/app/(signed)/editor/hooks/useEditorState.ts
+++ b/app/(signed)/editor/hooks/useEditorState.ts
@@ -1,6 +1,7 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 import ReactPlayer from "react-player";
-import { ZoomEffect } from "@/app/types/editor/zoom-effect";
+
+import { useEditorStore } from "@/app/store/editor/editorStore";
 
 export interface Segment {
   start: string;
@@ -17,139 +18,28 @@ export interface CtaItem {
   order: number;
 }
 
+/**
+ * Thin compatibility shim over the editorStore (issue #150).
+ *
+ * The editor state used to live here as 34 `useState` calls. It now lives in
+ * `useEditorStore`; this hook returns the SAME shape (all store fields + setters,
+ * plus the three locally-created refs) so existing consumers keep compiling and
+ * `EditorState = ReturnType<typeof useEditorState>` keeps resolving.
+ *
+ * Migrated consumers (EditorClient region components) read from `useEditorStore`
+ * via granular selectors directly; this shim stays in place for every consumer
+ * that has not been migrated yet (the feature sub-hooks).
+ */
 export function useEditorState() {
-  const [params, setParams] = useState<URLSearchParams | null>(null);
-  const [videoUrl, setVideoUrl] = useState<string | null>(null);
-  const [playing, setPlaying] = useState(false);
-  const [timelineStartTime, setTimelineStartTime] = useState<number>(0);
-  const [timelineEndTime, setTimelineEndTime] = useState(0);
+  const store = useEditorStore();
 
-  // Segments state
-  const [loadedSegments, setLoadedSegments] = useState<Segment[] | null>(null);
-  const [currentSegments, setCurrentSegments] = useState<Segment[]>([]);
-
-  // Tool state
-  const [tool, setTool] = useState<"none" | "blur" | "rect" | "arrow" | "text">("none");
-  const [textColor, setTextColor] = useState("#000000");
-  const [textFont, setTextFont] = useState("16px sans-serif");
-
-  // Sidebar state
-  const [sidebarTitle, setSidebarTitle] = useState("");
-  const [sidebarDescription, setSidebarDescription] = useState("");
-
-  // CTA state (definitions live in the Cta table, not in demo.editing)
-  const [ctas, setCtas] = useState<CtaItem[]>([]);
-
-  // Modal state
-  const [showSaveDemoModal, setShowSaveDemoModal] = useState(false);
-  const [savingDemo, setSavingDemo] = useState(false);
-  const [demoSaved, setDemoSaved] = useState(false);
-  const [savedDemoId, setSavedDemoId] = useState<string | null>(null);
-
-  // UI state
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const [isDashboardMenuOpen, setIsDashboardMenuOpen] = useState(false);
-  const [isFullscreen, setIsFullscreen] = useState(false);
-
-  // Video state
-  const [currentTime, setCurrentTime] = useState(0);
-  const [duration, setDuration] = useState(0);
-  const [volume, setVolume] = useState(1);
-
-  // Zoom effects state
-  const [zoomEffects, setZoomEffects] = useState<ZoomEffect[]>([]);
-  const [isZoomPopupOpen, setIsZoomPopupOpen] = useState(false);
-
-  // Timeline input state
-  const [inputStartTime, setInputStartTime] = useState("00:00:00");
-  const [inputEndTime, setInputEndTime] = useState("00:00:00");
-
-  // Background state
-  const [selectedBackground, setSelectedBackground] = useState<string | null>(null);
-  const [backgroundType, setBackgroundType] = useState<string>("");
-  const [customBackground, setCustomBackground] = useState<File | null>(null);
-
-  // Aspect ratio state
-  const [aspectRatio, setAspectRatio] = useState<string>("native");
-  const [browserFrameMode, setBrowserFrameMode] = useState<BrowserFrameMode>("default");
-  const [browserFrameDrawShadow, setBrowserFrameDrawShadow] = useState<boolean>(true);
-  const [browserFrameDrawBorder, setBrowserFrameDrawBorder] = useState<boolean>(false);
-
-  // Refs
+  // Refs stay as refs — never in the store.
   const playerRef = useRef<ReactPlayer>(null!);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const videoContainerRef = useRef<HTMLDivElement>(null);
 
   return {
-    // State
-    params,
-    setParams,
-    videoUrl,
-    setVideoUrl,
-    playing,
-    setPlaying,
-    timelineStartTime,
-    setTimelineStartTime,
-    timelineEndTime,
-    setTimelineEndTime,
-    loadedSegments,
-    setLoadedSegments,
-    currentSegments,
-    setCurrentSegments,
-    tool,
-    setTool,
-    textColor,
-    setTextColor,
-    textFont,
-    setTextFont,
-    sidebarTitle,
-    setSidebarTitle,
-    sidebarDescription,
-    setSidebarDescription,
-    ctas,
-    setCtas,
-    showSaveDemoModal,
-    setShowSaveDemoModal,
-    savingDemo,
-    setSavingDemo,
-    demoSaved,
-    setDemoSaved,
-    savedDemoId,
-    setSavedDemoId,
-    isSidebarOpen,
-    setIsSidebarOpen,
-    isDashboardMenuOpen,
-    setIsDashboardMenuOpen,
-    isFullscreen,
-    setIsFullscreen,
-    currentTime,
-    setCurrentTime,
-    duration,
-    setDuration,
-    volume,
-    setVolume,
-    zoomEffects,
-    setZoomEffects,
-    isZoomPopupOpen,
-    setIsZoomPopupOpen,
-    inputStartTime,
-    setInputStartTime,
-    inputEndTime,
-    setInputEndTime,
-    selectedBackground,
-    setSelectedBackground,
-    backgroundType,
-    setBackgroundType,
-    customBackground,
-    setCustomBackground,
-    aspectRatio,
-    setAspectRatio,
-    browserFrameMode,
-    setBrowserFrameMode,
-    browserFrameDrawShadow,
-    setBrowserFrameDrawShadow,
-    browserFrameDrawBorder,
-    setBrowserFrameDrawBorder,
+    ...store,
     // Refs
     playerRef,
     canvasRef,

--- a/app/store/editor/editorStore.ts
+++ b/app/store/editor/editorStore.ts
@@ -1,0 +1,205 @@
+import type { Dispatch, SetStateAction } from "react";
+import { create } from "zustand";
+
+import type { ZoomEffect } from "@/app/types/editor/zoom-effect";
+import type {
+  BrowserFrameMode,
+  CtaItem,
+  Segment,
+} from "@/app/(signed)/editor/hooks/useEditorState";
+
+type ToolMode = "none" | "blur" | "rect" | "arrow" | "text";
+
+/**
+ * Central editor state store (issue #150). Holds the 34 non-ref fields that used
+ * to live in the useEditorState god-hook. Refs (playerRef, canvasRef,
+ * videoContainerRef) intentionally stay OUT of the store and remain React refs,
+ * created in the useEditorState shim / EditorClient.
+ *
+ * Setters mirror React's useState signature (`Dispatch<SetStateAction<T>>`) so the
+ * useEditorState shim keeps returning the exact same shape and every existing
+ * consumer — including functional updates like `setCtas(prev => ...)` — keeps
+ * working untouched.
+ */
+export interface EditorStoreState {
+  // Source
+  params: URLSearchParams | null;
+  videoUrl: string | null;
+
+  // Playback / video
+  playing: boolean;
+  currentTime: number;
+  duration: number;
+  volume: number;
+
+  // Timeline
+  timelineStartTime: number;
+  timelineEndTime: number;
+  inputStartTime: string;
+  inputEndTime: string;
+
+  // Segments
+  loadedSegments: Segment[] | null;
+  currentSegments: Segment[];
+
+  // Tool
+  tool: ToolMode;
+  textColor: string;
+  textFont: string;
+
+  // Sidebar / UI
+  sidebarTitle: string;
+  sidebarDescription: string;
+  isSidebarOpen: boolean;
+  isDashboardMenuOpen: boolean;
+  isFullscreen: boolean;
+
+  // CTA (definitions live in the Cta table, not in demo.editing)
+  ctas: CtaItem[];
+
+  // Modal / save
+  showSaveDemoModal: boolean;
+  savingDemo: boolean;
+  demoSaved: boolean;
+  savedDemoId: string | null;
+
+  // Zoom UI
+  zoomEffects: ZoomEffect[];
+  isZoomPopupOpen: boolean;
+
+  // Background
+  selectedBackground: string | null;
+  backgroundType: string;
+  customBackground: File | null;
+
+  // Aspect ratio / browser frame
+  aspectRatio: string;
+  browserFrameMode: BrowserFrameMode;
+  browserFrameDrawShadow: boolean;
+  browserFrameDrawBorder: boolean;
+
+  // Setters
+  setParams: Dispatch<SetStateAction<URLSearchParams | null>>;
+  setVideoUrl: Dispatch<SetStateAction<string | null>>;
+  setPlaying: Dispatch<SetStateAction<boolean>>;
+  setCurrentTime: Dispatch<SetStateAction<number>>;
+  setDuration: Dispatch<SetStateAction<number>>;
+  setVolume: Dispatch<SetStateAction<number>>;
+  setTimelineStartTime: Dispatch<SetStateAction<number>>;
+  setTimelineEndTime: Dispatch<SetStateAction<number>>;
+  setInputStartTime: Dispatch<SetStateAction<string>>;
+  setInputEndTime: Dispatch<SetStateAction<string>>;
+  setLoadedSegments: Dispatch<SetStateAction<Segment[] | null>>;
+  setCurrentSegments: Dispatch<SetStateAction<Segment[]>>;
+  setTool: Dispatch<SetStateAction<ToolMode>>;
+  setTextColor: Dispatch<SetStateAction<string>>;
+  setTextFont: Dispatch<SetStateAction<string>>;
+  setSidebarTitle: Dispatch<SetStateAction<string>>;
+  setSidebarDescription: Dispatch<SetStateAction<string>>;
+  setIsSidebarOpen: Dispatch<SetStateAction<boolean>>;
+  setIsDashboardMenuOpen: Dispatch<SetStateAction<boolean>>;
+  setIsFullscreen: Dispatch<SetStateAction<boolean>>;
+  setCtas: Dispatch<SetStateAction<CtaItem[]>>;
+  setShowSaveDemoModal: Dispatch<SetStateAction<boolean>>;
+  setSavingDemo: Dispatch<SetStateAction<boolean>>;
+  setDemoSaved: Dispatch<SetStateAction<boolean>>;
+  setSavedDemoId: Dispatch<SetStateAction<string | null>>;
+  setZoomEffects: Dispatch<SetStateAction<ZoomEffect[]>>;
+  setIsZoomPopupOpen: Dispatch<SetStateAction<boolean>>;
+  setSelectedBackground: Dispatch<SetStateAction<string | null>>;
+  setBackgroundType: Dispatch<SetStateAction<string>>;
+  setCustomBackground: Dispatch<SetStateAction<File | null>>;
+  setAspectRatio: Dispatch<SetStateAction<string>>;
+  setBrowserFrameMode: Dispatch<SetStateAction<BrowserFrameMode>>;
+  setBrowserFrameDrawShadow: Dispatch<SetStateAction<boolean>>;
+  setBrowserFrameDrawBorder: Dispatch<SetStateAction<boolean>>;
+
+  reset: () => void;
+}
+
+/** Resolve a `SetStateAction` against the previous value (supports functional updates). */
+const resolve = <T>(value: SetStateAction<T>, prev: T): T =>
+  typeof value === "function" ? (value as (prev: T) => T)(prev) : value;
+
+const initialState = {
+  params: null as URLSearchParams | null,
+  videoUrl: null as string | null,
+  playing: false,
+  currentTime: 0,
+  duration: 0,
+  volume: 1,
+  timelineStartTime: 0,
+  timelineEndTime: 0,
+  inputStartTime: "00:00:00",
+  inputEndTime: "00:00:00",
+  loadedSegments: null as Segment[] | null,
+  currentSegments: [] as Segment[],
+  tool: "none" as ToolMode,
+  textColor: "#000000",
+  textFont: "16px sans-serif",
+  sidebarTitle: "",
+  sidebarDescription: "",
+  isSidebarOpen: false,
+  isDashboardMenuOpen: false,
+  isFullscreen: false,
+  ctas: [] as CtaItem[],
+  showSaveDemoModal: false,
+  savingDemo: false,
+  demoSaved: false,
+  savedDemoId: null as string | null,
+  zoomEffects: [] as ZoomEffect[],
+  isZoomPopupOpen: false,
+  selectedBackground: null as string | null,
+  backgroundType: "",
+  customBackground: null as File | null,
+  aspectRatio: "native",
+  browserFrameMode: "default" as BrowserFrameMode,
+  browserFrameDrawShadow: true,
+  browserFrameDrawBorder: false,
+};
+
+export const useEditorStore = create<EditorStoreState>((set) => ({
+  ...initialState,
+
+  setParams: (v) => set((s) => ({ params: resolve(v, s.params) })),
+  setVideoUrl: (v) => set((s) => ({ videoUrl: resolve(v, s.videoUrl) })),
+  setPlaying: (v) => set((s) => ({ playing: resolve(v, s.playing) })),
+  setCurrentTime: (v) => set((s) => ({ currentTime: resolve(v, s.currentTime) })),
+  setDuration: (v) => set((s) => ({ duration: resolve(v, s.duration) })),
+  setVolume: (v) => set((s) => ({ volume: resolve(v, s.volume) })),
+  setTimelineStartTime: (v) => set((s) => ({ timelineStartTime: resolve(v, s.timelineStartTime) })),
+  setTimelineEndTime: (v) => set((s) => ({ timelineEndTime: resolve(v, s.timelineEndTime) })),
+  setInputStartTime: (v) => set((s) => ({ inputStartTime: resolve(v, s.inputStartTime) })),
+  setInputEndTime: (v) => set((s) => ({ inputEndTime: resolve(v, s.inputEndTime) })),
+  setLoadedSegments: (v) => set((s) => ({ loadedSegments: resolve(v, s.loadedSegments) })),
+  setCurrentSegments: (v) => set((s) => ({ currentSegments: resolve(v, s.currentSegments) })),
+  setTool: (v) => set((s) => ({ tool: resolve(v, s.tool) })),
+  setTextColor: (v) => set((s) => ({ textColor: resolve(v, s.textColor) })),
+  setTextFont: (v) => set((s) => ({ textFont: resolve(v, s.textFont) })),
+  setSidebarTitle: (v) => set((s) => ({ sidebarTitle: resolve(v, s.sidebarTitle) })),
+  setSidebarDescription: (v) =>
+    set((s) => ({ sidebarDescription: resolve(v, s.sidebarDescription) })),
+  setIsSidebarOpen: (v) => set((s) => ({ isSidebarOpen: resolve(v, s.isSidebarOpen) })),
+  setIsDashboardMenuOpen: (v) =>
+    set((s) => ({ isDashboardMenuOpen: resolve(v, s.isDashboardMenuOpen) })),
+  setIsFullscreen: (v) => set((s) => ({ isFullscreen: resolve(v, s.isFullscreen) })),
+  setCtas: (v) => set((s) => ({ ctas: resolve(v, s.ctas) })),
+  setShowSaveDemoModal: (v) => set((s) => ({ showSaveDemoModal: resolve(v, s.showSaveDemoModal) })),
+  setSavingDemo: (v) => set((s) => ({ savingDemo: resolve(v, s.savingDemo) })),
+  setDemoSaved: (v) => set((s) => ({ demoSaved: resolve(v, s.demoSaved) })),
+  setSavedDemoId: (v) => set((s) => ({ savedDemoId: resolve(v, s.savedDemoId) })),
+  setZoomEffects: (v) => set((s) => ({ zoomEffects: resolve(v, s.zoomEffects) })),
+  setIsZoomPopupOpen: (v) => set((s) => ({ isZoomPopupOpen: resolve(v, s.isZoomPopupOpen) })),
+  setSelectedBackground: (v) =>
+    set((s) => ({ selectedBackground: resolve(v, s.selectedBackground) })),
+  setBackgroundType: (v) => set((s) => ({ backgroundType: resolve(v, s.backgroundType) })),
+  setCustomBackground: (v) => set((s) => ({ customBackground: resolve(v, s.customBackground) })),
+  setAspectRatio: (v) => set((s) => ({ aspectRatio: resolve(v, s.aspectRatio) })),
+  setBrowserFrameMode: (v) => set((s) => ({ browserFrameMode: resolve(v, s.browserFrameMode) })),
+  setBrowserFrameDrawShadow: (v) =>
+    set((s) => ({ browserFrameDrawShadow: resolve(v, s.browserFrameDrawShadow) })),
+  setBrowserFrameDrawBorder: (v) =>
+    set((s) => ({ browserFrameDrawBorder: resolve(v, s.browserFrameDrawBorder) })),
+
+  reset: () => set({ ...initialState }),
+}));


### PR DESCRIPTION
Convert the useEditorState god-hook (34 useState + 3 refs) into a grouped Zustand store and remove the editorState prop-drilling into the editor region components.

- Add app/store/editor/editorStore.ts holding the 34 non-ref fields plus SetStateAction-compatible setters (so functional updates like setCtas(prev => ...) keep working). Fields grouped logically (source, playback/video, timeline, segments, tool, sidebar/UI, cta, modal, zoom-UI, background, aspect-ratio).
- Turn useEditorState into a thin shim that returns the same shape (store fields/setters + the three locally-created refs) so EditorState still resolves and un-migrated consumers (feature sub-hooks) keep working.
- Migrate EditorClient + region components (EditorModals, EditorPreviewRegion, EditorSidebarRegion, EditorTimelineSection, EditorVideoStage) to read state from useEditorStore via granular selectors (useShallow for multi-field reads). Refs stay as refs and are passed explicitly from EditorClient instead of via the editorState bag.

partial fixes #150 