### PR TITLE
refactor(#150): move demos page state into a store

### DIFF
--- a/app/(signed)/demos/DemosClient.tsx
+++ b/app/(signed)/demos/DemosClient.tsx
@@ -1,13 +1,14 @@
 "use client";
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import ConfirmDeleteModal from "../../components/ConfirmDeleteModal";
 import { useDemosData } from "./hooks/useDemosData";
+import { useDemosStore } from "@/app/store/demosStore";
 import { buildDemoEditorParams, filterAndSortDemos } from "./utils/demoHelpers";
 import DemosToolbar from "./components/DemosToolbar";
 import DemoGridView from "./components/DemoGridView";
 import DemoListView from "./components/DemoListView";
-import type { Demo, DemoSortOption } from "./types";
+import type { Demo } from "./types";
 
 export const metadata = {
   titleText: "My Demos",
@@ -20,31 +21,17 @@ interface DemosPageProps {
 
 export default function DemosPage({ initialDemos }: DemosPageProps) {
   const router = useRouter();
-  const [search, setSearch] = useState("");
-  const [view, setView] = useState("list");
-  const [, setStatusDropdownOpen] = useState(false);
-  const statusDropdownRef = useRef<HTMLDivElement>(null);
-  const [sortDropdownOpen, setSortDropdownOpen] = useState(false);
-  const sortDropdownRef = useRef<HTMLDivElement>(null);
 
+  // Filters live in the demosStore so the toolbar reads/writes them directly.
+  const search = useDemosStore((s) => s.search);
+  const view = useDemosStore((s) => s.view);
+  const sortOption = useDemosStore((s) => s.sortOption);
+
+  // Local UI state for the delete modal stays as component state.
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
-  const [sortOption, setSortOption] = useState<DemoSortOption>("updatedAt");
 
-  const { demos, loading, error, durationMap, deleteDemo } = useDemosData(initialDemos);
-
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (statusDropdownRef.current && !statusDropdownRef.current.contains(event.target as Node)) {
-        setStatusDropdownOpen(false);
-      }
-      if (sortDropdownRef.current && !sortDropdownRef.current.contains(event.target as Node)) {
-        setSortDropdownOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  const { demos, loading, error, deleteDemo } = useDemosData(initialDemos);
 
   const filteredAndSortedDemos = filterAndSortDemos(demos, search, sortOption);
 
@@ -73,17 +60,7 @@ export default function DemosPage({ initialDemos }: DemosPageProps) {
           <h2 className="text-2xl font-normal text-[#8B8B8B] dark:text-[var(--text-muted)] mb-2">
             Manage and organize all your interactive demos.
           </h2>
-          <DemosToolbar
-            search={search}
-            setSearch={setSearch}
-            sortDropdownOpen={sortDropdownOpen}
-            setSortDropdownOpen={setSortDropdownOpen}
-            sortDropdownRef={sortDropdownRef}
-            sortOption={sortOption}
-            setSortOption={setSortOption}
-            view={view}
-            setView={setView}
-          />
+          <DemosToolbar />
         </div>
         <div className="mt-8">
           <h3 className="text-3xl font-semibold text-[#1A0033] dark:text-[var(--text-primary)] mb-6">
@@ -107,7 +84,6 @@ export default function DemosPage({ initialDemos }: DemosPageProps) {
           ) : view === "grid" ? (
             <DemoGridView
               demos={filteredAndSortedDemos}
-              durationMap={durationMap}
               onEdit={handleEditDemo}
               onDelete={handleDeleteDemo}
             />

--- a/app/(signed)/demos/components/DemoGridView.tsx
+++ b/app/(signed)/demos/components/DemoGridView.tsx
@@ -2,16 +2,18 @@
 import Image from "next/image";
 import { FaRegCalendarAlt, FaRegClock } from "react-icons/fa";
 import { formatDate } from "@/app/lib/dateTimeUtils";
+import { useDemosStore } from "@/app/store/demosStore";
 import type { Demo } from "../types";
 
 interface DemoGridViewProps {
   demos: Demo[];
-  durationMap: Record<string, string>;
   onEdit: (demo: Demo) => void;
   onDelete: (id: string) => void;
 }
 
-export default function DemoGridView({ demos, durationMap, onEdit, onDelete }: DemoGridViewProps) {
+export default function DemoGridView({ demos, onEdit, onDelete }: DemoGridViewProps) {
+  const durationMap = useDemosStore((s) => s.durationMap);
+
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 gap-8">
       {demos.map((demo: Demo) => (

--- a/app/(signed)/demos/components/DemosToolbar.tsx
+++ b/app/(signed)/demos/components/DemosToolbar.tsx
@@ -1,30 +1,36 @@
 "use client";
+import { useState, useRef, useEffect } from "react";
 import { FaTh, FaThList, FaSort, FaEye, FaListUl, FaRegClock, FaPlusSquare } from "react-icons/fa";
+import { useShallow } from "zustand/react/shallow";
+import { useDemosStore } from "@/app/store/demosStore";
 import type { DemoSortOption } from "../types";
 
-interface DemosToolbarProps {
-  search: string;
-  setSearch: (value: string) => void;
-  sortDropdownOpen: boolean;
-  setSortDropdownOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  sortDropdownRef: React.RefObject<HTMLDivElement | null>;
-  sortOption: DemoSortOption;
-  setSortOption: (option: DemoSortOption) => void;
-  view: string;
-  setView: (view: string) => void;
-}
+export default function DemosToolbar() {
+  const { search, setSearch, sortOption, setSortOption, view, setView } = useDemosStore(
+    useShallow((s) => ({
+      search: s.search,
+      setSearch: s.setSearch,
+      sortOption: s.sortOption,
+      setSortOption: s.setSortOption,
+      view: s.view,
+      setView: s.setView,
+    }))
+  );
 
-export default function DemosToolbar({
-  search,
-  setSearch,
-  sortDropdownOpen,
-  setSortDropdownOpen,
-  sortDropdownRef,
-  sortOption,
-  setSortOption,
-  view,
-  setView,
-}: DemosToolbarProps) {
+  // Dropdown open/close is local UI state; its DOM node stays a ref.
+  const [sortDropdownOpen, setSortDropdownOpen] = useState(false);
+  const sortDropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (sortDropdownRef.current && !sortDropdownRef.current.contains(event.target as Node)) {
+        setSortDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
   const selectSort = (option: DemoSortOption) => {
     setSortOption(option);
     setSortDropdownOpen(false);

--- a/app/(signed)/demos/hooks/useDemosData.ts
+++ b/app/(signed)/demos/hooks/useDemosData.ts
@@ -1,51 +1,34 @@
-import { useState, useEffect, useCallback } from "react";
-import axios from "axios";
-import { formatTime } from "@/app/lib/dateTimeUtils";
-import { probeVideoDuration } from "../utils/demoHelpers";
+import { useRef, useEffect } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useDemosStore } from "@/app/store/demosStore";
 import type { Demo } from "../types";
 
+/**
+ * Thin shim over the demosStore (strangler pattern). Returns the same shape it
+ * always exposed so existing consumers keep working untouched, but the list
+ * data now lives in the Zustand store. The store is seeded once from the
+ * server-provided initial demos, then duration probing runs off store changes.
+ */
 export function useDemosData(initialDemos: Demo[]) {
-  const [demos, setDemos] = useState<Demo[]>(initialDemos);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Seed the store synchronously on first render so the initial list (and any
+  // cached durations) are available before paint — matching the old useState
+  // initializer, no empty flash.
+  const didInit = useRef(false);
+  if (!didInit.current) {
+    useDemosStore.getState().initialize(initialDemos);
+    didInit.current = true;
+  }
 
-  const [durationMap, setDurationMap] = useState<Record<string, string>>(() => {
-    const map: Record<string, string> = {};
-    for (const demo of initialDemos) {
-      if (demo.duration && demo.duration > 0) {
-        map[demo.id] = formatTime(demo.duration);
-      }
-    }
-    return map;
-  });
-
-  const fetchDurations = useCallback(async (demoList: Demo[]) => {
-    const uncached = demoList.filter((d) => !d.duration && d.videoUrl);
-    for (const demo of uncached) {
-      try {
-        let playableUrl = demo.videoUrl;
-        if (demo.videoUrl.startsWith("gs://")) {
-          const res = await fetch(`/api/gcs/resolve?url=${encodeURIComponent(demo.videoUrl)}`);
-          const data = await res.json();
-          if (data.ok && data.playableUrl) {
-            playableUrl = data.playableUrl;
-          } else {
-            continue;
-          }
-        }
-        const dur = await probeVideoDuration(playableUrl);
-        if (dur > 0) {
-          setDurationMap((prev) => ({ ...prev, [demo.id]: formatTime(dur) }));
-
-          fetch("/api/demo/duration", {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ id: demo.id, duration: dur }),
-          }).catch(() => {});
-        }
-      } catch {}
-    }
-  }, []);
+  const { demos, loading, error, durationMap } = useDemosStore(
+    useShallow((s) => ({
+      demos: s.demos,
+      loading: s.loading,
+      error: s.error,
+      durationMap: s.durationMap,
+    }))
+  );
+  const deleteDemo = useDemosStore((s) => s.deleteDemo);
+  const fetchDurations = useDemosStore((s) => s.fetchDurations);
 
   useEffect(() => {
     if (demos.length > 0) {
@@ -53,36 +36,13 @@ export function useDemosData(initialDemos: Demo[]) {
     }
   }, [demos, fetchDurations]);
 
-  const fetchDemos = async () => {
-    setLoading(true);
-    try {
-      const response = await axios.get("/api/demo");
-      setDemos(response.data.demos || []);
-    } catch (err: unknown) {
-      console.error("Error fetching demos:", err);
-      if (axios.isAxiosError(err)) {
-        setError(err.response?.data?.message || "Failed to fetch demos");
-      } else {
-        setError("Failed to fetch demos");
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const deleteDemo = async (id: string) => {
-    try {
-      await axios.delete("/api/demo/", {
-        params: {
-          id,
-        },
-      });
-      await fetchDemos();
-    } catch (error) {
-      console.error("Error deleting demo:", error);
-      setError("Failed to delete demo");
-    }
-  };
+  // Reset the store when the route unmounts so data and filters start fresh on
+  // the next visit — matching the old per-mount useState lifecycle.
+  useEffect(() => {
+    return () => {
+      useDemosStore.getState().reset();
+    };
+  }, []);
 
   return { demos, loading, error, durationMap, deleteDemo };
 }

--- a/app/store/demosStore.ts
+++ b/app/store/demosStore.ts
@@ -1,0 +1,130 @@
+import { create } from "zustand";
+import axios from "axios";
+import { formatTime } from "@/app/lib/dateTimeUtils";
+import { probeVideoDuration } from "@/app/(signed)/demos/utils/demoHelpers";
+import type { Demo, DemoSortOption } from "@/app/(signed)/demos/types";
+
+// Page-level state for the Demos route: the list data fetched from the server
+// plus the toolbar filters (search / view / sort). Extracted from useDemosData
+// and DemosClient so the client and its children can read via selectors instead
+// of prop-drilling. Refs (dropdown nodes, etc.) stay in the components.
+interface DemosStore {
+  // Data
+  demos: Demo[];
+  loading: boolean;
+  error: string | null;
+  durationMap: Record<string, string>;
+
+  // Filters
+  search: string;
+  view: string;
+  sortOption: DemoSortOption;
+
+  // Filter setters
+  setSearch: (search: string) => void;
+  setView: (view: string) => void;
+  setSortOption: (sortOption: DemoSortOption) => void;
+
+  // Data actions
+  initialize: (initialDemos: Demo[]) => void;
+  fetchDemos: () => Promise<void>;
+  deleteDemo: (id: string) => Promise<void>;
+  fetchDurations: (demoList: Demo[]) => Promise<void>;
+
+  reset: () => void;
+}
+
+const initialState = {
+  demos: [] as Demo[],
+  loading: false,
+  error: null as string | null,
+  durationMap: {} as Record<string, string>,
+  search: "",
+  view: "list",
+  sortOption: "updatedAt" as DemoSortOption,
+};
+
+function buildDurationMap(demos: Demo[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const demo of demos) {
+    if (demo.duration && demo.duration > 0) {
+      map[demo.id] = formatTime(demo.duration);
+    }
+  }
+  return map;
+}
+
+export const useDemosStore = create<DemosStore>((set, get) => ({
+  ...initialState,
+
+  setSearch: (search) => set({ search }),
+  setView: (view) => set({ view }),
+  setSortOption: (sortOption) => set({ sortOption }),
+
+  initialize: (initialDemos) =>
+    set({
+      demos: initialDemos,
+      durationMap: buildDurationMap(initialDemos),
+      loading: false,
+      error: null,
+    }),
+
+  fetchDemos: async () => {
+    set({ loading: true });
+    try {
+      const response = await axios.get("/api/demo");
+      set({ demos: response.data.demos || [] });
+    } catch (err: unknown) {
+      console.error("Error fetching demos:", err);
+      if (axios.isAxiosError(err)) {
+        set({ error: err.response?.data?.message || "Failed to fetch demos" });
+      } else {
+        set({ error: "Failed to fetch demos" });
+      }
+    } finally {
+      set({ loading: false });
+    }
+  },
+
+  deleteDemo: async (id) => {
+    try {
+      await axios.delete("/api/demo/", { params: { id } });
+      await get().fetchDemos();
+    } catch (error) {
+      console.error("Error deleting demo:", error);
+      set({ error: "Failed to delete demo" });
+    }
+  },
+
+  fetchDurations: async (demoList) => {
+    const uncached = demoList.filter((d) => !d.duration && d.videoUrl);
+    for (const demo of uncached) {
+      try {
+        let playableUrl = demo.videoUrl;
+        if (demo.videoUrl.startsWith("gs://")) {
+          const res = await fetch(`/api/gcs/resolve?url=${encodeURIComponent(demo.videoUrl)}`);
+          const data = await res.json();
+          if (data.ok && data.playableUrl) {
+            playableUrl = data.playableUrl;
+          } else {
+            continue;
+          }
+        }
+        const dur = await probeVideoDuration(playableUrl);
+        if (dur > 0) {
+          set((state) => ({
+            durationMap: { ...state.durationMap, [demo.id]: formatTime(dur) },
+          }));
+
+          fetch("/api/demo/duration", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ id: demo.id, duration: dur }),
+          }).catch(() => {});
+        }
+      } catch {}
+    }
+  },
+
+  reset: () => set({ ...initialState }),
+}));


### PR DESCRIPTION
Introduce app/store/demosStore.ts holding the Demos route's list data (demos, loading, error, durationMap) and toolbar filters (search, view, sortOption), following the blobStore/recorderStore conventions with granular selectors and useShallow for multi-field reads.

- useDemosData is now a thin shim over the store (strangler pattern), returning the same { demos, loading, error, durationMap, deleteDemo } shape; it seeds the store from server data and resets on unmount.
- DemosClient reads filters via store selectors instead of local useState and no longer prop-drills them; delete-modal state stays local useState.
- DemosToolbar takes no props: it reads/writes filters from the store and owns its sort-dropdown open state + ref locally.
- DemoGridView reads durationMap from the store instead of a prop.
- Removed dead status-dropdown state/ref wiring from DemosClient.
- partial fixes #150 