### PR TITLE
feat(avs): subtitle stabilization (karaoke fix) + VTT export

### DIFF
--- a/app/components/editorSidebar/AvsPanel.tsx
+++ b/app/components/editorSidebar/AvsPanel.tsx
@@ -3,9 +3,11 @@ import React from "react";
 import StepTimeline from "./avs/StepTimeline";
 import ScriptEditor from "./avs/ScriptEditor";
 import VoiceoverEditor from "./avs/VoiceoverEditor";
+import CaptionsEditor from "./avs/CaptionsEditor";
 import { useStepEditing } from "./avs/useStepEditing";
 import { useScriptEditing } from "./avs/useScriptEditing";
 import { useVoiceoverGeneration } from "./avs/useVoiceoverGeneration";
+import { useCaptions } from "./avs/useCaptions";
 
 /**
  * AVS ("AI Voice & Script") sidebar panel.
@@ -24,6 +26,11 @@ import { useVoiceoverGeneration } from "./avs/useVoiceoverGeneration";
  * pronunciation dictionary, and a "Generate Voiceover" action that calls the
  * Cloud Run worker to produce ONE continuous MP3 (with per-step timings). It
  * persists to `Demo.editing.avs.voiceover`.
+ *
+ * PR 5 adds captions (AVS-2.3): a "Generate Captions" action transcribes the
+ * voiceover audio (via the existing subtitle route) and stabilizes the cues so
+ * they stop flickering, plus a `.vtt` export. It persists to
+ * `Demo.editing.avs.captions` and never touches the non-AVS subtitle flow.
  *
  * The whole panel is gated behind NEXT_PUBLIC_AVS_ENABLED by its parents
  * (EditorSidebar / SidebarHeader), so nothing here runs when the flag is off.
@@ -46,6 +53,7 @@ const AvsPanel: React.FC = () => {
 
   const script = useScriptEditing();
   const voiceover = useVoiceoverGeneration();
+  const captions = useCaptions();
 
   const btnBase =
     "flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50";
@@ -112,6 +120,10 @@ const AvsPanel: React.FC = () => {
 
       <div className="border-t border-[#ede7fa] pt-6">
         <VoiceoverEditor {...voiceover} />
+      </div>
+
+      <div className="border-t border-[#ede7fa] pt-6">
+        <CaptionsEditor {...captions} />
       </div>
     </div>
   );

--- a/app/components/editorSidebar/avs/CaptionsEditor.tsx
+++ b/app/components/editorSidebar/avs/CaptionsEditor.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import type { CaptionsGeneration } from "./useCaptions";
+
+/**
+ * AVS captions editor (AVS-2.3). Generates flicker-free captions from the
+ * voiceover audio and lets the user export them as a `.vtt` file. All state
+ * lives in the `useCaptions` hook; this component is presentational.
+ */
+const CaptionsEditor: React.FC<CaptionsGeneration> = ({
+  hasVoiceover,
+  generating,
+  captions,
+  handleGenerate,
+  handleDownloadVtt,
+}) => {
+  const hasCaptions = !!captions && captions.length > 0;
+
+  return (
+    <div>
+      <h3 className="control-block-label mb-3 text-sm font-bold text-[#A594F9]">Captions</h3>
+
+      <button
+        type="button"
+        onClick={handleGenerate}
+        disabled={generating || !hasVoiceover}
+        className="w-full rounded-lg bg-[#8A76FC] px-3 py-2 text-xs font-semibold text-white transition hover:bg-[#7A66EC] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {generating ? "Generating…" : "Generate Captions"}
+      </button>
+
+      <button
+        type="button"
+        onClick={handleDownloadVtt}
+        disabled={!hasCaptions}
+        className="mt-2 w-full rounded-lg border border-[#A594F9] px-3 py-2 text-xs font-semibold text-[#7C5CFC] transition hover:bg-[#F6F3FF] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Download .vtt
+      </button>
+
+      {hasCaptions ? (
+        <p className="mt-3 text-[11px] text-[#6B6B6B] dark:text-inherit">
+          {captions.length} caption{captions.length === 1 ? "" : "s"} · stabilized against flicker ·
+          saved automatically.
+        </p>
+      ) : (
+        <p className="mt-2 text-[11px] text-[#6B6B6B] dark:text-inherit">
+          {hasVoiceover
+            ? "Transcribes the voiceover into clean, word-timed captions (no rapid flicker)."
+            : "Generate a voiceover first, then caption it here."}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default CaptionsEditor;

--- a/app/components/editorSidebar/avs/useCaptions.ts
+++ b/app/components/editorSidebar/avs/useCaptions.ts
@@ -1,0 +1,145 @@
+import React from "react";
+import axios from "axios";
+import { toast } from "react-hot-toast";
+import { useShallow } from "zustand/react/shallow";
+
+import type { AvsState, CaptionCue } from "@/app/types/avs";
+import { useEditorStore } from "@/app/store/editor/editorStore";
+import { cuesToVtt, stabilizeCues, type Cue } from "@/app/lib/avs/karaoke";
+
+// Polling cadence for the subtitle job (mirrors useSubtitles).
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLLS = 180;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface CaptionsGeneration {
+  /** Whether a voiceover exists to caption. */
+  hasVoiceover: boolean;
+  generating: boolean;
+  /** The persisted, flicker-free captions, if any. */
+  captions: CaptionCue[] | undefined;
+  handleGenerate: () => void;
+  handleDownloadVtt: () => void;
+}
+
+/**
+ * Owns AVS captions (AVS-2.3). Generates captions from the AVS *voiceover* audio
+ * — never the source video — by calling the existing `/api/subtitles/create`
+ * route (with no demoId, so the demo's own `subtitles` are left untouched), then
+ * stabilizes the returned cues so they stop flickering. The result is written to
+ * `avs.captions`, which the existing autosave persists into `Demo.editing.avs`.
+ *
+ * The user can also export the stabilized captions as a `.vtt` file.
+ *
+ * Degrades gracefully: with no voiceover the generate action is disabled, and the
+ * existing (non-AVS) subtitle flow is not affected in any way.
+ */
+export function useCaptions(): CaptionsGeneration {
+  const { avs, setAvs } = useEditorStore(
+    useShallow((s) => ({
+      avs: s.avs,
+      setAvs: s.setAvs,
+    }))
+  );
+
+  const voiceover = avs?.voiceover;
+  const captions = avs?.captions;
+  const hasVoiceover = typeof voiceover?.audioUrl === "string" && voiceover.audioUrl.length > 0;
+
+  const [generating, setGenerating] = React.useState(false);
+
+  // Preserve the other AVS fields (steps, script, voiceover, …) when only the
+  // captions change.
+  const setCaptions = React.useCallback(
+    (cues: CaptionCue[]) => {
+      setAvs((prev) => {
+        const base: AvsState = prev ?? { steps: [] };
+        return { ...base, captions: cues };
+      });
+    },
+    [setAvs]
+  );
+
+  const handleGenerate = React.useCallback(async () => {
+    if (generating) {
+      return;
+    }
+    if (!voiceover?.audioUrl) {
+      toast.error("Generate a voiceover first");
+      return;
+    }
+
+    const toastId = toast.loading("Generating captions…");
+    setGenerating(true);
+    try {
+      // demoId is intentionally omitted so this does NOT overwrite the demo's
+      // own subtitles — AVS captions live under avs.captions.
+      const createRes = await axios.post("/api/subtitles/create", {
+        videoUrl: voiceover.audioUrl,
+        demoId: null,
+        language: "multi",
+      });
+      const jobId = createRes.data?.jobId as string | undefined;
+      if (!jobId) {
+        throw new Error("No caption job ID returned");
+      }
+
+      for (let poll = 0; poll < MAX_POLLS; poll++) {
+        const statusRes = await axios.get(`/api/jobs/${jobId}`);
+        const state = statusRes.data?.state as string | undefined;
+        if (state === "completed") {
+          const rawCues = (statusRes.data?.subtitles || []) as Cue[];
+          const stabilized = stabilizeCues(Array.isArray(rawCues) ? rawCues : []);
+          setCaptions(stabilized);
+          if (stabilized.length === 0) {
+            toast.error("No speech detected in the voiceover", { id: toastId });
+          } else {
+            toast.success("Captions ready", { id: toastId });
+          }
+          return;
+        }
+        if (state === "failed") {
+          throw new Error(statusRes.data?.error || "Caption generation failed");
+        }
+        await sleep(POLL_INTERVAL_MS);
+      }
+      throw new Error("Caption generation timed out");
+    } catch (e: unknown) {
+      const message =
+        axios.isAxiosError(e) && typeof e.response?.data?.error === "string"
+          ? e.response.data.error
+          : e instanceof Error
+            ? e.message
+            : "Failed to generate captions";
+      toast.error(message, { id: toastId });
+    } finally {
+      setGenerating(false);
+    }
+  }, [generating, voiceover?.audioUrl, setCaptions]);
+
+  const handleDownloadVtt = React.useCallback(() => {
+    if (!captions || captions.length === 0) {
+      toast.error("Generate captions first");
+      return;
+    }
+    const vtt = cuesToVtt(captions);
+    const blob = new Blob([vtt], { type: "text/vtt" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "captions.vtt";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }, [captions]);
+
+  return {
+    hasVoiceover,
+    generating,
+    captions,
+    handleGenerate,
+    handleDownloadVtt,
+  };
+}

--- a/app/lib/avs/karaoke.test.ts
+++ b/app/lib/avs/karaoke.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  countWords,
+  cuesToVtt,
+  cuesToWords,
+  formatVttTimestamp,
+  minCueDuration,
+  stabilizeCues,
+  type Cue,
+} from "./karaoke";
+
+// Tolerance for floating-point duration comparisons.
+const EPS = 1e-6;
+
+/** True when no cue overlaps the next (allowing a tiny FP margin). */
+function hasNoOverlaps(cues: Cue[]): boolean {
+  for (let i = 0; i < cues.length - 1; i++) {
+    if (cues[i].end > cues[i + 1].start + EPS) {
+      return false;
+    }
+  }
+  return true;
+}
+
+describe("minCueDuration", () => {
+  it("floors at 1.5s for short cues", () => {
+    expect(minCueDuration(1)).toBe(1.5);
+    expect(minCueDuration(4)).toBe(1.5); // 4 * 0.35 = 1.4 < 1.5
+  });
+
+  it("uses wordCount * 0.35 once it exceeds the floor", () => {
+    expect(minCueDuration(10)).toBeCloseTo(3.5, 10);
+  });
+});
+
+describe("countWords", () => {
+  it("counts whitespace-delimited words", () => {
+    expect(countWords("hello")).toBe(1);
+    expect(countWords("  hello   there  ")).toBe(2);
+    expect(countWords("")).toBe(0);
+  });
+});
+
+describe("stabilizeCues", () => {
+  it("pads a very short single-word cue to the 1.5s floor", () => {
+    const out = stabilizeCues([{ start: 0, end: 0.2, text: "Hello" }]);
+    expect(out).toHaveLength(1);
+    expect(out[0].end - out[0].start).toBeCloseTo(1.5, 10);
+  });
+
+  it("extends a long cue to wordCount * 0.35 seconds", () => {
+    const text = "one two three four five six seven eight nine ten"; // 10 words
+    const out = stabilizeCues([{ start: 0, end: 1, text }]);
+    expect(out).toHaveLength(1);
+    expect(out[0].end - out[0].start).toBeCloseTo(10 * 0.35, 10); // 3.5s
+  });
+
+  it("never produces overlapping cues", () => {
+    const cues: Cue[] = [
+      { start: 0, end: 0.3, text: "a" },
+      { start: 0.4, end: 0.7, text: "b" },
+      { start: 0.8, end: 1.1, text: "c" },
+      { start: 5, end: 5.2, text: "d" },
+    ];
+    const out = stabilizeCues(cues);
+    expect(hasNoOverlaps(out)).toBe(true);
+    // Every surviving cue meets its own minimum on-screen duration.
+    for (const cue of out) {
+      expect(cue.end - cue.start).toBeGreaterThanOrEqual(
+        minCueDuration(countWords(cue.text)) - EPS
+      );
+    }
+  });
+
+  it("merges adjacent too-short cues when there is no room to extend", () => {
+    const out = stabilizeCues([
+      { start: 0, end: 0.3, text: "a" },
+      { start: 0.4, end: 0.7, text: "b" },
+      { start: 0.8, end: 1.1, text: "c" },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe("a b c");
+    expect(out[0].end - out[0].start).toBeGreaterThanOrEqual(1.5 - EPS);
+  });
+
+  it("extends into the gap without touching the next cue", () => {
+    const out = stabilizeCues([
+      { start: 0, end: 0.3, text: "hi" },
+      { start: 5, end: 6, text: "still here" },
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0].end).toBeCloseTo(1.5, 10);
+    expect(out[0].end).toBeLessThanOrEqual(out[1].start + EPS);
+  });
+
+  it("is pure and deterministic — same output, input untouched", () => {
+    const input: Cue[] = [
+      { start: 0, end: 0.3, text: "a" },
+      { start: 0.4, end: 0.7, text: "b" },
+    ];
+    const snapshot = JSON.stringify(input);
+    const first = stabilizeCues(input);
+    const second = stabilizeCues(input);
+    expect(first).toEqual(second);
+    expect(JSON.stringify(input)).toBe(snapshot); // input not mutated
+  });
+
+  it("normalizes unsorted, empty, and invalid cues", () => {
+    const out = stabilizeCues([
+      { start: 5, end: 5.2, text: "second" },
+      { start: 0, end: 0.2, text: "first" },
+      { start: 1, end: 1.1, text: "   " }, // empty after trim → dropped
+      { start: NaN, end: 2, text: "bad" }, // non-finite → dropped
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0].text).toBe("first");
+    expect(out[1].text).toBe("second");
+    expect(hasNoOverlaps(out)).toBe(true);
+  });
+});
+
+describe("cuesToWords", () => {
+  it("distributes a cue's span evenly across its words", () => {
+    const words = cuesToWords([{ start: 0, end: 2, text: "a b" }]);
+    expect(words).toEqual([
+      { word: "a", start: 0, end: 1 },
+      { word: "b", start: 1, end: 2 },
+    ]);
+  });
+});
+
+describe("formatVttTimestamp", () => {
+  it("formats seconds as HH:MM:SS.mmm", () => {
+    expect(formatVttTimestamp(0)).toBe("00:00:00.000");
+    expect(formatVttTimestamp(1.5)).toBe("00:00:01.500");
+    expect(formatVttTimestamp(3661.5)).toBe("01:01:01.500");
+  });
+});
+
+describe("cuesToVtt", () => {
+  it("produces a valid WebVTT document", () => {
+    const vtt = cuesToVtt([
+      { start: 0, end: 1.5, text: "Hello" },
+      { start: 1.5, end: 3, text: "there" },
+    ]);
+    expect(vtt.startsWith("WEBVTT\n\n")).toBe(true);
+    expect(vtt).toContain("00:00:00.000 --> 00:00:01.500\nHello");
+    expect(vtt).toContain("00:00:01.500 --> 00:00:03.000\nthere");
+  });
+});

--- a/app/lib/avs/karaoke.ts
+++ b/app/lib/avs/karaoke.ts
@@ -1,0 +1,200 @@
+// Subtitle stabilization for AVS (AVS-2.3, "Karaoke fix").
+//
+// Captions transcribed from the AI voiceover can flicker: a single-word cue that
+// is only a few hundred milliseconds long snaps on and off the screen too fast to
+// read. This module implements the PRD pipeline as PURE, deterministic functions
+// over `Cue[]`:
+//
+//   1. Token clustering — normalize, sort, and de-overlap the raw cues so each
+//      one is a clean, non-overlapping cluster of words.
+//   2. Karaoke fix — guarantee every cue stays on screen for at least
+//      `T_min = max(1.5, wordCount * 0.35)` seconds by extending a too-short cue
+//      into the gap after it, or merging it with the next cue when there is no
+//      room — never producing an overlap.
+//
+// It also exposes a word-level view (`cuesToWords`) and a WebVTT serializer
+// (`cuesToVtt`). Everything here is free of DOM/network side effects so it can be
+// unit-tested directly; the browser download lives in the AVS panel hook.
+
+/** A single caption: `text` shown from `start` to `end` (both in seconds). */
+export interface Cue {
+  start: number;
+  end: number;
+  text: string;
+}
+
+/** One word with an estimated on-screen span, distributed evenly within a cue. */
+export interface Word {
+  word: string;
+  start: number;
+  end: number;
+}
+
+/** Floor on a cue's on-screen duration, in seconds (the `1.5` in the formula). */
+export const MIN_CUE_SECONDS = 1.5;
+
+/** Extra on-screen time granted per word, in seconds (the `0.35` in the formula). */
+export const PER_WORD_SECONDS = 0.35;
+
+// Tolerance for floating-point comparisons on second-scale durations.
+const EPSILON = 1e-6;
+
+/** Count whitespace-delimited words in a caption's text. */
+export function countWords(text: string): number {
+  const trimmed = text.trim();
+  return trimmed ? trimmed.split(/\s+/).length : 0;
+}
+
+/**
+ * Minimum on-screen duration for a cue with `wordCount` words:
+ * `T_min = max(1.5, wordCount * 0.35)` seconds. Longer cues get more time so
+ * viewers can actually read them.
+ */
+export function minCueDuration(wordCount: number): number {
+  return Math.max(MIN_CUE_SECONDS, wordCount * PER_WORD_SECONDS);
+}
+
+// Coerce a raw cue to finite numbers and trimmed text; `null` if unusable.
+function normalizeCue(cue: Cue): Cue | null {
+  const start = Number(cue.start);
+  const end = Number(cue.end);
+  const text = String(cue.text ?? "").trim();
+  if (!Number.isFinite(start) || !Number.isFinite(end) || !text) {
+    return null;
+  }
+  return { start: Math.max(0, start), end: Math.max(0, end), text };
+}
+
+/**
+ * Token clustering: drop unusable cues, sort by start time, and remove overlaps
+ * so the result is a clean, strictly non-overlapping, increasing sequence. When
+ * two cues overlap, the earlier one is clamped to the later one's start; a cue
+ * that starts at (or before) the previous one is folded into it instead of
+ * creating a zero-width sliver.
+ */
+export function clusterCues(cues: Cue[]): Cue[] {
+  const sorted = cues
+    .map(normalizeCue)
+    .filter((c): c is Cue => c !== null && c.end - c.start > EPSILON)
+    .sort((a, b) => a.start - b.start || a.end - b.end);
+
+  const clustered: Cue[] = [];
+  for (const cue of sorted) {
+    const prev = clustered[clustered.length - 1];
+    if (!prev || cue.start >= prev.end - EPSILON) {
+      clustered.push({ ...cue });
+      continue;
+    }
+    // Overlap with the previous cue.
+    if (cue.start > prev.start + EPSILON) {
+      prev.end = cue.start; // clamp the earlier cue so the boundary is clean
+      clustered.push({ ...cue });
+    } else {
+      // Same start (or earlier): merge the text into the previous cue.
+      prev.end = Math.max(prev.end, cue.end);
+      prev.text = `${prev.text} ${cue.text}`.trim();
+    }
+  }
+  return clustered;
+}
+
+/**
+ * Stabilize cues so none flickers: after token clustering, every cue is
+ * guaranteed to last at least `minCueDuration(wordCount)` seconds. A too-short
+ * cue is first extended into the gap before the next cue; if that is still not
+ * enough it is merged with the next cue (whose words then raise the threshold),
+ * repeating until the floor is met. The last cue is simply extended.
+ *
+ * Pure and deterministic. Given non-overlapping input it produces
+ * non-overlapping output (it only extends into gaps or consumes the next cue).
+ */
+export function stabilizeCues(cues: Cue[]): Cue[] {
+  const clustered = clusterCues(cues);
+  const result: Cue[] = [];
+
+  let i = 0;
+  while (i < clustered.length) {
+    let cur: Cue = { ...clustered[i] };
+    i += 1;
+
+    // Karaoke fix: grow `cur` until it meets its minimum on-screen duration.
+    for (;;) {
+      const need = minCueDuration(countWords(cur.text));
+      if (cur.end - cur.start >= need - EPSILON) {
+        break;
+      }
+      const next = clustered[i];
+      const desiredEnd = cur.start + need;
+      if (!next) {
+        cur.end = desiredEnd; // last cue: nothing to overlap, just extend
+        break;
+      }
+      if (desiredEnd <= next.start + EPSILON) {
+        cur.end = desiredEnd; // room in the gap — extend without overlapping
+        break;
+      }
+      // Not enough room: merge with the next cue and re-evaluate.
+      cur = {
+        start: cur.start,
+        end: Math.max(cur.end, next.end),
+        text: `${cur.text} ${next.text}`.trim(),
+      };
+      i += 1;
+    }
+
+    result.push(cur);
+  }
+
+  return result;
+}
+
+/**
+ * Word-level view of the cues: each cue's text is split into words and its
+ * timespan is distributed evenly across them. Deterministic — handy for a
+ * karaoke highlight or a word-timed JSON export. Run on stabilized cues to
+ * inherit the flicker-free timing.
+ */
+export function cuesToWords(cues: Cue[]): Word[] {
+  const words: Word[] = [];
+  for (const cue of cues) {
+    const tokens = cue.text.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) {
+      continue;
+    }
+    const span = Math.max(0, cue.end - cue.start);
+    const per = span / tokens.length;
+    tokens.forEach((word, idx) => {
+      words.push({
+        word,
+        start: cue.start + per * idx,
+        end: idx === tokens.length - 1 ? cue.end : cue.start + per * (idx + 1),
+      });
+    });
+  }
+  return words;
+}
+
+/** Format `seconds` as a WebVTT timestamp: `HH:MM:SS.mmm`. */
+export function formatVttTimestamp(seconds: number): string {
+  const total = Math.max(0, Number.isFinite(seconds) ? seconds : 0);
+  const ms = Math.round(total * 1000);
+  const hh = Math.floor(ms / 3_600_000);
+  const mm = Math.floor((ms % 3_600_000) / 60_000);
+  const ss = Math.floor((ms % 60_000) / 1000);
+  const millis = ms % 1000;
+  const pad = (n: number, width = 2) => String(n).padStart(width, "0");
+  return `${pad(hh)}:${pad(mm)}:${pad(ss)}.${pad(millis, 3)}`;
+}
+
+/**
+ * Serialize cues to a valid WebVTT string. Cues are clustered first so the
+ * output is ordered and non-overlapping regardless of input order.
+ */
+export function cuesToVtt(cues: Cue[]): string {
+  const ordered = clusterCues(cues);
+  const blocks = ordered.map(
+    (cue, i) =>
+      `${i + 1}\n${formatVttTimestamp(cue.start)} --> ${formatVttTimestamp(cue.end)}\n${cue.text}`
+  );
+  return `WEBVTT\n\n${blocks.join("\n\n")}\n`;
+}

--- a/app/types/avs.ts
+++ b/app/types/avs.ts
@@ -49,10 +49,23 @@ export interface PronunciationRule {
   phonetic: string;
 }
 
+/**
+ * A stabilized caption cue transcribed from the voiceover: `text` shown from
+ * `start` to `end` (seconds). Structurally identical to the `Cue` produced by
+ * `app/lib/avs/karaoke.ts`, so the two are interchangeable without coupling.
+ */
+export interface CaptionCue {
+  start: number;
+  end: number;
+  text: string;
+}
+
 /** The complete AVS state stored under Demo.editing.avs. */
 export interface AvsState {
   steps: Step[];
   script?: ScriptDoc;
   voiceover?: VoiceoverTrack;
   pronunciation?: PronunciationRule[];
+  /** Flicker-free captions generated from the voiceover audio (AVS-2.3). */
+  captions?: CaptionCue[];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,8 @@
         "prisma": "^6.11.1",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.3.4",
-        "typescript": "5.8.3"
+        "typescript": "5.8.3",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1640,13 +1641,13 @@
       ]
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -1859,6 +1860,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@panva/hkdf": {
@@ -2301,6 +2312,322 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -2763,9 +3090,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2798,6 +3125,17 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -2860,6 +3198,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3614,6 +3959,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3925,6 +4383,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -4301,6 +4769,16 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "license": "Apache-2.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4485,6 +4963,13 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "license": "ISC"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -5170,6 +5655,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -5695,6 +6187,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5719,6 +6221,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -6057,6 +6569,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -8326,6 +8853,20 @@
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -9264,6 +9805,40 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9595,6 +10170,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -9627,10 +10209,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -10014,6 +10610,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -10070,6 +10673,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -10385,6 +10998,200 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -10504,6 +11311,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.9.0",
@@ -74,7 +75,8 @@
     "prisma": "^6.11.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.4",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vitest": "^4.1.10"
   },
   "overrides": {
     "tar": "^7.5.16",


### PR DESCRIPTION
Add a pure, deterministic karaoke pipeline for AVS captions: stabilizeCues() clusters cues then guarantees each stays on screen for T_min = max(1.5, wordCount * 0.35)s, extending into gaps or merging with the next cue without creating overlaps. Also exposes word-level JSON (cuesToWords) and a WebVTT serializer (cuesToVtt).

Wire captions into the AVS flow only: a "Generate Captions" action transcribes the voiceover audio via the existing /api/subtitles/create route (no demoId, so the demo's own subtitles are untouched), stabilizes the cues, persists them to Demo.editing.avs.captions, and offers a .vtt download. The non-AVS subtitle flow is unchanged.

Add vitest with unit tests for stabilizeCues (short cue padded to 1.5s, long cue uses wordCount*0.35, no overlaps produced, merge/determinism).