### PR TITLE
refactor(#150): back useZoomEditor with a zoom store

### DIFF
--- a/app/(signed)/editor/hooks/useZoomEditor.ts
+++ b/app/(signed)/editor/hooks/useZoomEditor.ts
@@ -1,23 +1,14 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect } from "react";
 import { toast } from "react-hot-toast";
+import { useShallow } from "zustand/react/shallow";
 
 import { ZoomEffect } from "@/app/types/editor/zoom-effect";
+import { useZoomStore } from "@/app/store/editor/zoomStore";
 import { clamp } from "../utils/clamp";
 import { computeZoomPreview } from "../utils/zoomPreview";
 import type { EditorState } from "../apiTypes";
 
 type EditorMode = "main" | "trim" | "zoom" | "text";
-
-interface ExtensionClickEvent {
-  timestamp_ms: number;
-  event_type: string;
-  coordinates: {
-    x: number;
-    y: number;
-  };
-  screenshot_scale: number;
-  target_element: string;
-}
 
 interface UseZoomEditorProps {
   editorState: EditorState;
@@ -34,15 +25,36 @@ export function useZoomEditor({
 }: UseZoomEditorProps) {
   const { currentTime, playerRef } = editorState;
 
-  const [activeZoomIdx, setActiveZoomIdx] = useState<number>(-1);
-  const [zoomSegments, setZoomSegments] = useState<ZoomEffect[]>([]);
-  const [zoomLevel, setZoomLevel] = useState(1);
-  const [isDraggingZoomTarget, setIsDraggingZoomTarget] = useState(false);
-  const [showZoomModal, setShowZoomModal] = useState(false);
+  // Zoom state now lives in the zoom store (issue #150). This hook is a thin shim
+  // over it: it keeps the same effects/handlers and returns the same shape so
+  // EditorClient and every downstream consumer stay untouched.
+  const {
+    activeZoomIdx,
+    zoomSegments,
+    zoomLevel,
+    isDraggingZoomTarget,
+    showZoomModal,
+    extensionEvents,
+    hasAppliedAutoZoom,
+  } = useZoomStore(
+    useShallow((s) => ({
+      activeZoomIdx: s.activeZoomIdx,
+      zoomSegments: s.zoomSegments,
+      zoomLevel: s.zoomLevel,
+      isDraggingZoomTarget: s.isDraggingZoomTarget,
+      showZoomModal: s.showZoomModal,
+      extensionEvents: s.extensionEvents,
+      hasAppliedAutoZoom: s.hasAppliedAutoZoom,
+    }))
+  );
 
-  // States for Chrome Extension click events
-  const [extensionEvents, setExtensionEvents] = useState<ExtensionClickEvent[]>([]);
-  const [hasAppliedAutoZoom, setHasAppliedAutoZoom] = useState(false);
+  const setActiveZoomIdx = useZoomStore((s) => s.setActiveZoomIdx);
+  const setZoomSegments = useZoomStore((s) => s.setZoomSegments);
+  const setZoomLevel = useZoomStore((s) => s.setZoomLevel);
+  const setIsDraggingZoomTarget = useZoomStore((s) => s.setIsDraggingZoomTarget);
+  const setShowZoomModal = useZoomStore((s) => s.setShowZoomModal);
+  const setExtensionEvents = useZoomStore((s) => s.setExtensionEvents);
+  const setHasAppliedAutoZoom = useZoomStore((s) => s.setHasAppliedAutoZoom);
 
   // Listen for timeline messages from the extension content script
   useEffect(() => {
@@ -69,7 +81,7 @@ export function useZoomEditor({
       window.removeEventListener("message", handleExtensionMessage);
       clearTimeout(timer);
     };
-  }, []);
+  }, [setExtensionEvents]);
 
   // Convert click events to ZoomEffect segments
   const applyAutoZoomSuggestions = useCallback(() => {
@@ -115,7 +127,7 @@ export function useZoomEditor({
 
     setHasAppliedAutoZoom(true);
     toast.success(`Successfully applied ${debouncedSuggestions.length} auto-zoom highlights!`);
-  }, [extensionEvents]);
+  }, [extensionEvents, setZoomSegments, setHasAppliedAutoZoom]);
 
   const preview = computeZoomPreview({ zoomSegments, activeZoomIdx, currentTime });
   const { resolvedZoomIdx, activeEditedZoomSegment, shouldShowZoomFocusBox } = preview;
@@ -148,7 +160,7 @@ export function useZoomEditor({
         prev.map((segment, index) => (index === resolvedZoomIdx ? { ...segment, x, y } : segment))
       );
     },
-    [resolvedZoomIdx, shouldShowZoomFocusBox, zoomFocusStageRef]
+    [resolvedZoomIdx, shouldShowZoomFocusBox, zoomFocusStageRef, setZoomSegments]
   );
 
   const handleZoomTargetMouseDown = useCallback(
@@ -161,7 +173,7 @@ export function useZoomEditor({
       setIsDraggingZoomTarget(true);
       updateZoomTargetFromPointer(event.clientX, event.clientY);
     },
-    [activeEditedZoomSegment, updateZoomTargetFromPointer]
+    [activeEditedZoomSegment, updateZoomTargetFromPointer, setIsDraggingZoomTarget]
   );
 
   useEffect(() => {
@@ -182,13 +194,13 @@ export function useZoomEditor({
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, [isDraggingZoomTarget, updateZoomTargetFromPointer]);
+  }, [isDraggingZoomTarget, updateZoomTargetFromPointer, setIsDraggingZoomTarget]);
 
   useEffect(() => {
     if (activeZoomIdx === -1 && zoomSegments.length > 0) {
       setActiveZoomIdx(0);
     }
-  }, [activeZoomIdx, zoomSegments.length]);
+  }, [activeZoomIdx, zoomSegments.length, setActiveZoomIdx]);
 
   useEffect(() => {
     if (!currentTime) {
@@ -213,7 +225,7 @@ export function useZoomEditor({
         playerRef.current.seekTo(zoomInfo.startTime, "seconds");
       }
     }
-  }, [activeZoomIdx, currentTime, mode, playerRef, zoomSegments, lastInteractionRef]);
+  }, [activeZoomIdx, currentTime, mode, playerRef, zoomSegments, lastInteractionRef, setZoomLevel]);
 
   return {
     activeZoomIdx,

--- a/app/store/editor/zoomStore.ts
+++ b/app/store/editor/zoomStore.ts
@@ -1,0 +1,82 @@
+import type { Dispatch, SetStateAction } from "react";
+import { create } from "zustand";
+
+import type { ZoomEffect } from "@/app/types/editor/zoom-effect";
+
+/**
+ * A raw click event captured by the Marvedge Chrome Extension and forwarded to
+ * the editor for auto-zoom suggestions. Mirrors the payload posted by the
+ * extension content script.
+ */
+export interface ExtensionClickEvent {
+  timestamp_ms: number;
+  event_type: string;
+  coordinates: {
+    x: number;
+    y: number;
+  };
+  screenshot_scale: number;
+  target_element: string;
+}
+
+/**
+ * Zoom editor state store (issue #150). Holds the local state that used to live
+ * in the `useZoomEditor` hook as `useState` calls. `useZoomEditor` is now a thin
+ * shim over this store (strangler pattern) and keeps returning the exact same
+ * shape, so `EditorClient` and every downstream consumer stay untouched.
+ *
+ * Setters mirror React's `useState` signature (`Dispatch<SetStateAction<T>>`) so
+ * that functional updates like `setZoomSegments(prev => ...)` — used throughout
+ * the timeline-ruler hooks and `ZoomModal` — keep working unchanged.
+ */
+export interface ZoomStoreState {
+  activeZoomIdx: number;
+  zoomSegments: ZoomEffect[];
+  zoomLevel: number;
+  isDraggingZoomTarget: boolean;
+  showZoomModal: boolean;
+
+  // Chrome Extension click events → auto-zoom suggestions
+  extensionEvents: ExtensionClickEvent[];
+  hasAppliedAutoZoom: boolean;
+
+  setActiveZoomIdx: Dispatch<SetStateAction<number>>;
+  setZoomSegments: Dispatch<SetStateAction<ZoomEffect[]>>;
+  setZoomLevel: Dispatch<SetStateAction<number>>;
+  setIsDraggingZoomTarget: Dispatch<SetStateAction<boolean>>;
+  setShowZoomModal: Dispatch<SetStateAction<boolean>>;
+  setExtensionEvents: Dispatch<SetStateAction<ExtensionClickEvent[]>>;
+  setHasAppliedAutoZoom: Dispatch<SetStateAction<boolean>>;
+
+  reset: () => void;
+}
+
+/** Resolve a `SetStateAction` against the previous value (supports functional updates). */
+const resolve = <T>(value: SetStateAction<T>, prev: T): T =>
+  typeof value === "function" ? (value as (prev: T) => T)(prev) : value;
+
+const initialState = {
+  activeZoomIdx: -1,
+  zoomSegments: [] as ZoomEffect[],
+  zoomLevel: 1,
+  isDraggingZoomTarget: false,
+  showZoomModal: false,
+  extensionEvents: [] as ExtensionClickEvent[],
+  hasAppliedAutoZoom: false,
+};
+
+export const useZoomStore = create<ZoomStoreState>((set) => ({
+  ...initialState,
+
+  setActiveZoomIdx: (v) => set((s) => ({ activeZoomIdx: resolve(v, s.activeZoomIdx) })),
+  setZoomSegments: (v) => set((s) => ({ zoomSegments: resolve(v, s.zoomSegments) })),
+  setZoomLevel: (v) => set((s) => ({ zoomLevel: resolve(v, s.zoomLevel) })),
+  setIsDraggingZoomTarget: (v) =>
+    set((s) => ({ isDraggingZoomTarget: resolve(v, s.isDraggingZoomTarget) })),
+  setShowZoomModal: (v) => set((s) => ({ showZoomModal: resolve(v, s.showZoomModal) })),
+  setExtensionEvents: (v) => set((s) => ({ extensionEvents: resolve(v, s.extensionEvents) })),
+  setHasAppliedAutoZoom: (v) =>
+    set((s) => ({ hasAppliedAutoZoom: resolve(v, s.hasAppliedAutoZoom) })),
+
+  reset: () => set({ ...initialState }),
+}));


### PR DESCRIPTION
Move useZoomEditor's local state into a dedicated Zustand store (app/store/editor/zoomStore.ts) following the editorStore convention. useZoomEditor becomes a thin shim that reads the store via granular selectors (useShallow for the multi-field read) and returns the exact same shape, so EditorClient and all downstream consumers are untouched.

Setters keep the Dispatch<SetStateAction<T>> signature so functional updates (setZoomSegments(prev => ...)) used by ZoomModal and the timeline-ruler hooks keep working unchanged.
PARTIAL FIXES #150 