### PR TITLE
refactor(#150): back text-overlay and subtitle hooks with stores

### DIFF
--- a/app/(signed)/editor/hooks/useSubtitles.ts
+++ b/app/(signed)/editor/hooks/useSubtitles.ts
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import axios from "axios";
 import { toast } from "react-hot-toast";
+import { useShallow } from "zustand/react/shallow";
 
 import { uploadBlobToGcs } from "@/app/lib/gcsUploadClient";
+import { useSubtitleStore } from "@/app/store/editor/subtitleStore";
 import { SubtitleCue } from "../types";
 import type { EditorState } from "../apiTypes";
 
@@ -12,8 +14,14 @@ interface UseSubtitlesProps {
 
 export function useSubtitles({ editorState }: UseSubtitlesProps) {
   const { params, videoUrl, currentTime, savedDemoId } = editorState;
-  const [subtitleCues, setSubtitleCues] = useState<SubtitleCue[]>([]);
-  const [subtitlesLoading, setSubtitlesLoading] = useState(false);
+  const { subtitleCues, subtitlesLoading, setSubtitleCues, setSubtitlesLoading } = useSubtitleStore(
+    useShallow((s) => ({
+      subtitleCues: s.subtitleCues,
+      subtitlesLoading: s.subtitlesLoading,
+      setSubtitleCues: s.setSubtitleCues,
+      setSubtitlesLoading: s.setSubtitlesLoading,
+    }))
+  );
 
   useEffect(() => {
     if (!params) {
@@ -57,7 +65,7 @@ export function useSubtitles({ editorState }: UseSubtitlesProps) {
     } catch (e) {
       console.error("Failed to parse subtitles from URL:", e);
     }
-  }, [params]);
+  }, [params, setSubtitleCues]);
 
   const activeSubtitleText = React.useMemo(() => {
     if (!subtitleCues.length) {
@@ -149,7 +157,7 @@ export function useSubtitles({ editorState }: UseSubtitlesProps) {
   const handleSkipSubtitles = React.useCallback(() => {
     setSubtitleCues([]);
     toast.success("Subtitles skipped for export");
-  }, []);
+  }, [setSubtitleCues]);
 
   return {
     subtitleCues,

--- a/app/(signed)/editor/hooks/useTextOverlays.ts
+++ b/app/(signed)/editor/hooks/useTextOverlays.ts
@@ -1,5 +1,7 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect } from "react";
+import { useShallow } from "zustand/react/shallow";
 
+import { useTextOverlayStore } from "@/app/store/editor/textOverlayStore";
 import { TextOverlayItem } from "../types";
 import type { EditorState } from "../apiTypes";
 import { useTextOverlayInspector } from "./useTextOverlayInspector";
@@ -13,10 +15,27 @@ interface UseTextOverlaysProps {
 export function useTextOverlays({ editorState, zoomFocusStageRef }: UseTextOverlaysProps) {
   const { currentTime, duration, setTool } = editorState;
 
-  const [textOverlays, setTextOverlays] = useState<TextOverlayItem[]>([]);
-  const [selectedTextOverlayId, setSelectedTextOverlayId] = useState<string | null>(null);
-  const [draggingTextOverlayId, setDraggingTextOverlayId] = useState<string | null>(null);
-  const [resizingTextOverlayId, setResizingTextOverlayId] = useState<string | null>(null);
+  const {
+    textOverlays,
+    selectedTextOverlayId,
+    draggingTextOverlayId,
+    resizingTextOverlayId,
+    setTextOverlays,
+    setSelectedTextOverlayId,
+    setDraggingTextOverlayId,
+    setResizingTextOverlayId,
+  } = useTextOverlayStore(
+    useShallow((s) => ({
+      textOverlays: s.textOverlays,
+      selectedTextOverlayId: s.selectedTextOverlayId,
+      draggingTextOverlayId: s.draggingTextOverlayId,
+      resizingTextOverlayId: s.resizingTextOverlayId,
+      setTextOverlays: s.setTextOverlays,
+      setSelectedTextOverlayId: s.setSelectedTextOverlayId,
+      setDraggingTextOverlayId: s.setDraggingTextOverlayId,
+      setResizingTextOverlayId: s.setResizingTextOverlayId,
+    }))
+  );
 
   const inspector = useTextOverlayInspector({
     selectedTextOverlayId,
@@ -24,15 +43,18 @@ export function useTextOverlays({ editorState, zoomFocusStageRef }: UseTextOverl
     zoomFocusStageRef,
   });
 
-  const setTextOverlaysFromUrl = useCallback((overlays: unknown) => {
-    if (!overlays) {
-      setTextOverlays([]);
-      return;
-    }
-    if (Array.isArray(overlays)) {
-      setTextOverlays(overlays as TextOverlayItem[]);
-    }
-  }, []);
+  const setTextOverlaysFromUrl = useCallback(
+    (overlays: unknown) => {
+      if (!overlays) {
+        setTextOverlays([]);
+        return;
+      }
+      if (Array.isArray(overlays)) {
+        setTextOverlays(overlays as TextOverlayItem[]);
+      }
+    },
+    [setTextOverlays]
+  );
 
   const handleAddTextOverlay = useCallback(() => {
     const text = inspector.textOverlayInput.trim() || "Add text";
@@ -68,6 +90,8 @@ export function useTextOverlays({ editorState, zoomFocusStageRef }: UseTextOverl
     currentTime,
     duration,
     setTool,
+    setTextOverlays,
+    setSelectedTextOverlayId,
     inspector.textOverlayColor,
     inspector.textOverlayFontFamily,
     inspector.textOverlayFontSize,
@@ -96,7 +120,7 @@ export function useTextOverlays({ editorState, zoomFocusStageRef }: UseTextOverl
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [selectedTextOverlayId]);
+  }, [selectedTextOverlayId, setTextOverlays, setSelectedTextOverlayId]);
 
   const interactions = useTextOverlayInteractions({
     textOverlays,

--- a/app/store/editor/subtitleStore.ts
+++ b/app/store/editor/subtitleStore.ts
@@ -1,0 +1,45 @@
+import type { Dispatch, SetStateAction } from "react";
+import { create } from "zustand";
+
+import type { SubtitleCue } from "@/app/(signed)/editor/types";
+
+/**
+ * Subtitle state store (issue #150). Holds the value state that used to live as
+ * `useState` in the `useSubtitles` hook: the generated cue list and the
+ * generating-in-progress flag.
+ *
+ * The `activeSubtitleText` derivation and the async generate/skip handlers stay in
+ * the `useSubtitles` shim (they depend on `editorState`); only the serializable
+ * subtitle state lives here.
+ *
+ * Setters mirror React's `useState` signature (`Dispatch<SetStateAction<T>>`) so the
+ * `useSubtitles` shim keeps returning the exact same shape (`setSubtitleCues`) and
+ * every existing consumer keeps working untouched.
+ */
+export interface SubtitleStoreState {
+  subtitleCues: SubtitleCue[];
+  subtitlesLoading: boolean;
+
+  setSubtitleCues: Dispatch<SetStateAction<SubtitleCue[]>>;
+  setSubtitlesLoading: Dispatch<SetStateAction<boolean>>;
+
+  reset: () => void;
+}
+
+/** Resolve a `SetStateAction` against the previous value (supports functional updates). */
+const resolve = <T>(value: SetStateAction<T>, prev: T): T =>
+  typeof value === "function" ? (value as (prev: T) => T)(prev) : value;
+
+const initialState = {
+  subtitleCues: [] as SubtitleCue[],
+  subtitlesLoading: false,
+};
+
+export const useSubtitleStore = create<SubtitleStoreState>((set) => ({
+  ...initialState,
+
+  setSubtitleCues: (v) => set((s) => ({ subtitleCues: resolve(v, s.subtitleCues) })),
+  setSubtitlesLoading: (v) => set((s) => ({ subtitlesLoading: resolve(v, s.subtitlesLoading) })),
+
+  reset: () => set({ ...initialState }),
+}));

--- a/app/store/editor/textOverlayStore.ts
+++ b/app/store/editor/textOverlayStore.ts
@@ -1,0 +1,58 @@
+import type { Dispatch, SetStateAction } from "react";
+import { create } from "zustand";
+
+import type { TextOverlayItem } from "@/app/(signed)/editor/types";
+
+/**
+ * Text-overlay state store (issue #150). Holds the value state that used to live
+ * as `useState` in the `useTextOverlays` hook: the overlay list plus the ids of
+ * the currently selected / dragging / resizing overlays.
+ *
+ * The transient drag/resize geometry (offset + start refs) intentionally stays as
+ * React refs inside `useTextOverlayDrag` / `useTextOverlayResize`; the inspector's
+ * input/font/colour draft state stays local to `useTextOverlayInspector`. Only the
+ * serializable overlay state lives here.
+ *
+ * Setters mirror React's `useState` signature (`Dispatch<SetStateAction<T>>`) so the
+ * `useTextOverlays` shim keeps returning the exact same shape and every existing
+ * consumer — including functional updates like `setTextOverlays(prev => ...)` used
+ * by the drag/resize sub-hooks — keeps working untouched.
+ */
+export interface TextOverlayStoreState {
+  textOverlays: TextOverlayItem[];
+  selectedTextOverlayId: string | null;
+  draggingTextOverlayId: string | null;
+  resizingTextOverlayId: string | null;
+
+  setTextOverlays: Dispatch<SetStateAction<TextOverlayItem[]>>;
+  setSelectedTextOverlayId: Dispatch<SetStateAction<string | null>>;
+  setDraggingTextOverlayId: Dispatch<SetStateAction<string | null>>;
+  setResizingTextOverlayId: Dispatch<SetStateAction<string | null>>;
+
+  reset: () => void;
+}
+
+/** Resolve a `SetStateAction` against the previous value (supports functional updates). */
+const resolve = <T>(value: SetStateAction<T>, prev: T): T =>
+  typeof value === "function" ? (value as (prev: T) => T)(prev) : value;
+
+const initialState = {
+  textOverlays: [] as TextOverlayItem[],
+  selectedTextOverlayId: null as string | null,
+  draggingTextOverlayId: null as string | null,
+  resizingTextOverlayId: null as string | null,
+};
+
+export const useTextOverlayStore = create<TextOverlayStoreState>((set) => ({
+  ...initialState,
+
+  setTextOverlays: (v) => set((s) => ({ textOverlays: resolve(v, s.textOverlays) })),
+  setSelectedTextOverlayId: (v) =>
+    set((s) => ({ selectedTextOverlayId: resolve(v, s.selectedTextOverlayId) })),
+  setDraggingTextOverlayId: (v) =>
+    set((s) => ({ draggingTextOverlayId: resolve(v, s.draggingTextOverlayId) })),
+  setResizingTextOverlayId: (v) =>
+    set((s) => ({ resizingTextOverlayId: resolve(v, s.resizingTextOverlayId) })),
+
+  reset: () => set({ ...initialState }),
+}));


### PR DESCRIPTION
Extract the value state out of the useTextOverlays and useSubtitles editor feature hooks into dedicated Zustand stores, mirroring the editorStore strangler pattern. Each hook becomes a thin shim that reads from its store via useShallow and returns the exact same shape, so every consumer keeps working untouched.

- add app/store/editor/textOverlayStore.ts (textOverlays, selectedTextOverlayId, draggingTextOverlayId, resizingTextOverlayId)
- add app/store/editor/subtitleStore.ts (subtitleCues, subtitlesLoading)
- useTextOverlays: 4 useState -> textOverlayStore via useShallow
- useSubtitles: 2 useState -> subtitleStore via useShallow

Transient drag/resize geometry refs and the inspector's draft input state stay local to their sub-hooks; only serializable state moves to the stores.
partial fixes #150