### PR TITLE
feat(avs): end-to-end orchestration & enablement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,8 @@ DDB_TABLE=""
 OPENAI_API_KEY=""
 
 # AVS master switch (server-only). Set to "true" to enable AVS server routes.
+# For staging/QA, set this AND NEXT_PUBLIC_AVS_ENABLED to "true"; keep both blank
+# in production until the feature is signed off.
 AVS_ENABLED=""
 
 # AVS UI panel switch (client-safe). Set to "true" to show the "AI Voice & Script"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,57 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## AI Script, Voiceover & Audio Sync (AVS)
+
+AVS turns a recorded demo into an AI-voiced, time-synced, subtitled video. It is
+**PRO/ENTERPRISE only** and ships behind a feature flag, so it is completely
+invisible and no-op when the flag is off — existing (non-AVS) demos and exports
+are never affected.
+
+### The flow
+
+Open a saved demo in the editor, switch to the **AI Voice** sidebar tab, and use
+**Generate AI Voiceover Demo** to run the full pipeline in one click:
+
+1. **Steps** — the demo is auto-sliced into steps from the Chrome-extension
+   click-capture timestamps (falling back to one full-length step if there are no
+   clicks). Split / merge / adjust boundaries in the panel timeline.
+2. **AI script** — per-step narration is seeded from the Deepgram transcript and
+   rewritten into a tone (Sales / Onboarding / Support / Marketing) via OpenAI.
+3. **Voiceover** — the script is synthesized into one continuous MP3 with
+   Deepgram Aura TTS in the Cloud Run worker, recording each step's timing.
+4. **Captions** — the voiceover is transcribed and stabilized into flicker-free
+   captions (also exportable as `.vtt`).
+5. **Time-alignment** — a pre-pass freeze-frames video where the audio is longer
+   than its step and pads silence where it is shorter, muxing the voiceover into
+   one aligned source MP4.
+6. **Export** — the aligned source (AI voice already muxed in) plus the stabilized
+   captions are fed into the **existing** export route, so the final render carries
+   the AI voice, freeze-frame timing, and clean captions.
+
+Every stage persists to `Demo.editing.avs` via the normal autosave (there is no
+DB migration — all AVS state lives in the existing `editing` JSON). Each stage
+also has its own editor in the panel for fine-tuning before or after a full run.
+
+### Environment variables
+
+AVS keys are **server-side only** — never expose them with a `NEXT_PUBLIC_`
+prefix.
+
+| Variable | Where | Purpose |
+| :-- | :-- | :-- |
+| `AVS_ENABLED` | Next app (server) | Master switch for the AVS server routes. Set to `true` to enable. |
+| `NEXT_PUBLIC_AVS_ENABLED` | Next app (client) | Shows the "AI Voice" sidebar panel. Set to `true` to enable. |
+| `OPENAI_API_KEY` | Next app (server) | OpenAI script tone rewrite (`/api/avs/script`). |
+| `GCP_VIDEO_WORKER_URL` | Next app (server) | Reaches the Cloud Run worker for Aura TTS, subtitles, and alignment. |
+| `DEEPGRAM_API_KEY` | **Cloud Run worker only** | Deepgram transcription + Aura TTS. The Next app never holds this key. |
+
+To enable AVS for a staging/QA environment, set both `AVS_ENABLED=true` and
+`NEXT_PUBLIC_AVS_ENABLED=true` there (plus `OPENAI_API_KEY` and
+`GCP_VIDEO_WORKER_URL`), and make sure the worker has `DEEPGRAM_API_KEY`. Leave
+all of these blank/unset in production until the feature is signed off. See
+`.env.example` for the full list.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/components/editorSidebar/AvsPanel.tsx
+++ b/app/components/editorSidebar/AvsPanel.tsx
@@ -4,10 +4,12 @@ import StepTimeline from "./avs/StepTimeline";
 import ScriptEditor from "./avs/ScriptEditor";
 import VoiceoverEditor from "./avs/VoiceoverEditor";
 import CaptionsEditor from "./avs/CaptionsEditor";
+import AvsPipeline from "./avs/AvsPipeline";
 import { useStepEditing } from "./avs/useStepEditing";
 import { useScriptEditing } from "./avs/useScriptEditing";
 import { useVoiceoverGeneration } from "./avs/useVoiceoverGeneration";
 import { useCaptions } from "./avs/useCaptions";
+import { useAvsPipeline } from "./avs/useAvsPipeline";
 
 /**
  * AVS ("AI Voice & Script") sidebar panel.
@@ -32,6 +34,12 @@ import { useCaptions } from "./avs/useCaptions";
  * they stop flickering, plus a `.vtt` export. It persists to
  * `Demo.editing.avs.captions` and never touches the non-AVS subtitle flow.
  *
+ * PR 7 adds the end-to-end orchestration: a single "Generate AI Voiceover Demo"
+ * action (AvsPipeline) that runs every stage in sequence — steps → script →
+ * voiceover → subtitles → time-alignment → export — and feeds the aligned source
+ * plus stabilized captions into the existing export route. The stage editors
+ * below stay available for fine-tuning any individual step.
+ *
  * The whole panel is gated behind NEXT_PUBLIC_AVS_ENABLED by its parents
  * (EditorSidebar / SidebarHeader), so nothing here runs when the flag is off.
  */
@@ -54,6 +62,7 @@ const AvsPanel: React.FC = () => {
   const script = useScriptEditing();
   const voiceover = useVoiceoverGeneration();
   const captions = useCaptions();
+  const pipeline = useAvsPipeline();
 
   const btnBase =
     "flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50";
@@ -68,6 +77,17 @@ const AvsPanel: React.FC = () => {
           Break the demo into steps. Each step becomes a unit for the AI script and synced
           voiceover.
         </p>
+
+        <div className="mb-6">
+          <AvsPipeline
+            stages={pipeline.stages}
+            running={pipeline.running}
+            canRun={pipeline.canRun}
+            blockedReason={pipeline.blockedReason}
+            exportedUrl={pipeline.exportedUrl}
+            onRun={pipeline.run}
+          />
+        </div>
 
         <StepTimeline
           steps={steps}

--- a/app/components/editorSidebar/avs/AvsPipeline.tsx
+++ b/app/components/editorSidebar/avs/AvsPipeline.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+
+import type { PipelineStage, StageStatus } from "./useAvsPipeline";
+
+/**
+ * The headline AVS action (PR 7): one "Generate AI Voiceover Demo" button that
+ * runs the whole pipeline — steps → script → voiceover → subtitles →
+ * time-alignment → export — with a per-stage progress list. All logic lives in
+ * `useAvsPipeline`; this component is presentational.
+ */
+interface AvsPipelineProps {
+  stages: PipelineStage[];
+  running: boolean;
+  canRun: boolean;
+  blockedReason: string | null;
+  exportedUrl: string | null;
+  onRun: () => void;
+}
+
+const STATUS_STYLES: Record<StageStatus, { symbol: string; className: string }> = {
+  pending: { symbol: "○", className: "text-[#C4B9F5]" },
+  running: { symbol: "◐", className: "text-[#7C5CFC] animate-pulse" },
+  done: { symbol: "✓", className: "text-[#36b37e]" },
+  warning: { symbol: "!", className: "text-[#E5A200]" },
+  error: { symbol: "✕", className: "text-[#E5484D]" },
+};
+
+const StageRow: React.FC<{ stage: PipelineStage }> = ({ stage }) => {
+  const { symbol, className } = STATUS_STYLES[stage.status];
+  return (
+    <li className="flex items-start gap-2 py-1">
+      <span className={`mt-0.5 w-4 shrink-0 text-center text-xs font-bold ${className}`}>
+        {symbol}
+      </span>
+      <div className="min-w-0 flex-1">
+        <span
+          className={`text-xs font-semibold ${
+            stage.status === "pending"
+              ? "text-[#9a9a9a] dark:text-inherit"
+              : "text-[#4b4b4b] dark:text-inherit"
+          }`}
+        >
+          {stage.label}
+        </span>
+        {stage.note ? (
+          <span className="ml-1.5 text-[11px] text-[#8f8f8f] dark:text-inherit">
+            · {stage.note}
+          </span>
+        ) : null}
+      </div>
+    </li>
+  );
+};
+
+const AvsPipeline: React.FC<AvsPipelineProps> = ({
+  stages,
+  running,
+  canRun,
+  blockedReason,
+  exportedUrl,
+  onRun,
+}) => {
+  const started = running || stages.some((s) => s.status !== "pending");
+
+  return (
+    <div className="rounded-xl border border-[#ede7fa] bg-[#F6F3FF] p-4 dark:bg-transparent">
+      <h3 className="control-block-label mb-1 text-sm font-bold text-[#A594F9]">
+        One-click AI voiceover
+      </h3>
+      <p className="mb-3 text-[11px] text-[#6B6B6B] dark:text-inherit">
+        Runs the whole pipeline — steps, script, voiceover, captions, sync, and export — into one
+        AI-voiced, synced, subtitled video.
+      </p>
+
+      <button
+        type="button"
+        onClick={onRun}
+        disabled={running || !canRun}
+        className="w-full rounded-lg bg-[#8A76FC] px-3 py-2.5 text-xs font-semibold text-white transition hover:bg-[#7A66EC] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {running ? "Generating…" : "Generate AI Voiceover Demo"}
+      </button>
+
+      {!canRun && blockedReason ? (
+        <p className="mt-2 text-[11px] text-[#E5A200]">{blockedReason}</p>
+      ) : null}
+
+      {started ? (
+        <ul className="mt-3 border-t border-[#ede7fa] pt-2">
+          {stages.map((stage) => (
+            <StageRow key={stage.id} stage={stage} />
+          ))}
+        </ul>
+      ) : null}
+
+      {exportedUrl ? (
+        <a
+          href={exportedUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 block w-full rounded-lg border border-[#A594F9] px-3 py-2 text-center text-xs font-semibold text-[#7C5CFC] transition hover:bg-white"
+        >
+          Open exported video
+        </a>
+      ) : null}
+    </div>
+  );
+};
+
+export default AvsPipeline;

--- a/app/components/editorSidebar/avs/useAvsPipeline.ts
+++ b/app/components/editorSidebar/avs/useAvsPipeline.ts
@@ -1,0 +1,497 @@
+import React from "react";
+import axios from "axios";
+import { toast } from "react-hot-toast";
+import { useShallow } from "zustand/react/shallow";
+
+import type {
+  AlignedSource,
+  AvsState,
+  CaptionCue,
+  PronunciationRule,
+  ScriptLine,
+  Step,
+  StepTiming,
+  VoiceoverTrack,
+} from "@/app/types/avs";
+import { useEditorStore } from "@/app/store/editor/editorStore";
+import { useZoomStore } from "@/app/store/editor/zoomStore";
+import { useSubtitleStore } from "@/app/store/editor/subtitleStore";
+import { resolveClickTimes } from "@/app/lib/avs/clickSources";
+import { deriveSteps } from "@/app/lib/avs/deriveSteps";
+import { seedScriptLines } from "@/app/lib/avs/seedScript";
+import { stabilizeCues, type Cue } from "@/app/lib/avs/karaoke";
+import { DEFAULT_AVS_VOICE, isAvsVoiceId } from "@/app/lib/avs/voices";
+import type { ScriptTone } from "@/app/lib/avs/tones";
+
+// Job polling cadence (mirrors useCaptions / the export flow).
+const POLL_INTERVAL_MS = 2500;
+const MAX_POLLS = 240; // ~10 minutes for the heavier ffmpeg alignment/export.
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** The ordered stages of the end-to-end AVS pipeline. */
+export type PipelineStageId = "steps" | "script" | "voiceover" | "captions" | "sync" | "export";
+
+export type StageStatus = "pending" | "running" | "done" | "warning" | "error";
+
+export interface PipelineStage {
+  id: PipelineStageId;
+  label: string;
+  status: StageStatus;
+  /** Short human-readable detail (result summary or failure reason). */
+  note?: string;
+}
+
+const STAGE_LABELS: Record<PipelineStageId, string> = {
+  steps: "Steps",
+  script: "AI script",
+  voiceover: "Voiceover",
+  captions: "Captions",
+  sync: "Time-alignment",
+  export: "Export",
+};
+
+const STAGE_ORDER: PipelineStageId[] = [
+  "steps",
+  "script",
+  "voiceover",
+  "captions",
+  "sync",
+  "export",
+];
+
+function initialStages(): PipelineStage[] {
+  return STAGE_ORDER.map((id) => ({ id, label: STAGE_LABELS[id], status: "pending" }));
+}
+
+export interface AvsPipeline {
+  stages: PipelineStage[];
+  running: boolean;
+  /** Whether the pipeline can run right now (saved demo + fetchable source). */
+  canRun: boolean;
+  /** Why the pipeline is blocked, if `canRun` is false. */
+  blockedReason: string | null;
+  /** The exported, AI-voiced/synced/subtitled MP4 URL once the run completes. */
+  exportedUrl: string | null;
+  run: () => void;
+}
+
+// --- Stage helpers -----------------------------------------------------------
+// Each helper owns one stage's network work and returns plain data. The hook
+// wires them together and reflects progress into the stage list. Keeping these
+// at module scope keeps the orchestration readable and the calls testable.
+
+/** Poll `/api/jobs/[id]` until it completes or fails; returns the job payload. */
+async function pollJob(jobId: string): Promise<Record<string, unknown>> {
+  for (let poll = 0; poll < MAX_POLLS; poll++) {
+    const res = await axios.get(`/api/jobs/${jobId}`);
+    const data = (res.data ?? {}) as Record<string, unknown>;
+    const state = typeof data.state === "string" ? data.state : "";
+    if (state === "completed") {
+      return data;
+    }
+    if (state === "failed") {
+      throw new Error(typeof data.error === "string" ? data.error : "Job failed");
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error("Timed out waiting for the job to finish");
+}
+
+/** Rewrite per-step narration into `tone` via `/api/avs/script` (OpenAI). */
+async function rewriteScript(lines: ScriptLine[], tone: ScriptTone): Promise<ScriptLine[]> {
+  const res = await axios.post("/api/avs/script", { lines, tone });
+  const returned = (res.data?.lines ?? []) as ScriptLine[];
+  const rewritten = new Map(returned.map((l) => [l.stepId, l.text]));
+  return lines.map((l) => ({ stepId: l.stepId, text: rewritten.get(l.stepId) ?? l.text }));
+}
+
+/** Synthesize one continuous MP3 via `/api/avs/voiceover` (Aura in the worker). */
+async function synthesizeVoiceover(
+  lines: ScriptLine[],
+  voiceId: string,
+  pronunciation: PronunciationRule[]
+): Promise<VoiceoverTrack> {
+  const res = await axios.post("/api/avs/voiceover", { lines, voiceId, pronunciation });
+  const data = res.data as Partial<VoiceoverTrack>;
+  if (typeof data.audioUrl !== "string" || !data.audioUrl) {
+    throw new Error("Voiceover produced no audio");
+  }
+  return {
+    audioUrl: data.audioUrl,
+    duration: typeof data.duration === "number" ? data.duration : 0,
+    voiceId: isAvsVoiceId(data.voiceId) ? (data.voiceId as string) : voiceId,
+    stepTimings: Array.isArray(data.stepTimings) ? data.stepTimings : [],
+  };
+}
+
+/** Transcribe the voiceover audio into stabilized, flicker-free captions. */
+async function generateCaptions(audioUrl: string): Promise<CaptionCue[]> {
+  // demoId omitted so this never overwrites the demo's own subtitles.
+  const createRes = await axios.post("/api/subtitles/create", {
+    videoUrl: audioUrl,
+    demoId: null,
+    language: "multi",
+  });
+  const jobId = createRes.data?.jobId as string | undefined;
+  if (!jobId) {
+    throw new Error("No caption job id returned");
+  }
+  const jobData = await pollJob(jobId);
+  const rawCues = Array.isArray(jobData.subtitles) ? (jobData.subtitles as Cue[]) : [];
+  return stabilizeCues(rawCues);
+}
+
+interface AlignInput {
+  videoUrl: string;
+  audioUrl: string;
+  steps: Step[];
+  stepTimings: StepTiming[];
+  duration: number;
+  demoId: string | null;
+}
+
+/** Run the freeze-frame/silence pre-pass via `/api/avs/sync`; poll for the result. */
+async function alignSource(input: AlignInput): Promise<AlignedSource> {
+  const res = await axios.post("/api/avs/sync", input);
+  const jobId = res.data?.jobId as string | undefined;
+  if (!jobId) {
+    throw new Error("Time-alignment did not start");
+  }
+  const data = await pollJob(jobId);
+  const aligned =
+    data.aligned && typeof data.aligned === "object"
+      ? (data.aligned as Record<string, unknown>)
+      : {};
+  const videoUrl = typeof aligned.alignedVideoUrl === "string" ? aligned.alignedVideoUrl : "";
+  if (!videoUrl) {
+    throw new Error("Time-alignment returned no aligned source");
+  }
+  return {
+    videoUrl,
+    duration: typeof aligned.duration === "number" ? aligned.duration : input.duration,
+  };
+}
+
+interface ExportInput {
+  aligned: AlignedSource;
+  captions: CaptionCue[];
+  title: string;
+  demoId: string | null;
+  selectedBackground: string;
+  aspectRatio: string;
+  browserFrame: { mode: string; drawShadow: boolean; drawBorder: boolean };
+}
+
+/**
+ * Feed the aligned source (voiceover already muxed in) + stabilized captions into
+ * the EXISTING export route. Additive: nothing about the non-AVS export changes.
+ * Trims/zoom are dropped — their timings don't map onto the realigned timeline.
+ */
+async function exportAligned(input: ExportInput): Promise<string> {
+  const res = await axios.post("/api/jobs/create", {
+    videoUrl: input.aligned.videoUrl,
+    title: input.title,
+    description: "",
+    demoId: input.demoId,
+    segments: [],
+    zoomEffects: [],
+    textOverlays: [],
+    subtitles: input.captions,
+    duration: input.aligned.duration,
+    selectedBackground: input.selectedBackground,
+    customBackgroundUrl: null,
+    aspectRatio: input.aspectRatio,
+    browserFrame: input.browserFrame,
+    imageMap: {},
+    settings: { quality: "720p", fps: "24 FPS", compression: "Web", speed: "Default" },
+  });
+  const jobId = res.data?.jobId as string | undefined;
+  if (!jobId) {
+    throw new Error("Export did not start");
+  }
+  const data = await pollJob(jobId);
+  const url = typeof data.exportedUrl === "string" ? data.exportedUrl : "";
+  if (!url) {
+    throw new Error("Export finished without an output URL");
+  }
+  return url;
+}
+
+/**
+ * End-to-end AVS orchestration (PR 7): a single "Generate AI Voiceover Demo"
+ * action that runs steps → script → voiceover → subtitles → time-alignment →
+ * export, reusing the PR 3–6 routes. Each stage reports its own status for the
+ * progress UI, and every result is written back to the store's `avs` slice, so
+ * the existing autosave persists the whole thing into `Demo.editing.avs`.
+ *
+ * Degrades gracefully: no clicks → one full-length step; no transcript → empty
+ * script the user can fill; a failed rewrite or caption pass is non-fatal (the
+ * run continues with what it has). The voiceover and time-alignment are required
+ * for a meaningful export, so a hard failure there stops the run with a message.
+ */
+export function useAvsPipeline(): AvsPipeline {
+  const {
+    videoUrl,
+    duration,
+    savedDemoId,
+    sidebarTitle,
+    avs,
+    setAvs,
+    selectedBackground,
+    aspectRatio,
+    browserFrameMode,
+    browserFrameDrawShadow,
+    browserFrameDrawBorder,
+  } = useEditorStore(
+    useShallow((s) => ({
+      videoUrl: s.videoUrl,
+      duration: s.duration,
+      savedDemoId: s.savedDemoId,
+      sidebarTitle: s.sidebarTitle,
+      avs: s.avs,
+      setAvs: s.setAvs,
+      selectedBackground: s.selectedBackground,
+      aspectRatio: s.aspectRatio,
+      browserFrameMode: s.browserFrameMode,
+      browserFrameDrawShadow: s.browserFrameDrawShadow,
+      browserFrameDrawBorder: s.browserFrameDrawBorder,
+    }))
+  );
+
+  const { extensionEvents, zoomSegments } = useZoomStore(
+    useShallow((s) => ({
+      extensionEvents: s.extensionEvents,
+      zoomSegments: s.zoomSegments,
+    }))
+  );
+
+  const transcriptCues = useSubtitleStore((s) => s.subtitleCues);
+
+  const [stages, setStages] = React.useState<PipelineStage[]>(initialStages);
+  const [running, setRunning] = React.useState(false);
+  const [exportedUrl, setExportedUrl] = React.useState<string | null>(null);
+
+  // A fetchable https/gs source is required: the sync + export workers download
+  // it server-side, so an un-uploaded blob URL cannot be aligned.
+  const hasFetchableSource =
+    typeof videoUrl === "string" && videoUrl.length > 0 && !videoUrl.startsWith("blob:");
+
+  const blockedReason = React.useMemo<string | null>(() => {
+    if (!savedDemoId) {
+      return "Save the demo first, then generate its AI voiceover.";
+    }
+    if (!hasFetchableSource) {
+      return "The source video is still uploading — try again in a moment.";
+    }
+    if (!(duration > 0)) {
+      return "Load a video before generating.";
+    }
+    return null;
+  }, [savedDemoId, hasFetchableSource, duration]);
+
+  const canRun = blockedReason === null;
+
+  const patchStage = React.useCallback((id: PipelineStageId, patch: Partial<PipelineStage>) => {
+    setStages((prev) => prev.map((s) => (s.id === id ? { ...s, ...patch } : s)));
+  }, []);
+
+  // Persist a partial AVS update, preserving the other fields.
+  const mergeAvs = React.useCallback(
+    (patch: Partial<AvsState>) => {
+      setAvs((prev) => {
+        const base: AvsState = prev ?? { steps: [] };
+        return { ...base, ...patch };
+      });
+    },
+    [setAvs]
+  );
+
+  // Resolve the per-step narration to voice: stored text merged over the current
+  // steps, seeded from the transcript when everything is still empty.
+  const resolveScriptLines = React.useCallback(
+    (steps: Step[]): ScriptLine[] => {
+      const stored = new Map((avs?.script?.lines ?? []).map((l) => [l.stepId, l.text]));
+      const merged = steps.map((step) => ({
+        stepId: step.id,
+        text: (stored.get(step.id) ?? "").trim(),
+      }));
+      return merged.every((l) => l.text.length === 0)
+        ? seedScriptLines(steps, transcriptCues)
+        : merged;
+    },
+    [avs?.script?.lines, transcriptCues]
+  );
+
+  const run = React.useCallback(async () => {
+    if (running) {
+      return;
+    }
+    if (!canRun) {
+      toast.error(blockedReason ?? "Cannot generate right now");
+      return;
+    }
+
+    setRunning(true);
+    setExportedUrl(null);
+    setStages(initialStages());
+    const toastId = toast.loading("Generating AI voiceover demo…");
+
+    try {
+      // ---- Stage 1: steps ---------------------------------------------------
+      patchStage("steps", { status: "running" });
+      let steps: Step[] = avs?.steps ?? [];
+      if (steps.length === 0) {
+        steps = deriveSteps(resolveClickTimes(extensionEvents, zoomSegments), duration);
+        mergeAvs({ steps });
+      }
+      if (steps.length === 0) {
+        throw new Error("Could not derive any steps from the video");
+      }
+      patchStage("steps", {
+        status: "done",
+        note: `${steps.length} step${steps.length === 1 ? "" : "s"}`,
+      });
+
+      // ---- Stage 2: AI script ----------------------------------------------
+      patchStage("script", { status: "running" });
+      let lines = resolveScriptLines(steps);
+      if (lines.every((l) => l.text.trim().length === 0)) {
+        throw new Error("No script text — add narration or generate a transcript first");
+      }
+      const tone: ScriptTone = avs?.script?.tone ?? "sales";
+      // Rewrite is best effort — keep the seeded text if OpenAI is unavailable.
+      let scriptWarning: string | undefined;
+      try {
+        lines = await rewriteScript(
+          lines.filter((l) => l.text.trim().length > 0),
+          tone
+        );
+      } catch {
+        scriptWarning = "Rewrite skipped — using the seeded narration";
+      }
+      mergeAvs({ script: { tone, lines } });
+      patchStage("script", {
+        status: scriptWarning ? "warning" : "done",
+        note: scriptWarning ?? `Rewritten in ${tone} tone`,
+      });
+
+      // ---- Stage 3: voiceover ----------------------------------------------
+      patchStage("voiceover", { status: "running" });
+      const voiceId = isAvsVoiceId(avs?.voiceover?.voiceId)
+        ? (avs?.voiceover?.voiceId as string)
+        : DEFAULT_AVS_VOICE;
+      const pronunciation = (avs?.pronunciation ?? []).filter(
+        (r) => r.term.trim().length > 0 && r.phonetic.trim().length > 0
+      );
+      const voiceover = await synthesizeVoiceover(
+        lines.filter((l) => l.text.trim().length > 0),
+        voiceId,
+        pronunciation
+      );
+      mergeAvs({ voiceover });
+      patchStage("voiceover", {
+        status: "done",
+        note: `${voiceover.duration.toFixed(1)}s continuous MP3`,
+      });
+
+      // ---- Stage 4: captions (non-fatal) -----------------------------------
+      patchStage("captions", { status: "running" });
+      let captions: CaptionCue[] = avs?.captions ?? [];
+      try {
+        captions = await generateCaptions(voiceover.audioUrl);
+        mergeAvs({ captions });
+        patchStage("captions", {
+          status: captions.length > 0 ? "done" : "warning",
+          note:
+            captions.length > 0
+              ? `${captions.length} caption${captions.length === 1 ? "" : "s"}`
+              : "No speech detected",
+        });
+      } catch {
+        patchStage("captions", { status: "warning", note: "Skipped — export continues" });
+      }
+
+      // ---- Stage 5: time-alignment -----------------------------------------
+      patchStage("sync", { status: "running" });
+      const aligned = await alignSource({
+        videoUrl: videoUrl as string,
+        audioUrl: voiceover.audioUrl,
+        steps,
+        stepTimings: voiceover.stepTimings,
+        duration,
+        demoId: savedDemoId,
+      });
+      mergeAvs({ aligned });
+      patchStage("sync", {
+        status: "done",
+        note: `Aligned source (${aligned.duration.toFixed(1)}s)`,
+      });
+
+      // ---- Stage 6: export --------------------------------------------------
+      patchStage("export", { status: "running" });
+      const finalUrl = await exportAligned({
+        aligned,
+        captions,
+        title: sidebarTitle?.trim() || "AI Voiceover Demo",
+        demoId: savedDemoId,
+        selectedBackground: selectedBackground ?? "transparent",
+        aspectRatio: aspectRatio || "native",
+        browserFrame: {
+          mode: browserFrameMode,
+          drawShadow: browserFrameDrawShadow,
+          drawBorder: browserFrameDrawBorder,
+        },
+      });
+      setExportedUrl(finalUrl);
+      patchStage("export", { status: "done", note: "Ready to download" });
+
+      toast.success("AI voiceover demo ready", { id: toastId });
+    } catch (e: unknown) {
+      const message =
+        axios.isAxiosError(e) && typeof e.response?.data?.error === "string"
+          ? e.response.data.error
+          : e instanceof Error
+            ? e.message
+            : "Failed to generate AI voiceover demo";
+      // Mark the first still-running stage as the failure point.
+      setStages((prev) => {
+        const idx = prev.findIndex((s) => s.status === "running");
+        return idx === -1
+          ? prev
+          : prev.map((s, i) => (i === idx ? { ...s, status: "error", note: message } : s));
+      });
+      toast.error(message, { id: toastId });
+    } finally {
+      setRunning(false);
+    }
+  }, [
+    running,
+    canRun,
+    blockedReason,
+    avs,
+    mergeAvs,
+    patchStage,
+    resolveScriptLines,
+    extensionEvents,
+    zoomSegments,
+    duration,
+    videoUrl,
+    savedDemoId,
+    sidebarTitle,
+    selectedBackground,
+    aspectRatio,
+    browserFrameMode,
+    browserFrameDrawShadow,
+    browserFrameDrawBorder,
+  ]);
+
+  return {
+    stages,
+    running,
+    canRun,
+    blockedReason,
+    exportedUrl,
+    run,
+  };
+}

--- a/app/types/avs.ts
+++ b/app/types/avs.ts
@@ -60,6 +60,17 @@ export interface CaptionCue {
   text: string;
 }
 
+/**
+ * The intermediate source produced by the time-alignment pre-pass (AVS-2.4): the
+ * original video re-timed with freeze-frames / silence and the continuous
+ * voiceover muxed in. This URL becomes the source the normal export processes,
+ * so the final render carries the AI voice and freeze-frame timing.
+ */
+export interface AlignedSource {
+  videoUrl: string;
+  duration: number;
+}
+
 /** The complete AVS state stored under Demo.editing.avs. */
 export interface AvsState {
   steps: Step[];
@@ -68,4 +79,6 @@ export interface AvsState {
   pronunciation?: PronunciationRule[];
   /** Flicker-free captions generated from the voiceover audio (AVS-2.3). */
   captions?: CaptionCue[];
+  /** Freeze-frame/silence aligned source with the voiceover muxed in (AVS-2.4). */
+  aligned?: AlignedSource;
 }


### PR DESCRIPTION
Add a one-click 'Generate AI Voiceover Demo' pipeline that composes every AVS stage — steps -> script -> voiceover -> subtitles -> time-alignment -> export — with a per-stage progress UI, reusing the PR 3-6 routes.

- useAvsPipeline hook orchestrates the stages, persisting each result to the store's avs slice (so autosave round-trips the full AvsState into
  Demo.editing.avs). Degrades gracefully: no clicks -> one step, no transcript ->
  seed empty, failed rewrite/captions are non-fatal.
- Export integration is additive: the aligned source (voiceover already muxed in) plus stabilized captions are fed into the EXISTING /api/jobs/create route with no changes to the non-AVS export path.
- AvsPipeline component renders the headline action + stage progress + export link in the AI Voice panel, gated behind NEXT_PUBLIC_AVS_ENABLED.
- Add AlignedSource type + avs.aligned field for persistence.
- Document AVS env vars + the flow in the README; note staging enablement in .env.example.

Non-PRO (server 403) and flag-off (panel hidden, routes 404) paths are unaffected.
partial fixes #240 