### PR TITLE
feat(editor): preserve unsaved video and edits across page refresh 

### DIFF
--- a/app/(signed)/editor/EditorClient.tsx
+++ b/app/(signed)/editor/EditorClient.tsx
@@ -16,6 +16,7 @@ import { useExportFlow } from "./hooks/useExportFlow";
 import { useSaveDemo } from "./hooks/useSaveDemo";
 import { useDemoLoader } from "./hooks/useDemoLoader";
 import { useAutosave } from "./hooks/useAutosave";
+import { useLocalDraft } from "./hooks/useLocalDraft";
 import { useEditorWiring } from "./hooks/useEditorWiring";
 import { useEditorSyncEffects } from "./hooks/useEditorSyncEffects";
 
@@ -29,6 +30,7 @@ export default function EditorPage() {
   const { videoUrl: recordedVideoUrl, thumbnailUrl, processing, resetVideo } = useEditor();
   const blob = useBlobStore((state) => state.blob);
   const sourceDuration = useBlobStore((state) => state.sourceDuration);
+  const draftId = useBlobStore((state) => state.draftId);
   const { formatTimeForInput } = useFormatTime();
 
   const isEditorInitializedRef = useRef(false);
@@ -93,6 +95,11 @@ export default function EditorPage() {
     subtitleCues: subtitles.subtitleCues,
     textOverlays: text.textOverlays,
   });
+
+  // Persist/restore an UNSAVED session (no demoId) to localStorage so an
+  // accidental refresh doesn't discard timeline edits. The uploaded video
+  // itself is restored from IndexedDB via the blob store. See issue #226.
+  useLocalDraft({ editorState, draftId, segments, setSegments, zoom, subtitles, text });
 
   useEditorSyncEffects({
     editorState,

--- a/app/(signed)/editor/hooks/useAutosave.ts
+++ b/app/(signed)/editor/hooks/useAutosave.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 
 import { ZoomEffect } from "@/app/types/editor/zoom-effect";
 import { notifyAutosavePending } from "../utils/autosaveHelpers";
+import { buildEditingPayload } from "../utils/editingDraft";
 import { SubtitleCue, TextOverlayItem } from "../types";
 import type { EditorState } from "../apiTypes";
 
@@ -41,24 +42,19 @@ export function useAutosave({
   const lastAutosavePayloadRef = React.useRef<string>("");
   const autosaveInFlightRef = React.useRef(false);
 
-  const buildEditingPayload = React.useCallback(() => {
-    return {
-      segments: segments.map((s) => ({
-        start: String(s.start),
-        end: String(s.end),
-      })),
-      zoom: zoomSegments,
-      background: selectedBackground ?? null,
-      backgroundType: backgroundType || "",
-      subtitles: subtitleCues || [],
-      textOverlays: textOverlays || [],
-      aspectRatio: aspectRatio || "native",
-      browserFrame: {
-        mode: browserFrameMode,
-        drawShadow: browserFrameDrawShadow,
-        drawBorder: browserFrameDrawBorder,
-      },
-    };
+  const buildPayload = React.useCallback(() => {
+    return buildEditingPayload({
+      segments,
+      zoomSegments,
+      selectedBackground,
+      backgroundType,
+      subtitleCues,
+      textOverlays,
+      aspectRatio,
+      browserFrameMode,
+      browserFrameDrawShadow,
+      browserFrameDrawBorder,
+    });
   }, [
     segments,
     zoomSegments,
@@ -85,7 +81,7 @@ export function useAutosave({
       id: demoId,
       title: sidebarTitle || "",
       description: sidebarDescription || "",
-      editing: buildEditingPayload(),
+      editing: buildPayload(),
     };
     const serialized = JSON.stringify(payload);
     if (serialized === lastAutosavePayloadRef.current) {
@@ -101,7 +97,7 @@ export function useAutosave({
     } finally {
       autosaveInFlightRef.current = false;
     }
-  }, [buildEditingPayload, savedDemoId, sidebarTitle, sidebarDescription]);
+  }, [buildPayload, savedDemoId, sidebarTitle, sidebarDescription]);
 
   React.useEffect(() => {
     if (!savedDemoId) {

--- a/app/(signed)/editor/hooks/useDemoLoader.ts
+++ b/app/(signed)/editor/hooks/useDemoLoader.ts
@@ -3,7 +3,8 @@ import axios from "axios";
 import { toast } from "react-hot-toast";
 
 import { ZoomEffect } from "@/app/types/editor/zoom-effect";
-import { BrowserFrameMode } from "./useEditorState";
+import { applyDemoEditing } from "../utils/editingDraft";
+import { resolvePlayableVideoUrl } from "./useURLParams";
 import { SubtitleCue, TextOverlayItem } from "../types";
 import type { EditorState } from "../apiTypes";
 
@@ -16,21 +17,6 @@ interface UseDemoLoaderProps {
   setTextOverlays: (overlays: TextOverlayItem[]) => void;
 }
 
-type DemoEditing = {
-  segments?: { start: string | number; end: string | number }[];
-  zoom?: ZoomEffect[];
-  background?: string | null;
-  backgroundType?: string;
-  subtitles?: SubtitleCue[];
-  textOverlays?: TextOverlayItem[];
-  aspectRatio?: string;
-  browserFrame?: {
-    mode?: BrowserFrameMode;
-    drawShadow?: boolean;
-    drawBorder?: boolean;
-  };
-};
-
 export function useDemoLoader({
   editorState,
   isEditorInitializedRef,
@@ -42,6 +28,8 @@ export function useDemoLoader({
   const {
     params,
     savedDemoId,
+    videoUrl,
+    setVideoUrl,
     setParams,
     setSavedDemoId,
     setSidebarTitle,
@@ -55,6 +43,11 @@ export function useDemoLoader({
     setBrowserFrameDrawBorder,
     setCtas,
   } = editorState;
+
+  // Read the freshest videoUrl inside async callbacks without re-running the
+  // demo-fetch effect every time the video changes.
+  const videoUrlRef = React.useRef(videoUrl);
+  videoUrlRef.current = videoUrl;
 
   useEffect(() => {
     const nextParams = new URLSearchParams(window.location.search);
@@ -90,55 +83,6 @@ export function useDemoLoader({
     isEditorInitializedRef.current = false;
     let isMounted = true;
 
-    const restoreDemoEditing = (ed: DemoEditing) => {
-      if (ed.segments) {
-        const numeric = ed.segments
-          .map((s) => ({
-            start: typeof s.start === "string" ? parseFloat(s.start) : Number(s.start),
-            end: typeof s.end === "string" ? parseFloat(s.end) : Number(s.end),
-          }))
-          .filter((s) => !isNaN(s.start) && !isNaN(s.end));
-        if (numeric.length > 0) {
-          setSegments(numeric);
-          setCurrentSegments(
-            ed.segments.map((s) => ({
-              start: String(s.start),
-              end: String(s.end),
-            }))
-          );
-        }
-      }
-      if (ed.zoom) {
-        setZoomSegments(ed.zoom);
-      }
-      if (ed.background) {
-        setSelectedBackground(ed.background);
-      }
-      if (ed.backgroundType) {
-        setBackgroundType(ed.backgroundType);
-      }
-      if (ed.subtitles) {
-        setSubtitleCues(ed.subtitles);
-      }
-      if (ed.textOverlays) {
-        setTextOverlays(ed.textOverlays);
-      }
-      if (ed.aspectRatio) {
-        setAspectRatio(ed.aspectRatio);
-      }
-      if (ed.browserFrame) {
-        if (ed.browserFrame.mode) {
-          setBrowserFrameMode(ed.browserFrame.mode);
-        }
-        if (typeof ed.browserFrame.drawShadow === "boolean") {
-          setBrowserFrameDrawShadow(ed.browserFrame.drawShadow);
-        }
-        if (typeof ed.browserFrame.drawBorder === "boolean") {
-          setBrowserFrameDrawBorder(ed.browserFrame.drawBorder);
-        }
-      }
-    };
-
     axios
       .get(`/api/demo?id=${demoId}`)
       .then((res) => {
@@ -155,8 +99,26 @@ export function useDemoLoader({
         if (demo.description) {
           setSidebarDescription(demo.description || "");
         }
+        // Restore the source video from the demo record. This covers the case
+        // where a demo was saved from inside the editor (its URL only carries a
+        // demoId, no `video=` param) and the page is then refreshed. See #226.
+        if (demo.videoUrl && !videoUrlRef.current && !params?.get("video")) {
+          void resolvePlayableVideoUrl(demo.videoUrl, setVideoUrl);
+        }
         if (demo.editing) {
-          restoreDemoEditing(demo.editing);
+          applyDemoEditing(demo.editing, {
+            setSegments,
+            setCurrentSegments,
+            setZoomSegments,
+            setSubtitleCues,
+            setTextOverlays,
+            setSelectedBackground,
+            setBackgroundType,
+            setAspectRatio,
+            setBrowserFrameMode,
+            setBrowserFrameDrawShadow,
+            setBrowserFrameDrawBorder,
+          });
         }
         setTimeout(() => {
           if (isMounted) {
@@ -172,6 +134,7 @@ export function useDemoLoader({
     savedDemoId,
     params,
     isEditorInitializedRef,
+    setVideoUrl,
     setSidebarDescription,
     setSidebarTitle,
     setCurrentSegments,

--- a/app/(signed)/editor/hooks/useLocalDraft.ts
+++ b/app/(signed)/editor/hooks/useLocalDraft.ts
@@ -1,0 +1,263 @@
+import React from "react";
+
+import { clearVideoDraft } from "@/app/lib/videoDraftStore";
+
+import { applyDemoEditing, buildEditingPayload, DemoEditing } from "../utils/editingDraft";
+import type { EditorState, SubtitlesApi, TextOverlaysApi, ZoomEditorApi } from "../apiTypes";
+
+// localStorage draft of the editing state for an UNSAVED session (no demoId).
+// Once a demo is saved it gets a demoId and the backend becomes the source of
+// truth, so this hook is a no-op from that point on. See issue #226.
+const LOCAL_DRAFT_KEY = "marvedge-editor-local-draft";
+const DEBOUNCE_MS = 800;
+
+interface StoredDraft {
+  draftId: string;
+  title: string;
+  description: string;
+  editing: DemoEditing;
+}
+
+interface UseLocalDraftProps {
+  editorState: EditorState;
+  draftId: string | null;
+  segments: { start: number; end: number }[];
+  setSegments: (segments: { start: number; end: number }[]) => void;
+  zoom: ZoomEditorApi;
+  subtitles: SubtitlesApi;
+  text: TextOverlaysApi;
+}
+
+function getUrlDemoId(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return new URLSearchParams(window.location.search).get("demoId");
+}
+
+function readStoredDraft(): StoredDraft | null {
+  try {
+    const raw = window.localStorage.getItem(LOCAL_DRAFT_KEY);
+    return raw ? (JSON.parse(raw) as StoredDraft) : null;
+  } catch {
+    // Corrupt or unavailable storage: behave as if there is no draft.
+    return null;
+  }
+}
+
+function writeStoredDraft(draft: StoredDraft): void {
+  try {
+    window.localStorage.setItem(LOCAL_DRAFT_KEY, JSON.stringify(draft));
+  } catch {
+    // Ignore quota/availability errors — persistence is best-effort.
+  }
+}
+
+function removeStoredDraft(): void {
+  try {
+    window.localStorage.removeItem(LOCAL_DRAFT_KEY);
+  } catch {
+    // Ignore.
+  }
+}
+
+// Writes the pending draft immediately and clears it (used by both the debounce
+// timer and the hide/unload flush).
+function flushPending(ref: { current: StoredDraft | null }): void {
+  if (ref.current) {
+    writeStoredDraft(ref.current);
+    ref.current = null;
+  }
+}
+
+// Runs `flush` when the page is being hidden or unloaded, so the last edit isn't
+// lost inside the debounce window on an abrupt refresh. Returns a cleanup fn.
+function addFlushListeners(flush: () => void): () => void {
+  const onVisibility = () => {
+    if (document.visibilityState === "hidden") {
+      flush();
+    }
+  };
+  window.addEventListener("beforeunload", flush);
+  document.addEventListener("visibilitychange", onVisibility);
+  return () => {
+    window.removeEventListener("beforeunload", flush);
+    document.removeEventListener("visibilitychange", onVisibility);
+  };
+}
+
+export function useLocalDraft({
+  editorState,
+  draftId,
+  segments,
+  setSegments,
+  zoom,
+  subtitles,
+  text,
+}: UseLocalDraftProps) {
+  const { zoomSegments, setZoomSegments } = zoom;
+  const { subtitleCues, setSubtitleCues } = subtitles;
+  const { textOverlays, setTextOverlays } = text;
+  const {
+    savedDemoId,
+    selectedBackground,
+    backgroundType,
+    aspectRatio,
+    browserFrameMode,
+    browserFrameDrawShadow,
+    browserFrameDrawBorder,
+    sidebarTitle,
+    sidebarDescription,
+    setSidebarTitle,
+    setSidebarDescription,
+    setCurrentSegments,
+    setSelectedBackground,
+    setBackgroundType,
+    setAspectRatio,
+    setBrowserFrameMode,
+    setBrowserFrameDrawShadow,
+    setBrowserFrameDrawBorder,
+  } = editorState;
+
+  const restoredRef = React.useRef(false);
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Holds the draft the debounced timer will write, so it can be flushed early.
+  const pendingDraftRef = React.useRef<StoredDraft | null>(null);
+
+  // Whether this editor session began WITHOUT a demoId (i.e. an unsaved upload),
+  // captured once. Used so that merely opening an existing demo never clears a
+  // separate, unrelated draft that a previous unsaved session left behind.
+  const startedUnsavedRef = React.useRef<boolean | null>(null);
+  if (startedUnsavedRef.current === null) {
+    startedUnsavedRef.current = !getUrlDemoId();
+  }
+
+  // Restore editing state from localStorage once the draft video is known.
+  React.useEffect(() => {
+    if (restoredRef.current || !draftId) {
+      return;
+    }
+    // A saved demo restores its editing from the backend (demo.editing); never
+    // let a local draft clobber it.
+    if (savedDemoId || getUrlDemoId()) {
+      restoredRef.current = true;
+      return;
+    }
+
+    restoredRef.current = true;
+    const parsed = readStoredDraft();
+    // Ignore a missing draft or one that belongs to a different (older) video.
+    if (!parsed || parsed.draftId !== draftId) {
+      return;
+    }
+    if (parsed.title) {
+      setSidebarTitle(parsed.title);
+    }
+    if (parsed.description) {
+      setSidebarDescription(parsed.description);
+    }
+    applyDemoEditing(parsed.editing, {
+      setSegments,
+      setCurrentSegments,
+      setZoomSegments,
+      setSubtitleCues,
+      setTextOverlays,
+      setSelectedBackground,
+      setBackgroundType,
+      setAspectRatio,
+      setBrowserFrameMode,
+      setBrowserFrameDrawShadow,
+      setBrowserFrameDrawBorder,
+    });
+  }, [
+    draftId,
+    savedDemoId,
+    setSidebarTitle,
+    setSidebarDescription,
+    setSegments,
+    setCurrentSegments,
+    setZoomSegments,
+    setSubtitleCues,
+    setTextOverlays,
+    setSelectedBackground,
+    setBackgroundType,
+    setAspectRatio,
+    setBrowserFrameMode,
+    setBrowserFrameDrawShadow,
+    setBrowserFrameDrawBorder,
+  ]);
+
+  // Persist editing state to localStorage (debounced) for unsaved sessions only.
+  React.useEffect(() => {
+    if (!draftId || !restoredRef.current) {
+      return;
+    }
+    if (savedDemoId || getUrlDemoId()) {
+      return;
+    }
+
+    pendingDraftRef.current = {
+      draftId,
+      title: sidebarTitle || "",
+      description: sidebarDescription || "",
+      editing: buildEditingPayload({
+        segments,
+        zoomSegments,
+        selectedBackground,
+        backgroundType,
+        subtitleCues,
+        textOverlays,
+        aspectRatio,
+        browserFrameMode,
+        browserFrameDrawShadow,
+        browserFrameDrawBorder,
+      }),
+    };
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    debounceRef.current = setTimeout(() => flushPending(pendingDraftRef), DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+  }, [
+    draftId,
+    savedDemoId,
+    segments,
+    zoomSegments,
+    subtitleCues,
+    textOverlays,
+    selectedBackground,
+    backgroundType,
+    aspectRatio,
+    browserFrameMode,
+    browserFrameDrawShadow,
+    browserFrameDrawBorder,
+    sidebarTitle,
+    sidebarDescription,
+  ]);
+
+  // Flush any pending (debounced) write before the tab is hidden or unloaded so
+  // an abrupt refresh keeps the very last edit.
+  React.useEffect(() => {
+    return addFlushListeners(() => flushPending(pendingDraftRef));
+  }, []);
+
+  // Once THIS unsaved session is saved as a demo, the backend owns both the
+  // editing state and the source video (restored on reload via demo.editing /
+  // demo.videoUrl), so drop the client-side draft to avoid resurrecting stale
+  // work on a later visit. Skipped when the session opened an existing demo, so
+  // an unrelated draft from a prior session is left untouched.
+  React.useEffect(() => {
+    if (!savedDemoId || !startedUnsavedRef.current) {
+      return;
+    }
+    removeStoredDraft();
+    void clearVideoDraft().catch(() => {});
+  }, [savedDemoId]);
+}

--- a/app/(signed)/editor/hooks/useURLParams.ts
+++ b/app/(signed)/editor/hooks/useURLParams.ts
@@ -51,7 +51,7 @@ function normalizeBrowserFrameMode(value: string | null): BrowserFrameMode | nul
 }
 
 // Resolves a gs:// video URL to a playable URL (or sets the URL directly).
-async function resolvePlayableVideoUrl(
+export async function resolvePlayableVideoUrl(
   urlVideo: string,
   setVideoUrl: (url: string | null) => void
 ): Promise<void> {

--- a/app/(signed)/editor/utils/editingDraft.ts
+++ b/app/(signed)/editor/utils/editingDraft.ts
@@ -1,0 +1,122 @@
+import { ZoomEffect } from "@/app/types/editor/zoom-effect";
+
+import { BrowserFrameMode } from "../hooks/useEditorState";
+import { SubtitleCue, TextOverlayItem } from "../types";
+
+// The serialized editing state persisted for a demo (backend `demo.editing`,
+// local draft, or URL params). Segments are strings on the wire but may arrive
+// as numbers from some sources, so both are accepted when reading back.
+export type DemoEditing = {
+  segments?: { start: string | number; end: string | number }[];
+  zoom?: ZoomEffect[];
+  background?: string | null;
+  backgroundType?: string;
+  subtitles?: SubtitleCue[];
+  textOverlays?: TextOverlayItem[];
+  aspectRatio?: string;
+  browserFrame?: {
+    mode?: BrowserFrameMode;
+    drawShadow?: boolean;
+    drawBorder?: boolean;
+  };
+};
+
+export interface EditingPayloadInput {
+  segments: { start: number; end: number }[];
+  zoomSegments: ZoomEffect[];
+  selectedBackground: string | null;
+  backgroundType: string;
+  subtitleCues: SubtitleCue[];
+  textOverlays: TextOverlayItem[];
+  aspectRatio: string;
+  browserFrameMode: BrowserFrameMode;
+  browserFrameDrawShadow: boolean;
+  browserFrameDrawBorder: boolean;
+}
+
+// Builds the canonical editing payload shared by backend autosave and the local
+// draft, so both write the exact same shape.
+export function buildEditingPayload(input: EditingPayloadInput): DemoEditing {
+  return {
+    segments: input.segments.map((s) => ({
+      start: String(s.start),
+      end: String(s.end),
+    })),
+    zoom: input.zoomSegments,
+    background: input.selectedBackground ?? null,
+    backgroundType: input.backgroundType || "",
+    subtitles: input.subtitleCues || [],
+    textOverlays: input.textOverlays || [],
+    aspectRatio: input.aspectRatio || "native",
+    browserFrame: {
+      mode: input.browserFrameMode,
+      drawShadow: input.browserFrameDrawShadow,
+      drawBorder: input.browserFrameDrawBorder,
+    },
+  };
+}
+
+export interface EditingSetters {
+  setSegments: (segments: { start: number; end: number }[]) => void;
+  setCurrentSegments: (segments: { start: string; end: string }[]) => void;
+  setZoomSegments: (segments: ZoomEffect[]) => void;
+  setSubtitleCues: (cues: SubtitleCue[]) => void;
+  setTextOverlays: (overlays: TextOverlayItem[]) => void;
+  setSelectedBackground: (bg: string) => void;
+  setBackgroundType: (type: string) => void;
+  setAspectRatio: (ratio: string) => void;
+  setBrowserFrameMode: (mode: BrowserFrameMode) => void;
+  setBrowserFrameDrawShadow: (enabled: boolean) => void;
+  setBrowserFrameDrawBorder: (enabled: boolean) => void;
+}
+
+// Applies a saved editing payload back into editor state. Shared by the backend
+// demo loader and the local draft restore so both behave identically.
+export function applyDemoEditing(ed: DemoEditing, setters: EditingSetters): void {
+  if (ed.segments) {
+    const numeric = ed.segments
+      .map((s) => ({
+        start: typeof s.start === "string" ? parseFloat(s.start) : Number(s.start),
+        end: typeof s.end === "string" ? parseFloat(s.end) : Number(s.end),
+      }))
+      .filter((s) => !isNaN(s.start) && !isNaN(s.end));
+    if (numeric.length > 0) {
+      setters.setSegments(numeric);
+      setters.setCurrentSegments(
+        ed.segments.map((s) => ({
+          start: String(s.start),
+          end: String(s.end),
+        }))
+      );
+    }
+  }
+  if (ed.zoom) {
+    setters.setZoomSegments(ed.zoom);
+  }
+  if (ed.background) {
+    setters.setSelectedBackground(ed.background);
+  }
+  if (ed.backgroundType) {
+    setters.setBackgroundType(ed.backgroundType);
+  }
+  if (ed.subtitles) {
+    setters.setSubtitleCues(ed.subtitles);
+  }
+  if (ed.textOverlays) {
+    setters.setTextOverlays(ed.textOverlays);
+  }
+  if (ed.aspectRatio) {
+    setters.setAspectRatio(ed.aspectRatio);
+  }
+  if (ed.browserFrame) {
+    if (ed.browserFrame.mode) {
+      setters.setBrowserFrameMode(ed.browserFrame.mode);
+    }
+    if (typeof ed.browserFrame.drawShadow === "boolean") {
+      setters.setBrowserFrameDrawShadow(ed.browserFrame.drawShadow);
+    }
+    if (typeof ed.browserFrame.drawBorder === "boolean") {
+      setters.setBrowserFrameDrawBorder(ed.browserFrame.drawBorder);
+    }
+  }
+}

--- a/app/hooks/useEditor.ts
+++ b/app/hooks/useEditor.ts
@@ -32,7 +32,14 @@ export const useEditor = () => {
   };
 
   useEffect(() => {
-    if (!blob) {
+    if (blob) {
+      return;
+    }
+    // Only rehydrate a persisted draft for a fresh, param-less editor session
+    // (an accidental refresh after upload). A video/demo opened from the URL
+    // provides its own source, so we must not resurrect an unrelated draft.
+    const params = new URLSearchParams(window.location.search);
+    if (!params.get("video") && !params.get("demoId")) {
       restoreBlob();
     }
   }, [blob, restoreBlob]);

--- a/app/lib/videoDraftStore.ts
+++ b/app/lib/videoDraftStore.ts
@@ -1,0 +1,130 @@
+// IndexedDB-backed persistence for the in-progress editor video ("draft").
+//
+// The recorded/uploaded video otherwise lives only in memory (see blobStore), so
+// an accidental refresh before the user saves or exports discards the video
+// entirely. IndexedDB (not localStorage) is used because it stores large Blobs
+// natively without the ~5MB string limit. See issue #226.
+
+const DB_NAME = "marvedge-editor";
+const DB_VERSION = 1;
+const STORE_NAME = "video-draft";
+const BLOB_KEY = "blob";
+const META_KEY = "meta";
+
+export interface VideoDraftMeta {
+  // Identifies which draft the persisted editing state (localStorage) belongs to,
+  // so stale edits are never applied to a different video.
+  draftId: string;
+  type: string;
+  name: string;
+  title: string;
+  description: string;
+  sourceDuration: number;
+  savedAt: number;
+}
+
+export interface VideoDraft {
+  blob: Blob;
+  meta: VideoDraftMeta | null;
+}
+
+function getIndexedDb(): IDBFactory | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.indexedDB ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const idb = getIndexedDb();
+    if (!idb) {
+      reject(new Error("IndexedDB is not available"));
+      return;
+    }
+    const request = idb.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Failed to open IndexedDB"));
+  });
+}
+
+function runWrite(db: IDBDatabase, work: (store: IDBObjectStore) => void): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    work(tx.objectStore(STORE_NAME));
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+function getValue<T>(db: IDBDatabase, key: string): Promise<T | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const request = tx.objectStore(STORE_NAME).get(key);
+    request.onsuccess = () => resolve(request.result as T | undefined);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+// Persists the video blob together with its metadata in a single transaction.
+export async function saveVideoDraft(blob: Blob, meta: VideoDraftMeta): Promise<void> {
+  const db = await openDb();
+  try {
+    await runWrite(db, (store) => {
+      store.put(blob, BLOB_KEY);
+      store.put(meta, META_KEY);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+// Updates only the metadata (title/description/duration) without rewriting the blob.
+export async function saveVideoDraftMeta(meta: VideoDraftMeta): Promise<void> {
+  const db = await openDb();
+  try {
+    await runWrite(db, (store) => {
+      store.put(meta, META_KEY);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export async function loadVideoDraft(): Promise<VideoDraft | null> {
+  const db = await openDb();
+  try {
+    const [blob, meta] = await Promise.all([
+      getValue<Blob>(db, BLOB_KEY),
+      getValue<VideoDraftMeta>(db, META_KEY),
+    ]);
+    if (!blob) {
+      return null;
+    }
+    return { blob, meta: meta ?? null };
+  } finally {
+    db.close();
+  }
+}
+
+export async function clearVideoDraft(): Promise<void> {
+  const db = await openDb();
+  try {
+    await runWrite(db, (store) => {
+      store.clear();
+    });
+  } finally {
+    db.close();
+  }
+}

--- a/app/store/blobStore.ts
+++ b/app/store/blobStore.ts
@@ -1,27 +1,113 @@
 import { create } from "zustand";
 
-export const useBlobStore = create<{
+import {
+  clearVideoDraft,
+  loadVideoDraft,
+  saveVideoDraft,
+  saveVideoDraftMeta,
+  type VideoDraftMeta,
+} from "../lib/videoDraftStore";
+
+// Unique id for a persisted draft, so restored editing state (localStorage) can be
+// matched to the video it belongs to. See issue #226.
+function generateDraftId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `draft-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+interface BlobStore {
   blob: Blob | null;
   sourceDuration: number;
   title: string;
   description: string;
+  draftId: string | null;
   setBlob: (blob: Blob | null) => void;
   setSourceDuration: (seconds: number) => void;
   setTitle: (title: string) => void;
   setDescription: (description: string) => void;
   reset: () => void;
   restoreBlob: () => void;
-}>((set) => ({
-  blob: null,
-  sourceDuration: 0,
-  title: "",
-  description: "",
-  setBlob: (blob) => {
-    set({ blob });
-  },
-  setSourceDuration: (sourceDuration) => set({ sourceDuration }),
-  setTitle: (title) => set({ title }),
-  setDescription: (description) => set({ description }),
-  reset: () => set({ blob: null, sourceDuration: 0, title: "", description: "" }),
-  restoreBlob: () => {},
-}));
+}
+
+export const useBlobStore = create<BlobStore>((set, get) => {
+  const buildMeta = (draftId: string): VideoDraftMeta => {
+    const { blob, title, description, sourceDuration } = get();
+    return {
+      draftId,
+      type: blob?.type ?? "",
+      name: (blob as File | null)?.name ?? "",
+      title,
+      description,
+      sourceDuration,
+      savedAt: Date.now(),
+    };
+  };
+
+  // Metadata edits (title/description/duration) only re-persist if a draft video
+  // already exists in IndexedDB — there is nothing to attach them to otherwise.
+  const persistMetaIfDraft = () => {
+    const { blob, draftId } = get();
+    if (blob && draftId) {
+      void saveVideoDraftMeta(buildMeta(draftId)).catch(() => {});
+    }
+  };
+
+  return {
+    blob: null,
+    sourceDuration: 0,
+    title: "",
+    description: "",
+    draftId: null,
+    setBlob: (blob) => {
+      if (blob) {
+        // A new video is a new draft; any previously restored editing state no
+        // longer applies and is invalidated by the fresh draftId.
+        const draftId = generateDraftId();
+        set({ blob, draftId });
+        void saveVideoDraft(blob, buildMeta(draftId)).catch(() => {});
+      } else {
+        set({ blob: null, draftId: null });
+        void clearVideoDraft().catch(() => {});
+      }
+    },
+    setSourceDuration: (sourceDuration) => {
+      set({ sourceDuration });
+      persistMetaIfDraft();
+    },
+    setTitle: (title) => {
+      set({ title });
+      persistMetaIfDraft();
+    },
+    setDescription: (description) => {
+      set({ description });
+      persistMetaIfDraft();
+    },
+    reset: () => {
+      set({ blob: null, sourceDuration: 0, title: "", description: "", draftId: null });
+      void clearVideoDraft().catch(() => {});
+    },
+    // Rehydrates the in-memory blob from IndexedDB after a refresh. No-op if a
+    // blob is already present or nothing was persisted.
+    restoreBlob: () => {
+      if (get().blob) {
+        return;
+      }
+      void loadVideoDraft()
+        .then((draft) => {
+          if (!draft || get().blob) {
+            return;
+          }
+          set({
+            blob: draft.blob,
+            draftId: draft.meta?.draftId ?? generateDraftId(),
+            sourceDuration: draft.meta?.sourceDuration ?? 0,
+            title: draft.meta?.title ?? "",
+            description: draft.meta?.description ?? "",
+          });
+        })
+        .catch(() => {});
+    },
+  };
+});


### PR DESCRIPTION
fixes #226

The uploaded/recorded video (blobStore) and pre-save editing state lived only in memory, so an accidental refresh before saving lost everything.

- Persist the draft video blob to IndexedDB and rehydrate it via restoreBlob() after a refresh (only for a param-less editor session).
- Persist editing state to localStorage for unsaved sessions, keyed by a draftId so stale edits are never applied to a different video; flush on hide/unload and drop the draft once the project is saved.
- Restore the source video from demo.videoUrl on reload, covering demos saved from inside the editor (URL carries only a demoId).
- Extract shared buildEditingPayload/applyDemoEditing helpers used by the backend autosave, the local draft, and the demo loader.