### PR TITLE
feat(avs): step model & timeline step editing

### DIFF
--- a/app/api/avs/script/route.ts
+++ b/app/api/avs/script/route.ts
@@ -1,0 +1,215 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import OpenAI from "openai";
+
+import { authOptions } from "@/app/lib/auth/options";
+import { prisma } from "@/app/lib/prisma";
+import { isAvsEnabled } from "@/app/lib/avs/flags";
+import { isAvsAllowed } from "@/app/lib/avs/access";
+import { isScriptTone, toneGuidance, type ScriptTone } from "@/app/lib/avs/tones";
+import type { ScriptLine } from "@/app/types/avs";
+
+// OpenAI rewrite can take a few seconds for many steps; allow headroom.
+export const maxDuration = 60;
+
+// gpt-4o for rewrite quality (see AVS plan §7 / nit #5).
+const MODEL = "gpt-4o";
+
+const SYSTEM_PROMPT =
+  "You are an expert scriptwriter for software product demo voiceovers. You rewrite " +
+  "narration in a requested tone. Rules: always keep the text in English and never " +
+  "translate it; keep each segment concise and natural for a spoken voiceover; preserve " +
+  "the original meaning and the exact number of segments; never merge, split, reorder, or " +
+  "drop segments; do not add commentary, labels, headings, or markdown. Respond with " +
+  "strict JSON only.";
+
+interface LineInput {
+  stepId: string;
+  text: string;
+}
+
+/** Read + sanitize the `lines` body field into non-empty {stepId,text} entries. */
+function parseLines(value: unknown): LineInput[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const lines: LineInput[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null) {
+      continue;
+    }
+    const rec = entry as Record<string, unknown>;
+    const stepId = typeof rec.stepId === "string" ? rec.stepId : "";
+    const text = typeof rec.text === "string" ? rec.text.trim() : "";
+    if (stepId && text) {
+      lines.push({ stepId, text });
+    }
+  }
+  return lines;
+}
+
+/** Rewrite a batch of per-step narration lines, preserving order and stepIds. */
+async function rewriteLines(
+  openai: OpenAI,
+  lines: LineInput[],
+  tone: ScriptTone
+): Promise<ScriptLine[]> {
+  // Key segments by index (not stepId) so the model can't mangle ids; we map the
+  // rewritten text back onto the original stepIds ourselves.
+  const segments = lines.map((line, i) => ({ i, text: line.text }));
+
+  const instructions =
+    'Rewrite the "text" of every segment below in that tone. Return JSON of the exact form ' +
+    '{"segments":[{"i":<same index>,"text":<rewritten text>}]}, with one entry for every input ' +
+    "index and nothing else.";
+  const userPrompt = `Tone: ${tone}\nTone guidance: ${toneGuidance(tone)}\n\n${instructions}\n\n${JSON.stringify(
+    { segments }
+  )}`;
+
+  const completion = await openai.chat.completions.create({
+    model: MODEL,
+    temperature: 0.7,
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userPrompt },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "{}";
+  const rewritten = new Map<number, string>();
+  try {
+    const parsed = JSON.parse(content) as { segments?: unknown };
+    if (Array.isArray(parsed.segments)) {
+      for (const seg of parsed.segments) {
+        if (typeof seg !== "object" || seg === null) {
+          continue;
+        }
+        const rec = seg as Record<string, unknown>;
+        const i = Number(rec.i);
+        const text = typeof rec.text === "string" ? rec.text.trim() : "";
+        if (Number.isInteger(i) && text) {
+          rewritten.set(i, text);
+        }
+      }
+    }
+  } catch {
+    // Malformed JSON → fall back to the original text for every line below.
+  }
+
+  // Always return a line per input, falling back to the original text if the
+  // model omitted or blanked a segment.
+  return lines.map((line, i) => ({ stepId: line.stepId, text: rewritten.get(i) ?? line.text }));
+}
+
+/** Rewrite a single free-form script blob (the no-steps fallback). */
+async function rewriteRaw(openai: OpenAI, raw: string, tone: ScriptTone): Promise<string> {
+  const instructions =
+    "Rewrite the following demo narration in that tone. Return JSON of the exact form " +
+    '{"text":<rewritten text>} and nothing else.';
+  const userPrompt = `Tone: ${tone}\nTone guidance: ${toneGuidance(tone)}\n\n${instructions}\n\n${JSON.stringify(
+    { text: raw }
+  )}`;
+
+  const completion = await openai.chat.completions.create({
+    model: MODEL,
+    temperature: 0.7,
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userPrompt },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "{}";
+  try {
+    const parsed = JSON.parse(content) as { text?: unknown };
+    if (typeof parsed.text === "string" && parsed.text.trim()) {
+      return parsed.text.trim();
+    }
+  } catch {
+    // fall through to the original text
+  }
+  return raw;
+}
+
+export async function POST(req: NextRequest) {
+  // Flag off → the feature is invisible; behave as if the route doesn't exist.
+  if (!isAvsEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await prisma.user.findFirst({
+    where: {
+      OR: [
+        session.user.id ? { id: session.user.id as string } : undefined,
+        session.user.email ? { email: session.user.email } : undefined,
+      ].filter(Boolean) as Array<{ id?: string; email?: string }>,
+    },
+    select: { plan: true },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  // PRO/ENTERPRISE only — mirrors the export path's plan gate.
+  if (!isAvsAllowed(user.plan)) {
+    return NextResponse.json(
+      { error: "AVS is available on PRO and ENTERPRISE plans." },
+      {
+        status: 403,
+      }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!isScriptTone(body.tone)) {
+    return NextResponse.json({ error: "Invalid or missing tone" }, { status: 400 });
+  }
+  const tone = body.tone;
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "Script rewrite is not configured" }, { status: 500 });
+  }
+  const openai = new OpenAI({ apiKey });
+
+  try {
+    // Per-step mode takes precedence when `lines` is present.
+    const lines = parseLines(body.lines);
+    if (lines !== null && Array.isArray(body.lines)) {
+      if (lines.length === 0) {
+        return NextResponse.json({ error: "No script text to rewrite" }, { status: 400 });
+      }
+      const result = await rewriteLines(openai, lines, tone);
+      return NextResponse.json({ lines: result, tone });
+    }
+
+    // Fallback: single free-form blob.
+    if (typeof body.raw === "string") {
+      const raw = body.raw.trim();
+      if (!raw) {
+        return NextResponse.json({ error: "No script text to rewrite" }, { status: 400 });
+      }
+      const result = await rewriteRaw(openai, raw, tone);
+      return NextResponse.json({ raw: result, tone });
+    }
+
+    return NextResponse.json({ error: "Provide `lines` or `raw` to rewrite" }, { status: 400 });
+  } catch (err) {
+    console.error("AVS script rewrite failed:", err);
+    return NextResponse.json({ error: "Failed to rewrite script" }, { status: 502 });
+  }
+}

--- a/app/components/editorSidebar/AvsPanel.tsx
+++ b/app/components/editorSidebar/AvsPanel.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
 import StepTimeline from "./avs/StepTimeline";
+import ScriptEditor from "./avs/ScriptEditor";
 import { useStepEditing } from "./avs/useStepEditing";
+import { useScriptEditing } from "./avs/useScriptEditing";
 
 /**
  * AVS ("AI Voice & Script") sidebar panel.
@@ -11,6 +13,10 @@ import { useStepEditing } from "./avs/useStepEditing";
  * on a timeline where the user can split at the playhead, merge adjacent steps,
  * and drag boundaries. Steps persist to `Demo.editing.avs.steps` via the
  * existing autosave (it already serializes the store's `avs` field).
+ *
+ * PR 3 adds the AI script (AVS-2.1): per-step narration seeded from the Deepgram
+ * transcript, editable, and rewritable into a tone via OpenAI. It persists to
+ * `Demo.editing.avs.script`.
  *
  * The whole panel is gated behind NEXT_PUBLIC_AVS_ENABLED by its parents
  * (EditorSidebar / SidebarHeader), so nothing here runs when the flag is off.
@@ -30,6 +36,8 @@ const AvsPanel: React.FC = () => {
     handleAutoSlice,
     handleAdjustBoundary,
   } = useStepEditing();
+
+  const script = useScriptEditing();
 
   const btnBase =
     "flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50";
@@ -88,6 +96,10 @@ const AvsPanel: React.FC = () => {
           {steps.length} step{steps.length === 1 ? "" : "s"}
           {" · select a step to merge, or drag a boundary to adjust."}
         </p>
+      </div>
+
+      <div className="border-t border-[#ede7fa] pt-6">
+        <ScriptEditor {...script} />
       </div>
     </div>
   );

--- a/app/components/editorSidebar/AvsPanel.tsx
+++ b/app/components/editorSidebar/AvsPanel.tsx
@@ -1,26 +1,93 @@
 import React from "react";
 
+import StepTimeline from "./avs/StepTimeline";
+import { useStepEditing } from "./avs/useStepEditing";
+
 /**
- * AVS ("AI Voice & Script") sidebar panel — scaffold only.
+ * AVS ("AI Voice & Script") sidebar panel.
  *
- * PR 1 ships this as an empty shell behind the client feature flag
- * (NEXT_PUBLIC_AVS_ENABLED). Later AVS PRs fill it in: step editing, AI script,
- * Deepgram Aura voiceover, subtitle stabilization and time-alignment. Styling
- * mirrors ToolsPanel so it drops into the existing sidebar unchanged.
+ * PR 2 fills the scaffold with step editing: the demo auto-slices into steps
+ * from click-capture timestamps (reusing the auto-zoom ingestion, #216), shown
+ * on a timeline where the user can split at the playhead, merge adjacent steps,
+ * and drag boundaries. Steps persist to `Demo.editing.avs.steps` via the
+ * existing autosave (it already serializes the store's `avs` field).
+ *
+ * The whole panel is gated behind NEXT_PUBLIC_AVS_ENABLED by its parents
+ * (EditorSidebar / SidebarHeader), so nothing here runs when the flag is off.
  */
 const AvsPanel: React.FC = () => {
+  const {
+    steps,
+    duration,
+    currentTime,
+    selectedStepId,
+    setSelectedStepId,
+    clickTimes,
+    splittable,
+    canMerge,
+    handleSplit,
+    handleMerge,
+    handleAutoSlice,
+    handleAdjustBoundary,
+  } = useStepEditing();
+
+  const btnBase =
+    "flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50";
+
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="control-block-label text-lg font-bold text-[#A594F9] mb-4">
+        <h2 className="control-block-label text-lg font-bold text-[#A594F9] mb-1">
           AI Voice &amp; Script
         </h2>
-        <div className="rounded-lg border border-[#ede7fa] bg-[#F6F3FF] px-4 py-6 text-sm text-[#7C5CFC]">
-          <p className="font-semibold">Coming soon</p>
-          <p className="mt-1 text-[#6B6B6B] dark:text-inherit">
-            Generate an AI script, voiceover, and perfectly synced audio for your demo.
-          </p>
+        <p className="text-xs text-[#6B6B6B] dark:text-inherit mb-4">
+          Break the demo into steps. Each step becomes a unit for the AI script and synced
+          voiceover.
+        </p>
+
+        <StepTimeline
+          steps={steps}
+          duration={duration}
+          currentTime={currentTime}
+          selectedStepId={selectedStepId}
+          onSelectStep={setSelectedStepId}
+          onAdjustBoundary={handleAdjustBoundary}
+        />
+
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            onClick={handleSplit}
+            disabled={!splittable}
+            className={`${btnBase} bg-[#8A76FC] text-white hover:bg-[#7A66EC]`}
+          >
+            Split at playhead
+          </button>
+          <button
+            type="button"
+            onClick={handleMerge}
+            disabled={!canMerge}
+            className={`${btnBase} border border-[#A594F9] text-[#7C5CFC] hover:bg-[#F6F3FF]`}
+          >
+            Merge selected
+          </button>
         </div>
+
+        <button
+          type="button"
+          onClick={handleAutoSlice}
+          disabled={clickTimes.length === 0}
+          className={`${btnBase} mt-2 w-full border border-[#A594F9] text-[#7C5CFC] hover:bg-[#F6F3FF]`}
+        >
+          {clickTimes.length > 0
+            ? `Auto-slice from ${clickTimes.length} click${clickTimes.length === 1 ? "" : "s"}`
+            : "No clicks captured"}
+        </button>
+
+        <p className="mt-3 text-[11px] text-[#6B6B6B] dark:text-inherit">
+          {steps.length} step{steps.length === 1 ? "" : "s"}
+          {" · select a step to merge, or drag a boundary to adjust."}
+        </p>
       </div>
     </div>
   );

--- a/app/components/editorSidebar/avs/ScriptEditor.tsx
+++ b/app/components/editorSidebar/avs/ScriptEditor.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+
+import { SCRIPT_TONES } from "@/app/lib/avs/tones";
+import type { ScriptEditing } from "./useScriptEditing";
+
+/**
+ * AVS script editor (AVS-2.1). Renders the tone selector, the per-step (or
+ * single-blob fallback) narration text areas, and the "Rewrite with AI" action.
+ * All state lives in the `useScriptEditing` hook; this component is presentational.
+ */
+const ScriptEditor: React.FC<ScriptEditing> = ({
+  hasSteps,
+  lines,
+  raw,
+  tone,
+  hasTranscript,
+  hasContent,
+  rewriting,
+  setTone,
+  updateLine,
+  setRaw,
+  seedFromTranscript,
+  handleRewrite,
+}) => {
+  const textareaClass =
+    "w-full resize-y rounded-lg border border-[#ede7fa] bg-white px-3 py-2 text-sm text-[#333] " +
+    "placeholder:text-[#B7B7B7] focus:border-[#A594F9] focus:outline-none focus:ring-1 " +
+    "focus:ring-[#A594F9] dark:text-inherit";
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="control-block-label text-sm font-bold text-[#A594F9]">Script</h3>
+        <button
+          type="button"
+          onClick={seedFromTranscript}
+          disabled={!hasTranscript}
+          title={
+            hasTranscript
+              ? "Replace the text with the demo transcript"
+              : "Generate subtitles first to seed from the transcript"
+          }
+          className="text-[11px] font-semibold text-[#7C5CFC] underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:text-[#B7B7B7] disabled:no-underline"
+        >
+          Seed from transcript
+        </button>
+      </div>
+
+      {/* Tone selector */}
+      <div className="mb-3 grid grid-cols-2 gap-2">
+        {SCRIPT_TONES.map((t) => {
+          const selected = t.id === tone;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTone(t.id)}
+              aria-pressed={selected}
+              className={`rounded-lg px-3 py-2 text-xs font-semibold transition ${
+                selected
+                  ? "bg-[#8A76FC] text-white"
+                  : "border border-[#A594F9] text-[#7C5CFC] hover:bg-[#F6F3FF]"
+              }`}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Editable narration */}
+      {hasSteps ? (
+        <div className="space-y-3">
+          {lines.map((line, i) => (
+            <div key={line.stepId}>
+              <label className="mb-1 block text-[11px] font-semibold text-[#6B6B6B] dark:text-inherit">
+                Step {i + 1}
+              </label>
+              <textarea
+                value={line.text}
+                onChange={(e) => updateLine(line.stepId, e.target.value)}
+                rows={2}
+                placeholder="Narration for this step…"
+                className={textareaClass}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <textarea
+          value={raw}
+          onChange={(e) => setRaw(e.target.value)}
+          rows={6}
+          placeholder="Write or paste your demo narration here…"
+          className={textareaClass}
+        />
+      )}
+
+      <button
+        type="button"
+        onClick={handleRewrite}
+        disabled={rewriting || !hasContent}
+        className="mt-3 w-full rounded-lg bg-[#8A76FC] px-3 py-2 text-xs font-semibold text-white transition hover:bg-[#7A66EC] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {rewriting ? "Rewriting…" : "Rewrite with AI"}
+      </button>
+
+      <p className="mt-2 text-[11px] text-[#6B6B6B] dark:text-inherit">
+        Rewrites the narration above into the selected tone. English only — your edits are saved
+        automatically.
+      </p>
+    </div>
+  );
+};
+
+export default ScriptEditor;

--- a/app/components/editorSidebar/avs/StepTimeline.tsx
+++ b/app/components/editorSidebar/avs/StepTimeline.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+
+import type { Step } from "@/app/types/avs";
+
+interface StepTimelineProps {
+  steps: Step[];
+  duration: number;
+  currentTime: number;
+  selectedStepId: string | null;
+  onSelectStep: (id: string | null) => void;
+  /** Move the boundary between step `index` and `index + 1` to `time` (seconds). */
+  onAdjustBoundary: (index: number, time: number) => void;
+}
+
+/** Compact m:ss.d readout for a step length. */
+function formatDuration(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  const mins = Math.floor(safe / 60);
+  const secs = safe - mins * 60;
+  return mins > 0 ? `${mins}:${secs.toFixed(1).padStart(4, "0")}` : `${secs.toFixed(1)}s`;
+}
+
+/**
+ * Horizontal step timeline for the AVS panel. Renders each step as a proportion
+ * of the video duration, shows a live playhead, and lets the user drag the
+ * boundaries between adjacent steps. Purely presentational: split / merge and
+ * persistence live in the parent (AvsPanel).
+ */
+const StepTimeline: React.FC<StepTimelineProps> = ({
+  steps,
+  duration,
+  currentTime,
+  selectedStepId,
+  onSelectStep,
+  onAdjustBoundary,
+}) => {
+  const trackRef = React.useRef<HTMLDivElement>(null);
+  const [dragIndex, setDragIndex] = React.useState<number | null>(null);
+
+  const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : 0;
+  const pct = React.useCallback(
+    (time: number) =>
+      safeDuration > 0 ? Math.max(0, Math.min(100, (time / safeDuration) * 100)) : 0,
+    [safeDuration]
+  );
+
+  const timeFromClientX = React.useCallback(
+    (clientX: number): number | null => {
+      const el = trackRef.current;
+      if (!el || safeDuration <= 0) {
+        return null;
+      }
+      const rect = el.getBoundingClientRect();
+      if (rect.width <= 0) {
+        return null;
+      }
+      const ratio = (clientX - rect.left) / rect.width;
+      return Math.max(0, Math.min(1, ratio)) * safeDuration;
+    },
+    [safeDuration]
+  );
+
+  React.useEffect(() => {
+    if (dragIndex === null) {
+      return;
+    }
+    const onMove = (e: MouseEvent) => {
+      const time = timeFromClientX(e.clientX);
+      if (time !== null) {
+        onAdjustBoundary(dragIndex, time);
+      }
+    };
+    const onUp = () => setDragIndex(null);
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [dragIndex, timeFromClientX, onAdjustBoundary]);
+
+  if (safeDuration <= 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-[#ede7fa] bg-[#F6F3FF] px-4 py-6 text-center text-sm text-[#7C5CFC]">
+        Load a video to edit steps.
+      </div>
+    );
+  }
+
+  return (
+    <div className="select-none">
+      <div
+        ref={trackRef}
+        className="relative h-14 w-full overflow-hidden rounded-lg border border-[#A594F9] bg-white dark:bg-[#0a081a]"
+      >
+        {steps.map((step, idx) => {
+          const left = pct(step.startTime);
+          const width = pct(step.endTime) - left;
+          const selected = step.id === selectedStepId;
+          return (
+            <button
+              key={step.id}
+              type="button"
+              onClick={() => onSelectStep(selected ? null : step.id)}
+              title={`Step ${idx + 1} · ${formatDuration(step.endTime - step.startTime)}`}
+              className={`absolute top-0 flex h-full items-center justify-center overflow-hidden border-r border-white/70 text-[11px] font-semibold transition-colors last:border-r-0 ${
+                selected
+                  ? "bg-[#8A76FC] text-white"
+                  : idx % 2 === 0
+                    ? "bg-[#F6F3FF] text-[#7C5CFC] hover:bg-[#ede7fa]"
+                    : "bg-[#ede7fa] text-[#7C5CFC] hover:bg-[#e2d9fb]"
+              }`}
+              style={{ left: `${left}%`, width: `${width}%` }}
+            >
+              <span className="truncate px-1">{idx + 1}</span>
+            </button>
+          );
+        })}
+
+        {/* Draggable interior boundaries (between step i and i+1). */}
+        {steps.slice(0, -1).map((step, idx) => (
+          <div
+            key={`boundary-${step.id}`}
+            role="separator"
+            aria-orientation="vertical"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setDragIndex(idx);
+            }}
+            className="absolute top-0 z-20 h-full w-2 -translate-x-1/2 cursor-ew-resize"
+            style={{ left: `${pct(step.endTime)}%` }}
+          >
+            <div className="mx-auto h-full w-px bg-[#8A76FC]" />
+          </div>
+        ))}
+
+        {/* Live playhead. */}
+        <div
+          className="pointer-events-none absolute top-0 z-10 h-full w-px bg-green-500"
+          style={{ left: `${pct(currentTime)}%` }}
+        />
+      </div>
+
+      <div className="mt-1 flex justify-between text-[11px] font-medium text-[#A594F9]">
+        <span>0.0s</span>
+        <span>{formatDuration(safeDuration)}</span>
+      </div>
+    </div>
+  );
+};
+
+export default StepTimeline;

--- a/app/components/editorSidebar/avs/useScriptEditing.ts
+++ b/app/components/editorSidebar/avs/useScriptEditing.ts
@@ -1,0 +1,205 @@
+import React from "react";
+import axios from "axios";
+import { toast } from "react-hot-toast";
+import { useShallow } from "zustand/react/shallow";
+
+import type { AvsState, ScriptDoc, ScriptLine, Step } from "@/app/types/avs";
+import { useEditorStore } from "@/app/store/editor/editorStore";
+import { useSubtitleStore } from "@/app/store/editor/subtitleStore";
+import { seedScriptLines, seedScriptRaw } from "@/app/lib/avs/seedScript";
+import { SCRIPT_TONES, type ScriptTone } from "@/app/lib/avs/tones";
+
+export interface ScriptEditing {
+  /** True when the demo has steps → per-step editing; false → single-blob fallback. */
+  hasSteps: boolean;
+  /** One line per current step (stored text merged over the step list). */
+  lines: ScriptLine[];
+  /** The single free-form blob used when there are no steps. */
+  raw: string;
+  /** Currently selected tone (persisted to `avs.script.tone`). */
+  tone: ScriptTone;
+  /** Whether a transcript is available to seed from. */
+  hasTranscript: boolean;
+  /** Whether there is any script text to rewrite. */
+  hasContent: boolean;
+  rewriting: boolean;
+  setTone: (tone: ScriptTone) => void;
+  updateLine: (stepId: string, text: string) => void;
+  setRaw: (text: string) => void;
+  seedFromTranscript: () => void;
+  handleRewrite: () => void;
+}
+
+/**
+ * Owns the AVS script for the panel (AVS-2.1): seeds per-step narration from the
+ * Deepgram transcript, keeps it editable, and rewrites it into a tone via
+ * `/api/avs/script` (OpenAI, server-side). Text is written back to
+ * `avs.script`, which the existing autosave persists into `Demo.editing.avs`.
+ *
+ * Degrades gracefully: with no steps it edits a single raw blob seeded from the
+ * whole transcript; with no transcript it just starts empty.
+ */
+export function useScriptEditing(): ScriptEditing {
+  const { duration, avs, setAvs } = useEditorStore(
+    useShallow((s) => ({
+      duration: s.duration,
+      avs: s.avs,
+      setAvs: s.setAvs,
+    }))
+  );
+
+  const cues = useSubtitleStore((s) => s.subtitleCues);
+
+  const steps = React.useMemo<Step[]>(() => avs?.steps ?? [], [avs?.steps]);
+  const script = avs?.script;
+  const hasSteps = steps.length > 0;
+  const hasTranscript = cues.length > 0;
+
+  const [rewriting, setRewriting] = React.useState(false);
+
+  // Preserve other AVS fields (steps, voiceover, …) when only the script changes.
+  const updateScript = React.useCallback(
+    (updater: (prev: ScriptDoc) => ScriptDoc) => {
+      setAvs((prev) => {
+        const base: AvsState = prev ?? { steps: [] };
+        const prevScript: ScriptDoc = base.script ?? { lines: [] };
+        return { ...base, script: updater(prevScript) };
+      });
+    },
+    [setAvs]
+  );
+
+  // Effective per-step lines: stored text merged over the current step list, so
+  // steps added by split/merge always get a (possibly empty) editable line.
+  const lines = React.useMemo<ScriptLine[]>(() => {
+    const stored = new Map((script?.lines ?? []).map((l) => [l.stepId, l.text]));
+    return steps.map((step) => ({ stepId: step.id, text: stored.get(step.id) ?? "" }));
+  }, [steps, script?.lines]);
+
+  const raw = script?.raw ?? "";
+  const tone: ScriptTone = script?.tone ?? SCRIPT_TONES[0].id;
+
+  const hasContent = hasSteps ? lines.some((l) => l.text.trim().length > 0) : raw.trim().length > 0;
+
+  const seedFromTranscript = React.useCallback(() => {
+    if (hasSteps) {
+      const seeded = seedScriptLines(steps, cues);
+      updateScript((prev) => ({ ...prev, lines: seeded }));
+    } else {
+      updateScript((prev) => ({ ...prev, raw: seedScriptRaw(cues) }));
+    }
+  }, [hasSteps, steps, cues, updateScript]);
+
+  // Auto-seed narration from the transcript the first time we have one and the
+  // script is still empty, so the headline flow is one click (pick tone →
+  // rewrite). Separate guards per mode avoid the brief window where the
+  // transcript is ready but steps haven't been derived yet.
+  const seededLinesRef = React.useRef(false);
+  const seededRawRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!hasTranscript) {
+      return;
+    }
+    if (hasSteps && !seededLinesRef.current) {
+      const hasLineText = (script?.lines ?? []).some((l) => l.text.trim().length > 0);
+      if (!hasLineText) {
+        updateScript((prev) => ({ ...prev, lines: seedScriptLines(steps, cues) }));
+      }
+      seededLinesRef.current = true;
+    } else if (!hasSteps && duration > 0 && !seededRawRef.current) {
+      if (!(script?.raw ?? "").trim()) {
+        updateScript((prev) => ({ ...prev, raw: seedScriptRaw(cues) }));
+      }
+      seededRawRef.current = true;
+    }
+  }, [hasTranscript, hasSteps, steps, cues, duration, script?.lines, script?.raw, updateScript]);
+
+  const setTone = React.useCallback(
+    (next: ScriptTone) => {
+      updateScript((prev) => ({ ...prev, tone: next }));
+    },
+    [updateScript]
+  );
+
+  const updateLine = React.useCallback(
+    (stepId: string, text: string) => {
+      updateScript((prev) => {
+        const next = [...prev.lines];
+        const idx = next.findIndex((l) => l.stepId === stepId);
+        if (idx === -1) {
+          next.push({ stepId, text });
+        } else {
+          next[idx] = { stepId, text };
+        }
+        return { ...prev, lines: next };
+      });
+    },
+    [updateScript]
+  );
+
+  const setRaw = React.useCallback(
+    (text: string) => {
+      updateScript((prev) => ({ ...prev, raw: text }));
+    },
+    [updateScript]
+  );
+
+  const handleRewrite = React.useCallback(async () => {
+    if (rewriting) {
+      return;
+    }
+    if (!hasContent) {
+      toast.error("Add or seed some script text first");
+      return;
+    }
+
+    const toastId = toast.loading("Rewriting script...");
+    setRewriting(true);
+    try {
+      if (hasSteps) {
+        const payloadLines = lines.filter((l) => l.text.trim().length > 0);
+        const res = await axios.post("/api/avs/script", { lines: payloadLines, tone });
+        const returned = (res.data?.lines ?? []) as ScriptLine[];
+        const rewritten = new Map(returned.map((l) => [l.stepId, l.text]));
+        updateScript((prev) => {
+          const existing = new Map(prev.lines.map((l) => [l.stepId, l.text]));
+          const merged = steps.map((step) => ({
+            stepId: step.id,
+            text: rewritten.get(step.id) ?? existing.get(step.id) ?? "",
+          }));
+          return { ...prev, tone, lines: merged };
+        });
+      } else {
+        const res = await axios.post("/api/avs/script", { raw, tone });
+        const returnedRaw = typeof res.data?.raw === "string" ? res.data.raw : raw;
+        updateScript((prev) => ({ ...prev, tone, raw: returnedRaw }));
+      }
+      toast.success("Script rewritten", { id: toastId });
+    } catch (e: unknown) {
+      const message =
+        axios.isAxiosError(e) && typeof e.response?.data?.error === "string"
+          ? e.response.data.error
+          : e instanceof Error
+            ? e.message
+            : "Failed to rewrite script";
+      toast.error(message, { id: toastId });
+    } finally {
+      setRewriting(false);
+    }
+  }, [rewriting, hasContent, hasSteps, lines, raw, tone, steps, updateScript]);
+
+  return {
+    hasSteps,
+    lines,
+    raw,
+    tone,
+    hasTranscript,
+    hasContent,
+    rewriting,
+    setTone,
+    updateLine,
+    setRaw,
+    seedFromTranscript,
+    handleRewrite,
+  };
+}

--- a/app/components/editorSidebar/avs/useStepEditing.ts
+++ b/app/components/editorSidebar/avs/useStepEditing.ts
@@ -1,0 +1,168 @@
+import React from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import type { AvsState, Step } from "@/app/types/avs";
+import { useEditorStore } from "@/app/store/editor/editorStore";
+import { useZoomStore } from "@/app/store/editor/zoomStore";
+import { resolveClickTimes } from "@/app/lib/avs/clickSources";
+import {
+  MIN_STEP_DURATION,
+  adjustStepBoundary,
+  deriveSteps,
+  mergeStepWithNext,
+  splitStepAt,
+} from "@/app/lib/avs/deriveSteps";
+
+export interface StepEditing {
+  steps: Step[];
+  duration: number;
+  currentTime: number;
+  selectedStepId: string | null;
+  setSelectedStepId: (id: string | null) => void;
+  clickTimes: number[];
+  splittable: boolean;
+  canMerge: boolean;
+  handleSplit: () => void;
+  handleMerge: () => void;
+  handleAutoSlice: () => void;
+  handleAdjustBoundary: (index: number, time: number) => void;
+}
+
+/**
+ * Owns the AVS step model for the panel: reads live editor/zoom state, auto-
+ * slices steps from click capture, and exposes split / merge / adjust / re-slice
+ * actions. Steps are written back to the store's `avs.steps`, which the existing
+ * autosave persists into `Demo.editing.avs`.
+ */
+export function useStepEditing(): StepEditing {
+  const { duration, currentTime, avs, setAvs } = useEditorStore(
+    useShallow((s) => ({
+      duration: s.duration,
+      currentTime: s.currentTime,
+      avs: s.avs,
+      setAvs: s.setAvs,
+    }))
+  );
+
+  const { extensionEvents, zoomSegments } = useZoomStore(
+    useShallow((s) => ({
+      extensionEvents: s.extensionEvents,
+      zoomSegments: s.zoomSegments,
+    }))
+  );
+
+  const [selectedStepId, setSelectedStepId] = React.useState<string | null>(null);
+
+  const steps = React.useMemo<Step[]>(() => avs?.steps ?? [], [avs?.steps]);
+
+  const clickTimes = React.useMemo(
+    () => resolveClickTimes(extensionEvents, zoomSegments),
+    [extensionEvents, zoomSegments]
+  );
+
+  // Preserve other AVS fields (script, voiceover, …) when only steps change.
+  const updateSteps = React.useCallback(
+    (updater: (prevSteps: Step[]) => Step[]) => {
+      setAvs((prev) => {
+        const base: AvsState = prev ?? { steps: [] };
+        return { ...base, steps: updater(base.steps) };
+      });
+    },
+    [setAvs]
+  );
+
+  // Auto-slice once per demo when no steps exist yet. Click data from a fresh
+  // recording arrives asynchronously from the extension, so if it isn't ready we
+  // wait briefly before falling back to a single full-length step.
+  const autoSliceDoneRef = React.useRef(false);
+  React.useEffect(() => {
+    if (autoSliceDoneRef.current || duration <= 0) {
+      return;
+    }
+    if (steps.length > 0) {
+      autoSliceDoneRef.current = true;
+      return;
+    }
+    if (clickTimes.length > 0) {
+      const derived = deriveSteps(clickTimes, duration);
+      if (derived.length > 0) {
+        updateSteps(() => derived);
+        autoSliceDoneRef.current = true;
+      }
+      return;
+    }
+    const timer = setTimeout(() => {
+      if (autoSliceDoneRef.current) {
+        return;
+      }
+      const derived = deriveSteps([], duration);
+      if (derived.length > 0) {
+        updateSteps(() => derived);
+      }
+      autoSliceDoneRef.current = true;
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [duration, steps.length, clickTimes, updateSteps]);
+
+  const splittable = React.useMemo(
+    () =>
+      steps.some(
+        (s) =>
+          currentTime > s.startTime + MIN_STEP_DURATION &&
+          currentTime < s.endTime - MIN_STEP_DURATION
+      ),
+    [steps, currentTime]
+  );
+
+  const handleSplit = React.useCallback(() => {
+    updateSteps((prev) => splitStepAt(prev, currentTime));
+    setSelectedStepId(null);
+  }, [updateSteps, currentTime]);
+
+  const handleMerge = React.useCallback(() => {
+    if (!selectedStepId) {
+      return;
+    }
+    const index = steps.findIndex((s) => s.id === selectedStepId);
+    if (index === -1) {
+      return;
+    }
+    // The last step has no "next" — merge it into its predecessor instead.
+    const mergeIndex = index >= steps.length - 1 ? index - 1 : index;
+    if (mergeIndex < 0) {
+      return;
+    }
+    updateSteps((prev) => mergeStepWithNext(prev, mergeIndex));
+    setSelectedStepId(null);
+  }, [selectedStepId, steps, updateSteps]);
+
+  const handleAdjustBoundary = React.useCallback(
+    (index: number, time: number) => {
+      updateSteps((prev) => adjustStepBoundary(prev, index, time));
+    },
+    [updateSteps]
+  );
+
+  const handleAutoSlice = React.useCallback(() => {
+    const derived = deriveSteps(clickTimes, duration);
+    if (derived.length > 0) {
+      updateSteps(() => derived);
+      setSelectedStepId(null);
+    }
+  }, [clickTimes, duration, updateSteps]);
+
+  return {
+    steps,
+    duration,
+    currentTime,
+    selectedStepId,
+    setSelectedStepId,
+    clickTimes,
+    splittable,
+    canMerge: selectedStepId !== null && steps.length > 1,
+    handleSplit,
+    handleMerge,
+    handleAutoSlice,
+    handleAdjustBoundary,
+  };
+}

--- a/app/lib/avs/clickSources.ts
+++ b/app/lib/avs/clickSources.ts
@@ -1,0 +1,44 @@
+// Resolving click timestamps for AVS step auto-slicing.
+//
+// The auto-zoom feature (#216) ingests Chrome-extension click capture two ways:
+//   1. Live, right after recording — raw `ExtensionClickEvent`s posted to the
+//      editor and held in the zoom store as `extensionEvents`.
+//   2. Persisted — those clicks are turned into `ZoomEffect` auto-zoom segments
+//      and saved in `demo.editing.zoom`, so they survive a reload even though
+//      the raw events do not.
+//
+// `deriveSteps` only needs numbers (click seconds), so this module isolates the
+// "where do the clicks come from" concern and hands back a clean list.
+
+import type { ZoomEffect } from "@/app/types/editor/zoom-effect";
+import type { ExtensionClickEvent } from "@/app/store/editor/zoomStore";
+
+// Auto-zoom segments begin ~0.3s before their originating click (see
+// `applyAutoZoomSuggestions` in useZoomEditor). Adding it back recovers an
+// approximate click time when only the persisted segments remain.
+const ZOOM_LEAD_SECONDS = 0.3;
+
+/**
+ * Best-available click timestamps (seconds) for step derivation. Prefers the
+ * raw extension events when present (freshly recorded session); otherwise falls
+ * back to recovering approximate click times from persisted auto-zoom segments.
+ * Returns `[]` when neither source has usable data — callers then get a single
+ * full-length step from `deriveSteps`.
+ */
+export function resolveClickTimes(
+  extensionEvents: ExtensionClickEvent[],
+  zoomSegments: ZoomEffect[]
+): number[] {
+  const fromEvents = extensionEvents
+    .filter((e) => e.event_type === "click" && e.coordinates)
+    .map((e) => e.timestamp_ms / 1000)
+    .filter((t) => Number.isFinite(t) && t >= 0);
+
+  if (fromEvents.length > 0) {
+    return fromEvents;
+  }
+
+  return zoomSegments
+    .map((z) => z.startTime + ZOOM_LEAD_SECONDS)
+    .filter((t) => Number.isFinite(t) && t >= 0);
+}

--- a/app/lib/avs/deriveSteps.ts
+++ b/app/lib/avs/deriveSteps.ts
@@ -1,0 +1,150 @@
+// Step model for AVS (AI Script, Voiceover & Audio Synchronization).
+//
+// A "step" is an editable slice of the demo video. Steps are auto-derived from
+// the Chrome-extension click-capture timestamps already ingested by the
+// auto-zoom feature (#216), then refined by the user (split / merge / adjust)
+// in the AVS panel timeline. All operations here are PURE functions over
+// `Step[]` so they are trivial to reason about and reuse.
+//
+// Downstream AVS stages degrade gracefully: if there are no clicks (or no click
+// data survives a reload) the whole video becomes a single step.
+
+import type { Step } from "@/app/types/avs";
+
+/**
+ * Minimum length (seconds) of a step, and therefore the minimum gap enforced
+ * between two adjacent boundaries. Prevents zero-width steps from rapid clicks
+ * and keeps split/adjust interactions from collapsing a step to nothing.
+ */
+export const MIN_STEP_DURATION = 0.5;
+
+/**
+ * Deterministic id for a step starting at `startTime`. Boundaries are always
+ * spaced by at least MIN_STEP_DURATION, so rounding to the millisecond yields a
+ * stable, collision-free id — handy as a React key and for diffing on autosave.
+ */
+export function createStepId(startTime: number): string {
+  return `step-${Math.max(0, Math.round(startTime * 1000))}`;
+}
+
+/** Re-number `index` to match array order after an insert/remove. */
+function reindex(steps: Step[]): Step[] {
+  return steps.map((step, i) => (step.index === i ? step : { ...step, index: i }));
+}
+
+/**
+ * Build steps from click timestamps and the video duration.
+ *
+ * Each step spans from one click to the next: the first step starts at 0 and the
+ * last ends at `duration`. Clicks are sanitized first — dropped if out of range
+ * or non-finite, sorted, and thinned so no two boundaries sit closer than
+ * MIN_STEP_DURATION (and never within MIN_STEP_DURATION of 0 or `duration`).
+ *
+ * FALLBACK: with no usable clicks this returns a single step covering the whole
+ * video. Returns `[]` only when `duration` is not a positive number.
+ */
+export function deriveSteps(clickTimes: number[], duration: number): Step[] {
+  const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : 0;
+  if (safeDuration <= 0) {
+    return [];
+  }
+
+  const boundaries: number[] = [];
+  const sorted = [...clickTimes]
+    .filter(
+      (t) => Number.isFinite(t) && t > MIN_STEP_DURATION && t < safeDuration - MIN_STEP_DURATION
+    )
+    .sort((a, b) => a - b);
+
+  for (const t of sorted) {
+    const last = boundaries[boundaries.length - 1];
+    if (last === undefined || t - last >= MIN_STEP_DURATION) {
+      boundaries.push(t);
+    }
+  }
+
+  const marks = [0, ...boundaries, safeDuration];
+  const steps: Step[] = [];
+  for (let i = 0; i < marks.length - 1; i++) {
+    steps.push({
+      id: createStepId(marks[i]),
+      index: i,
+      startTime: marks[i],
+      endTime: marks[i + 1],
+    });
+  }
+  return steps;
+}
+
+/**
+ * Split the step containing `time` into two steps at `time`. The left half keeps
+ * the original id and label; the right half gets a fresh id. No-op if `time`
+ * does not fall strictly inside a step with room for MIN_STEP_DURATION on both
+ * sides of the cut.
+ */
+export function splitStepAt(steps: Step[], time: number): Step[] {
+  const idx = steps.findIndex(
+    (s) => time > s.startTime + MIN_STEP_DURATION && time < s.endTime - MIN_STEP_DURATION
+  );
+  if (idx === -1) {
+    return steps;
+  }
+
+  const step = steps[idx];
+  const left: Step = { ...step, endTime: time };
+  const right: Step = {
+    id: createStepId(time),
+    index: idx + 1,
+    startTime: time,
+    endTime: step.endTime,
+  };
+
+  return reindex([...steps.slice(0, idx), left, right, ...steps.slice(idx + 1)]);
+}
+
+/**
+ * Merge the step at `index` with the following step, extending it to the next
+ * step's end. The kept step retains its id and label. No-op when there is no
+ * following step.
+ */
+export function mergeStepWithNext(steps: Step[], index: number): Step[] {
+  if (index < 0 || index >= steps.length - 1) {
+    return steps;
+  }
+  const merged: Step = { ...steps[index], endTime: steps[index + 1].endTime };
+  return reindex([...steps.slice(0, index), merged, ...steps.slice(index + 2)]);
+}
+
+/**
+ * Move the boundary shared by step `index` and step `index + 1` to `time`,
+ * clamped so neither step shrinks below MIN_STEP_DURATION. Indices are
+ * unchanged. No-op when `index` is not an interior boundary.
+ */
+export function adjustStepBoundary(steps: Step[], index: number, time: number): Step[] {
+  if (index < 0 || index >= steps.length - 1) {
+    return steps;
+  }
+
+  const prev = steps[index];
+  const next = steps[index + 1];
+  const min = prev.startTime + MIN_STEP_DURATION;
+  const max = next.endTime - MIN_STEP_DURATION;
+  if (max < min) {
+    return steps;
+  }
+
+  const clamped = Math.min(max, Math.max(min, time));
+  if (clamped === prev.endTime) {
+    return steps;
+  }
+
+  return steps.map((s, i) => {
+    if (i === index) {
+      return { ...s, endTime: clamped };
+    }
+    if (i === index + 1) {
+      return { ...s, startTime: clamped };
+    }
+    return s;
+  });
+}

--- a/app/lib/avs/seedScript.ts
+++ b/app/lib/avs/seedScript.ts
@@ -1,0 +1,65 @@
+// Transcript seeding for the AVS script (AVS-2.1).
+//
+// The Deepgram subtitle flow (see app/(signed)/editor/hooks/useSubtitles.ts)
+// produces `SubtitleCue`s ({start, end, text}) on `Demo.subtitles`. These pure
+// helpers turn that transcript into starting narration text for the script:
+//   - with steps → one `ScriptLine` per step, seeded from the cues that fall in
+//     that step's time range;
+//   - without steps → a single raw blob of the whole transcript (the fallback
+//     the panel edits in a single textarea).
+//
+// Everything here is a pure, deterministic function over its inputs so it is easy
+// to reason about and reuse (panel seeding, tests).
+
+import type { ScriptLine, Step } from "@/app/types/avs";
+
+/** Minimal cue shape — matches `SubtitleCue` from the editor without importing it. */
+export interface TranscriptCue {
+  start: number;
+  end: number;
+  text: string;
+}
+
+/** Midpoint of a cue; used to assign each cue to exactly one step. */
+function cueMidpoint(cue: TranscriptCue): number {
+  return (cue.start + cue.end) / 2;
+}
+
+/** Join cue texts into a single space-separated, trimmed string. */
+function joinCues(cues: TranscriptCue[]): string {
+  return cues
+    .map((c) => c.text.trim())
+    .filter((t) => t.length > 0)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Seed one `ScriptLine` per step from the transcript. A cue is assigned to the
+ * step whose `[startTime, endTime]` range contains the cue's midpoint (so each
+ * cue lands in exactly one step, even when cues straddle a boundary). The last
+ * step also absorbs any cues past the final boundary. Steps with no cues get an
+ * empty string so the panel still renders an editable textarea for them.
+ */
+export function seedScriptLines(steps: Step[], cues: TranscriptCue[]): ScriptLine[] {
+  const usable = cues.filter(
+    (c) => Number.isFinite(c.start) && Number.isFinite(c.end) && c.text.trim().length > 0
+  );
+
+  return steps.map((step, i) => {
+    const isLast = i === steps.length - 1;
+    const inStep = usable.filter((c) => {
+      const mid = cueMidpoint(c);
+      // Half-open [start, end) for interior steps; the last step is inclusive so
+      // trailing cues (or ones a touch past `duration`) are never dropped.
+      return mid >= step.startTime && (isLast ? true : mid < step.endTime);
+    });
+    return { stepId: step.id, text: joinCues(inStep) };
+  });
+}
+
+/** Flatten the whole transcript into one blob — the no-steps fallback seed. */
+export function seedScriptRaw(cues: TranscriptCue[]): string {
+  return joinCues(cues.filter((c) => Number.isFinite(c.start) && Number.isFinite(c.end)));
+}

--- a/app/lib/avs/tones.ts
+++ b/app/lib/avs/tones.ts
@@ -1,0 +1,57 @@
+// Script tones for the AVS AI rewrite (AVS-2.1).
+//
+// Shared by the client (the tone selector in AvsPanel) and the server
+// (`/api/avs/script` validation + prompt building), so the list stays in sync.
+// No secrets here — safe to import from client code.
+
+import type { ScriptDoc } from "@/app/types/avs";
+
+/** The tone id used on `ScriptDoc.tone`. */
+export type ScriptTone = NonNullable<ScriptDoc["tone"]>;
+
+/** A selectable tone: its id, the label shown in the panel, and a rewrite hint. */
+export interface ToneOption {
+  id: ScriptTone;
+  label: string;
+  /** Short guidance handed to the model to shape the rewrite. */
+  guidance: string;
+}
+
+export const SCRIPT_TONES: ToneOption[] = [
+  {
+    id: "sales",
+    label: "Sales",
+    guidance:
+      "Persuasive and benefit-driven. Lead with value, build desire, and nudge toward action — confident but not pushy.",
+  },
+  {
+    id: "onboarding",
+    label: "Onboarding",
+    guidance:
+      "Friendly and guiding, as if walking a brand-new user through the product step by step. Warm, clear, and reassuring.",
+  },
+  {
+    id: "support",
+    label: "Support",
+    guidance:
+      "Calm, clear, and helpful, like a patient support agent. Reduce confusion and reassure the viewer at each step.",
+  },
+  {
+    id: "marketing",
+    label: "Marketing",
+    guidance:
+      "Punchy and energetic, brand-forward and memorable. Emphasize the wow moments while staying honest.",
+  },
+];
+
+const TONE_IDS = SCRIPT_TONES.map((t) => t.id);
+
+/** Type guard: whether an unknown value is a supported tone id. */
+export function isScriptTone(value: unknown): value is ScriptTone {
+  return typeof value === "string" && (TONE_IDS as string[]).includes(value);
+}
+
+/** Look up a tone's guidance for prompt building; falls back to the first tone. */
+export function toneGuidance(tone: ScriptTone): string {
+  return (SCRIPT_TONES.find((t) => t.id === tone) ?? SCRIPT_TONES[0]).guidance;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
         "nprogress": "^0.2.0",
+        "openai": "^6.46.0",
         "postcss": "^8.5.15",
         "razorpay": "^2.9.6",
         "react": "^18.3.1",
@@ -8348,6 +8349,36 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
+      "integrity": "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/openid-client": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
     "nprogress": "^0.2.0",
+    "openai": "^6.46.0",
     "postcss": "^8.5.15",
     "razorpay": "^2.9.6",
     "react": "^18.3.1",


### PR DESCRIPTION
Derive editable "steps" for a demo from click-capture data and let users refine them, behind the AVS panel flag (no-op when off).

- app/lib/avs/deriveSteps.ts: pure step model — deriveSteps(clickTimes, duration) slices the video at click boundaries (first step from 0, last to duration) and falls back to a single full-length step when there are no clicks; plus split/merge/adjust operations with a MIN_STEP_DURATION guard.
- app/lib/avs/clickSources.ts: resolve click timestamps from the auto-zoom ingestion (#216) — prefers live extension events, falls back to recovering approximate click times from persisted auto-zoom segments after a reload.
- AVS panel (StepTimeline + useStepEditing): auto-slices on open, renders step boundaries with a live playhead, supports split at playhead, merge adjacent, and drag-to-adjust boundaries. Steps persist to Demo.editing.avs.steps via the existing autosave (no migration).

partial fixes #240 