### PR TITLE
feat(avs): foundation & AVS panel scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,79 @@
+# ---------------------------------------------------------------------------
+# Marvedge — example environment. Copy to `.env` and fill in the values you need.
+# Only DATABASE_URL + NEXTAUTH_* are required to boot the app.
+# Everything below the "Optional integrations" line powers individual features
+# (payments, email, video processing, uploads, AVS) and can stay blank until needed.
+# ---------------------------------------------------------------------------
+
+# --- Database (REQUIRED) ---------------------------------------------------
+# PostgreSQL connection string. Replace with your own local/hosted Postgres URL.
+DATABASE_URL=""
+
+# --- NextAuth (REQUIRED) ---------------------------------------------------
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET=""
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+
+# ---------------------------------------------------------------------------
+# Optional integrations — leave blank unless you are exercising that feature.
+# ---------------------------------------------------------------------------
+
+# Google OAuth (sign-in with Google)
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+
+# Razorpay (payments)
+NEXT_PUBLIC_RAZORPAY_KEY_ID=""
+RAZORPAY_KEY_SECRET=""
+
+# Resend (transactional email: contact form, password reset)
+RESEND_API_KEY=""
+RESEND_FROM_EMAIL=""
+DEMO_REQUEST_TO_EMAIL=""
+
+# Cloudinary (media uploads)
+CLOUDINARY_CLOUD_NAME=""
+CLOUDINARY_API_KEY=""
+CLOUDINARY_API_SECRET=""
+NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=""
+NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET=""
+CLOUDINARY_UPLOAD_PRESET=""
+
+# Redis / BullMQ (background video jobs)
+REDIS_URL=""
+
+# Video processing worker / cloud backends
+NEXT_PUBLIC_VIDEO_PROCESSING_BACKEND_URL=""
+USE_GCP_WORKER=""
+USE_AWS_SPLITTER=""
+GCP_VIDEO_WORKER_URL=""
+CALLBACK_SECRET=""
+
+# Deepgram (subtitles / transcription AND Aura text-to-speech for AVS voiceover).
+# Server-only — never expose with a NEXT_PUBLIC_ prefix.
+DEEPGRAM_API_KEY=""
+
+# Google Cloud Storage (raw/processed video buckets)
+GOOGLE_CLOUD_PROJECT_ID=""
+GOOGLE_CLOUD_CLIENT_EMAIL=""
+GOOGLE_CLOUD_PRIVATE_KEY=""
+GCP_RAW_BUCKET=""
+
+# AWS (DynamoDB job progress + Lambda splitter)
+AWS_REGION=""
+AWS_SPLITTER_FUNCTION_NAME=""
+DDB_TABLE=""
+
+# ---------------------------------------------------------------------------
+# AVS — AI Script, Voiceover & Audio Synchronization (PRO/ENTERPRISE only)
+# ---------------------------------------------------------------------------
+
+# OpenAI (AI script tone rewrite). Server-only — never expose to the browser.
+OPENAI_API_KEY=""
+
+# AVS master switch (server-only). Set to "true" to enable AVS server routes.
+AVS_ENABLED=""
+
+# AVS UI panel switch (client-safe). Set to "true" to show the "AI Voice & Script"
+# sidebar panel. Only shows for PRO/ENTERPRISE users.
+NEXT_PUBLIC_AVS_ENABLED=""

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/(signed)/editor/hooks/useAutosave.ts
+++ b/app/(signed)/editor/hooks/useAutosave.ts
@@ -34,6 +34,7 @@ export function useAutosave({
     browserFrameMode,
     browserFrameDrawShadow,
     browserFrameDrawBorder,
+    avs,
     sidebarTitle,
     sidebarDescription,
   } = editorState;
@@ -54,6 +55,7 @@ export function useAutosave({
       browserFrameMode,
       browserFrameDrawShadow,
       browserFrameDrawBorder,
+      avs,
     });
   }, [
     segments,
@@ -66,6 +68,7 @@ export function useAutosave({
     browserFrameMode,
     browserFrameDrawShadow,
     browserFrameDrawBorder,
+    avs,
   ]);
 
   const flushAutosave = React.useCallback(async () => {
@@ -135,6 +138,7 @@ export function useAutosave({
     browserFrameMode,
     browserFrameDrawShadow,
     browserFrameDrawBorder,
+    avs,
     sidebarTitle,
     sidebarDescription,
     flushAutosave,

--- a/app/(signed)/editor/hooks/useDemoLoader.ts
+++ b/app/(signed)/editor/hooks/useDemoLoader.ts
@@ -41,6 +41,7 @@ export function useDemoLoader({
     setBrowserFrameMode,
     setBrowserFrameDrawShadow,
     setBrowserFrameDrawBorder,
+    setAvs,
     setCtas,
   } = editorState;
 
@@ -118,6 +119,7 @@ export function useDemoLoader({
             setBrowserFrameMode,
             setBrowserFrameDrawShadow,
             setBrowserFrameDrawBorder,
+            setAvs,
           });
         }
         setTimeout(() => {
@@ -144,6 +146,7 @@ export function useDemoLoader({
     setBrowserFrameMode,
     setBrowserFrameDrawShadow,
     setBrowserFrameDrawBorder,
+    setAvs,
     setSegments,
     setZoomSegments,
     setSubtitleCues,

--- a/app/(signed)/editor/hooks/useLocalDraft.ts
+++ b/app/(signed)/editor/hooks/useLocalDraft.ts
@@ -106,6 +106,7 @@ export function useLocalDraft({
     browserFrameMode,
     browserFrameDrawShadow,
     browserFrameDrawBorder,
+    avs,
     sidebarTitle,
     sidebarDescription,
     setSidebarTitle,
@@ -117,6 +118,7 @@ export function useLocalDraft({
     setBrowserFrameMode,
     setBrowserFrameDrawShadow,
     setBrowserFrameDrawBorder,
+    setAvs,
   } = editorState;
 
   const restoredRef = React.useRef(false);
@@ -168,6 +170,7 @@ export function useLocalDraft({
       setBrowserFrameMode,
       setBrowserFrameDrawShadow,
       setBrowserFrameDrawBorder,
+      setAvs,
     });
   }, [
     draftId,
@@ -185,6 +188,7 @@ export function useLocalDraft({
     setBrowserFrameMode,
     setBrowserFrameDrawShadow,
     setBrowserFrameDrawBorder,
+    setAvs,
   ]);
 
   // Persist editing state to localStorage (debounced) for unsaved sessions only.
@@ -211,6 +215,7 @@ export function useLocalDraft({
         browserFrameMode,
         browserFrameDrawShadow,
         browserFrameDrawBorder,
+        avs,
       }),
     };
 
@@ -238,6 +243,7 @@ export function useLocalDraft({
     browserFrameMode,
     browserFrameDrawShadow,
     browserFrameDrawBorder,
+    avs,
     sidebarTitle,
     sidebarDescription,
   ]);

--- a/app/(signed)/editor/utils/editingDraft.ts
+++ b/app/(signed)/editor/utils/editingDraft.ts
@@ -1,4 +1,5 @@
 import { ZoomEffect } from "@/app/types/editor/zoom-effect";
+import { AvsState } from "@/app/types/avs";
 
 import { BrowserFrameMode } from "../hooks/useEditorState";
 import { SubtitleCue, TextOverlayItem } from "../types";
@@ -19,6 +20,9 @@ export type DemoEditing = {
     drawShadow?: boolean;
     drawBorder?: boolean;
   };
+  // AVS state (steps / script / voiceover / pronunciation). Absent on demos
+  // saved before AVS existed, or whenever the feature produced no state.
+  avs?: AvsState | null;
 };
 
 export interface EditingPayloadInput {
@@ -32,6 +36,7 @@ export interface EditingPayloadInput {
   browserFrameMode: BrowserFrameMode;
   browserFrameDrawShadow: boolean;
   browserFrameDrawBorder: boolean;
+  avs: AvsState | null;
 }
 
 // Builds the canonical editing payload shared by backend autosave and the local
@@ -53,6 +58,7 @@ export function buildEditingPayload(input: EditingPayloadInput): DemoEditing {
       drawShadow: input.browserFrameDrawShadow,
       drawBorder: input.browserFrameDrawBorder,
     },
+    avs: input.avs ?? null,
   };
 }
 
@@ -68,6 +74,7 @@ export interface EditingSetters {
   setBrowserFrameMode: (mode: BrowserFrameMode) => void;
   setBrowserFrameDrawShadow: (enabled: boolean) => void;
   setBrowserFrameDrawBorder: (enabled: boolean) => void;
+  setAvs: (avs: AvsState | null) => void;
 }
 
 // Applies a saved editing payload back into editor state. Shared by the backend
@@ -118,5 +125,8 @@ export function applyDemoEditing(ed: DemoEditing, setters: EditingSetters): void
     if (typeof ed.browserFrame.drawBorder === "boolean") {
       setters.setBrowserFrameDrawBorder(ed.browserFrame.drawBorder);
     }
+  }
+  if (ed.avs) {
+    setters.setAvs(ed.avs);
   }
 }

--- a/app/components/EditorSidebar.tsx
+++ b/app/components/EditorSidebar.tsx
@@ -4,6 +4,8 @@ import SidebarHeader from "./editorSidebar/SidebarHeader";
 import BackgroundPanel from "./editorSidebar/BackgroundPanel";
 import ToolsPanel from "./editorSidebar/ToolsPanel";
 import CtaPanel from "./editorSidebar/CtaPanel";
+import AvsPanel from "./editorSidebar/AvsPanel";
+import { isAvsPanelEnabled } from "@/app/lib/avs/flags";
 import type { CtaItem } from "@/app/(signed)/editor/apiTypes";
 
 interface EditorSidebarProps {
@@ -158,6 +160,8 @@ const EditorSidebar: React.FC<EditorSidebarProps> = ({
           onReorderCta={onReorderCta}
         />
       )}
+
+      {activeTab === "avs" && isAvsPanelEnabled() && <AvsPanel />}
     </aside>
   );
 };

--- a/app/components/editorSidebar/AvsPanel.tsx
+++ b/app/components/editorSidebar/AvsPanel.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+/**
+ * AVS ("AI Voice & Script") sidebar panel — scaffold only.
+ *
+ * PR 1 ships this as an empty shell behind the client feature flag
+ * (NEXT_PUBLIC_AVS_ENABLED). Later AVS PRs fill it in: step editing, AI script,
+ * Deepgram Aura voiceover, subtitle stabilization and time-alignment. Styling
+ * mirrors ToolsPanel so it drops into the existing sidebar unchanged.
+ */
+const AvsPanel: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="control-block-label text-lg font-bold text-[#A594F9] mb-4">
+          AI Voice &amp; Script
+        </h2>
+        <div className="rounded-lg border border-[#ede7fa] bg-[#F6F3FF] px-4 py-6 text-sm text-[#7C5CFC]">
+          <p className="font-semibold">Coming soon</p>
+          <p className="mt-1 text-[#6B6B6B] dark:text-inherit">
+            Generate an AI script, voiceover, and perfectly synced audio for your demo.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AvsPanel;

--- a/app/components/editorSidebar/SidebarHeader.tsx
+++ b/app/components/editorSidebar/SidebarHeader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import { MainTab } from "./backgroundOptions";
+import { isAvsPanelEnabled } from "@/app/lib/avs/flags";
 
 interface SidebarHeaderProps {
   title: string;
@@ -99,6 +100,16 @@ const SidebarHeader: React.FC<SidebarHeaderProps> = ({
         >
           CTA
         </button>
+        {isAvsPanelEnabled() && (
+          <button
+            className={`tab-item flex-1 cursor-pointer py-2 rounded-lg text-sm font-semibold ${
+              activeTab === "avs" ? "active bg-white text-[#7C5CFC] shadow" : "text-gray-600"
+            }`}
+            onClick={() => setActiveTab("avs")}
+          >
+            AI Voice
+          </button>
+        )}
       </div>
     </>
   );

--- a/app/components/editorSidebar/backgroundOptions.ts
+++ b/app/components/editorSidebar/backgroundOptions.ts
@@ -1,4 +1,4 @@
-export type MainTab = "background" | "tools" | "cta";
+export type MainTab = "background" | "tools" | "cta" | "avs";
 export type BgSubTab = "image" | "gradient" | "color" | "hidden";
 
 export interface ImageBackgroundOption {

--- a/app/lib/avs/access.ts
+++ b/app/lib/avs/access.ts
@@ -1,0 +1,16 @@
+// PRO-gate for AVS. Access mirrors the plan check used by the export path
+// (`isExportAllowed` in app/api/jobs/create/route.ts): AVS is available to
+// PRO and ENTERPRISE users only. The free 3-export limit is unaffected.
+//
+// The User.plan column is a plain string defaulting to "FREE" (see
+// prisma/schema.prisma), with paid tiers stored as "PRO" / "ENTERPRISE".
+
+const AVS_ALLOWED_PLANS = ["PRO", "ENTERPRISE"] as const;
+
+/**
+ * Whether a user on the given plan may use AVS. Server routes should call this
+ * after resolving the user's plan and return 403 when it returns false.
+ */
+export function isAvsAllowed(plan: string | null | undefined): boolean {
+  return typeof plan === "string" && (AVS_ALLOWED_PLANS as readonly string[]).includes(plan);
+}

--- a/app/lib/avs/flags.ts
+++ b/app/lib/avs/flags.ts
@@ -1,0 +1,26 @@
+// Feature flags for AVS (AI Script, Voiceover & Audio Synchronization).
+//
+// AVS ships behind a flag and must be a no-op when the flag is off. There are
+// two flags so that server work (AI/TTS routes) and the client UI panel can be
+// toggled independently:
+//   - AVS_ENABLED            — server-only master switch (never sent to browser).
+//   - NEXT_PUBLIC_AVS_ENABLED — client-safe switch that gates the sidebar panel.
+
+const truthy = (value: string | undefined): boolean => value === "true" || value === "1";
+
+/**
+ * Server-side AVS master switch. Reads the server-only `AVS_ENABLED` env var, so
+ * this must only be called from server code (API routes, server components).
+ */
+export function isAvsEnabled(): boolean {
+  return truthy(process.env.AVS_ENABLED);
+}
+
+/**
+ * Client-safe flag that gates the "AI Voice & Script" sidebar panel. Reads
+ * `NEXT_PUBLIC_AVS_ENABLED`, which Next inlines at build time so it is safe to
+ * call from client components. Never exposes a real secret.
+ */
+export function isAvsPanelEnabled(): boolean {
+  return truthy(process.env.NEXT_PUBLIC_AVS_ENABLED);
+}

--- a/app/store/editor/editorStore.ts
+++ b/app/store/editor/editorStore.ts
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { create } from "zustand";
 
 import type { ZoomEffect } from "@/app/types/editor/zoom-effect";
+import type { AvsState } from "@/app/types/avs";
 import type {
   BrowserFrameMode,
   CtaItem,
@@ -78,6 +79,10 @@ export interface EditorStoreState {
   browserFrameDrawShadow: boolean;
   browserFrameDrawBorder: boolean;
 
+  // AVS (AI Script, Voiceover & Audio Synchronization) — persisted to
+  // Demo.editing.avs. Null until the feature produces state for this demo.
+  avs: AvsState | null;
+
   // Setters
   setParams: Dispatch<SetStateAction<URLSearchParams | null>>;
   setVideoUrl: Dispatch<SetStateAction<string | null>>;
@@ -113,6 +118,7 @@ export interface EditorStoreState {
   setBrowserFrameMode: Dispatch<SetStateAction<BrowserFrameMode>>;
   setBrowserFrameDrawShadow: Dispatch<SetStateAction<boolean>>;
   setBrowserFrameDrawBorder: Dispatch<SetStateAction<boolean>>;
+  setAvs: Dispatch<SetStateAction<AvsState | null>>;
 
   reset: () => void;
 }
@@ -156,6 +162,7 @@ const initialState = {
   browserFrameMode: "default" as BrowserFrameMode,
   browserFrameDrawShadow: true,
   browserFrameDrawBorder: false,
+  avs: null as AvsState | null,
 };
 
 export const useEditorStore = create<EditorStoreState>((set) => ({
@@ -200,6 +207,7 @@ export const useEditorStore = create<EditorStoreState>((set) => ({
     set((s) => ({ browserFrameDrawShadow: resolve(v, s.browserFrameDrawShadow) })),
   setBrowserFrameDrawBorder: (v) =>
     set((s) => ({ browserFrameDrawBorder: resolve(v, s.browserFrameDrawBorder) })),
+  setAvs: (v) => set((s) => ({ avs: resolve(v, s.avs) })),
 
   reset: () => set({ ...initialState }),
 }));

--- a/app/types/avs.ts
+++ b/app/types/avs.ts
@@ -1,0 +1,58 @@
+// Shared types for AVS (AI Script, Voiceover & Audio Synchronization).
+//
+// All AVS state is persisted inside the existing Demo.editing JSON under an
+// `avs` key (Demo.editing.avs) — there is no dedicated table or migration.
+// Downstream stages degrade gracefully when parts are absent (no steps → treat
+// the whole video as one step; no script → use the raw transcript; no voiceover
+// → skip that stage), so most fields on AvsState are optional.
+
+/** A slice of the demo video, derived from click-capture timestamps and editable in the timeline. */
+export interface Step {
+  id: string;
+  index: number;
+  startTime: number;
+  endTime: number;
+  label?: string;
+}
+
+/** Narration text for a single step. */
+export interface ScriptLine {
+  stepId: string;
+  text: string;
+}
+
+/** The full per-step narration script, optionally rewritten into a tone. */
+export interface ScriptDoc {
+  tone?: "sales" | "onboarding" | "support" | "marketing";
+  lines: ScriptLine[];
+  raw?: string;
+}
+
+/** Where a step's audio begins and ends within the continuous voiceover track. */
+export interface StepTiming {
+  stepId: string;
+  start: number;
+  end: number;
+}
+
+/** A generated voiceover: one continuous MP3 plus per-step timing markers. */
+export interface VoiceoverTrack {
+  audioUrl: string;
+  duration: number;
+  voiceId: string;
+  stepTimings: StepTiming[];
+}
+
+/** A phonetic override applied before TTS so a term is pronounced correctly. */
+export interface PronunciationRule {
+  term: string;
+  phonetic: string;
+}
+
+/** The complete AVS state stored under Demo.editing.avs. */
+export interface AvsState {
+  steps: Step[];
+  script?: ScriptDoc;
+  voiceover?: VoiceoverTrack;
+  pronunciation?: PronunciationRule[];
+}


### PR DESCRIPTION
Purely additive, feature-flagged scaffolding for the AI Script, Voiceover & Audio Synchronization (AVS) feature. No user-visible change when the flag is off.

- flags: isAvsEnabled() (server, AVS_ENABLED) + isAvsPanelEnabled() (client, NEXT_PUBLIC_AVS_ENABLED) in app/lib/avs/flags.ts
- access: isAvsAllowed() PRO/ENTERPRISE gate in app/lib/avs/access.ts, mirroring the export plan check
- types: shared AVS types (Step, ScriptDoc, VoiceoverTrack, PronunciationRule, AvsState) in app/types/avs.ts
- ui: empty "AI Voice & Script" sidebar panel (AvsPanel), shown as a new tab only when the client flag is on
- persistence: avs slice in the editor store, round-tripped through Demo.editing.avs via autosave/local-draft (save) and the demo loader (load)
- env: add .env.example (un-ignored) documenting OPENAI_API_KEY, DEEPGRAM_API_KEY, AVS_ENABLED and NEXT_PUBLIC_AVS_ENABLED as server-only / client flags

partial fixes #240 