### PR TITLE
feat(wtm): custom watermark upload, transparency & removal (WTM-6.3)

### DIFF
--- a/app/(signed)/editor/hooks/useExportFlow.ts
+++ b/app/(signed)/editor/hooks/useExportFlow.ts
@@ -5,6 +5,7 @@ import { toast } from "react-hot-toast";
 import { ExportSettings } from "@/app/components/ExportSettingsModal";
 import { ZoomEffect } from "@/app/types/editor/zoom-effect";
 import { exportVideo } from "../utils/videoHandlers";
+import { sanitizeWatermarkConfig } from "@/app/lib/wtm/watermark";
 import { buildExportSpeed, resolveExportBackgroundSelection } from "../utils/exportHelpers";
 import { SubtitleCue, TextOverlayItem } from "../types";
 import type { EditorState } from "../apiTypes";
@@ -50,6 +51,7 @@ export function useExportFlow({
     browserFrameDrawBorder,
     duration,
     savedDemoId,
+    wtm,
   } = editorState;
 
   const [showExportSettings, setShowExportSettings] = useState(false);
@@ -110,6 +112,11 @@ export function useExportFlow({
         fps: "24 FPS",
         speed: buildExportSpeed(playbackSpeed),
       },
+      // WTM: hand the demo's persisted watermark config to the export. The
+      // server decides the effective watermark from the user's plan (FREE →
+      // forced Marvedge badge), so this is a request, not the final word.
+      // Undefined for demos with no branding config → payload unchanged.
+      watermark: sanitizeWatermarkConfig(wtm?.watermark),
     });
 
     if (result) {

--- a/app/(signed)/editor/utils/videoHandlers.ts
+++ b/app/(signed)/editor/utils/videoHandlers.ts
@@ -4,6 +4,7 @@ import { ZoomEffect } from "@/app/types/editor/zoom-effect";
 import { Segment } from "../hooks/useEditorState";
 import { uploadBlobToGcs } from "@/app/lib/gcsUploadClient";
 import { fixWebmDurationIfNeeded } from "@/app/lib/fixWebmDuration";
+import type { WatermarkConfig } from "@/app/types/wtm";
 
 function getDemoIdFromApiResponse(data: unknown): string | null {
   if (!data || typeof data !== "object") {
@@ -536,6 +537,9 @@ interface ExportVideoParams {
   savedDemoId?: string | null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   settings?: any; // The new export settings
+  // WTM: the demo's `editing.wtm.watermark`, if any. Only a *request* — the
+  // server re-resolves the effective watermark from the user's plan.
+  watermark?: WatermarkConfig;
 }
 
 interface ExportVideoResult {
@@ -778,6 +782,7 @@ export const exportVideo = async ({
   duration,
   savedDemoId,
   settings,
+  watermark,
 }: ExportVideoParams): Promise<ExportVideoResult | null> => {
   const toastId = toast.loading("Preparing to export...");
   const exportSettings = settings || {
@@ -846,6 +851,9 @@ export const exportVideo = async ({
       imageMap,
       settings: exportSettings,
       subtitles: subtitles || [],
+      // WTM: omitted entirely when the demo has no watermark config, so the
+      // request body is identical to today for non-WTM demos.
+      ...(watermark ? { watermark } : {}),
     });
 
     const { jobId } = createRes.data;

--- a/app/api/jobs/create/route.ts
+++ b/app/api/jobs/create/route.ts
@@ -5,7 +5,8 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/lib/auth/options";
 import { isWtmEnabled } from "@/app/lib/wtm/flags";
 import { isWtmAllowed } from "@/app/lib/wtm/access";
-import type { WatermarkConfig, WtmPosition } from "@/app/types/wtm";
+import { DEFAULT_WATERMARK, sanitizeWatermarkConfig } from "@/app/lib/wtm/watermark";
+import type { WatermarkConfig } from "@/app/types/wtm";
 export const maxDuration = 300;
 
 const EXEMPT_EMAILS = [
@@ -45,60 +46,17 @@ async function isExportAllowed(
 
 // --- WTM (watermark) -------------------------------------------------------
 // The watermark baked into an export is decided here by plan — never by the
-// worker, which only renders whatever `recipe.watermark` it is handed. The
-// whole path is a no-op unless WTM_ENABLED is set, so prod behavior (and
-// existing recipes) are unchanged until enablement.
-
-const WTM_POSITIONS: readonly WtmPosition[] = ["br", "bl", "tr", "tl"];
-
-// FREE / anonymous default: a small, semi-transparent blue Marvedge badge in
-// the bottom-right. assetUrl omitted → the worker uses its bundled default logo.
-const FREE_TIER_WATERMARK: WatermarkConfig = {
-  enabled: true,
-  opacity: 0.55,
-  position: "br",
-  scale: 0.08,
-};
-
-function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
-  const n = Number(value);
-  if (!Number.isFinite(n)) {
-    return fallback;
-  }
-  return Math.min(max, Math.max(min, n));
-}
-
-function toHttpsUrl(url: string): string {
-  return url.startsWith("gs://") ? url.replace("gs://", "https://storage.googleapis.com/") : url;
-}
-
-// Validate + clamp a PRO/ENTERPRISE user's watermark config from the client.
-// enabled:false is preserved (a PRO user removing the watermark entirely).
-function sanitizeWatermarkConfig(raw: unknown): WatermarkConfig | undefined {
-  if (!raw || typeof raw !== "object") {
-    return undefined;
-  }
-  const w = raw as Record<string, unknown>;
-  const position = WTM_POSITIONS.includes(w.position as WtmPosition)
-    ? (w.position as WtmPosition)
-    : "br";
-  const assetUrl =
-    typeof w.assetUrl === "string" && w.assetUrl.trim().length > 0
-      ? toHttpsUrl(w.assetUrl.trim())
-      : undefined;
-  return {
-    enabled: Boolean(w.enabled),
-    ...(assetUrl ? { assetUrl } : {}),
-    opacity: clampNumber(w.opacity, 0, 1, 0.55),
-    position,
-    scale: clampNumber(w.scale, 0.01, 0.5, 0.08),
-  };
-}
+// worker, which only renders whatever `recipe.watermark` it is handed, and never
+// by the client, whose config is only ever a request. The whole path is a no-op
+// unless WTM_ENABLED is set, so prod behavior (and existing recipes) are
+// unchanged until enablement.
 
 // Resolve the effective watermark for an export:
 //   flag off         → undefined (no watermark; existing behavior preserved)
-//   FREE / anonymous → forced Marvedge badge (the monetization path)
-//   PRO / ENTERPRISE → the client's editing.wtm.watermark (incl. enabled:false), else none
+//   FREE / anonymous → forced Marvedge badge, client input ignored entirely
+//                      (they cannot upload a logo, change opacity, or remove it)
+//   PRO / ENTERPRISE → the client's editing.wtm.watermark, validated and clamped
+//                      (incl. enabled:false — removing the watermark), else none
 function resolveWatermarkForPlan(
   plan: string | null,
   clientWatermark: unknown
@@ -107,7 +65,7 @@ function resolveWatermarkForPlan(
     return undefined;
   }
   if (!isWtmAllowed(plan)) {
-    return { ...FREE_TIER_WATERMARK };
+    return { ...DEFAULT_WATERMARK };
   }
   return sanitizeWatermarkConfig(clientWatermark);
 }

--- a/app/components/editorSidebar/BrandingPanel.tsx
+++ b/app/components/editorSidebar/BrandingPanel.tsx
@@ -1,22 +1,28 @@
 import React from "react";
 
+import WatermarkEditor from "./wtm/WatermarkEditor";
+import { useWatermarkSettings } from "./wtm/useWatermarkSettings";
+
 /**
  * WTM ("Branding") sidebar panel.
  *
- * PR 1 (this) is a scaffold only — an empty shell so the tab exists behind the
- * flag. Nothing is wired to the export yet.
+ * PR 3 fills the scaffold with the watermark controls (WTM-6.3): a custom PNG
+ * upload (`uploadBlobToGcs`, `kind:"watermark"`), an opacity slider, a corner
+ * placement picker, and an enable/disable toggle so PRO users can remove the
+ * Marvedge watermark. Those persist to `Demo.editing.wtm.watermark` via the
+ * existing autosave (it already serializes the store's `wtm` field) and are
+ * carried into the export payload by useExportFlow.
  *
- * PR 3 fills it in with the watermark controls (WTM-6.3): a custom PNG upload
- * (`uploadBlobToGcs`, `kind:"watermark"`), an opacity slider, a corner-position
- * picker, and an enable/disable toggle so PRO users can remove the Marvedge
- * watermark. Those persist to `Demo.editing.wtm.watermark` via the existing
- * autosave (it already serializes the store's `wtm` field). The forced free-tier
- * Marvedge badge is decided server-side in jobs/create and is not controlled here.
+ * The panel only decides what a user is *offered*: jobs/create re-resolves the
+ * watermark from the user's real plan, so FREE/anonymous exports always get the
+ * forced Marvedge badge no matter what is persisted here.
  *
  * The whole panel is gated behind NEXT_PUBLIC_WTM_ENABLED by its parents
  * (EditorSidebar / SidebarHeader), so nothing here renders when the flag is off.
  */
 const BrandingPanel: React.FC = () => {
+  const watermarkSettings = useWatermarkSettings();
+
   return (
     <div className="space-y-6">
       <div>
@@ -25,6 +31,8 @@ const BrandingPanel: React.FC = () => {
           Add your watermark to exported videos. Upload a custom logo, adjust its transparency and
           placement, or remove the Marvedge badge (PRO).
         </p>
+
+        <WatermarkEditor {...watermarkSettings} />
       </div>
     </div>
   );

--- a/app/components/editorSidebar/wtm/WatermarkEditor.tsx
+++ b/app/components/editorSidebar/wtm/WatermarkEditor.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import { Lock, Trash2, Upload } from "lucide-react";
+
+import type { WtmPosition } from "@/app/types/wtm";
+import {
+  WTM_OPACITY_MAX,
+  WTM_OPACITY_MIN,
+  WTM_POSITIONS,
+  WTM_POSITION_LABELS,
+} from "@/app/lib/wtm/watermark";
+import type { WatermarkSettings } from "./useWatermarkSettings";
+
+// Where the little dot sits inside the corner-picker preview box.
+const CORNER_DOT_CLASS: Record<WtmPosition, string> = {
+  tl: "top-1 left-1",
+  tr: "top-1 right-1",
+  bl: "bottom-1 left-1",
+  br: "bottom-1 right-1",
+};
+
+/**
+ * Watermark controls (WTM-6.3): enable/disable, custom PNG upload + preview,
+ * opacity, and corner placement. PRO/ENTERPRISE only — FREE users see the same
+ * controls in a locked, read-only state describing the forced Marvedge badge,
+ * which is what jobs/create will bake in for them regardless.
+ */
+const WatermarkEditor: React.FC<WatermarkSettings> = ({
+  planLoading,
+  isPro,
+  watermark,
+  previewUrl,
+  uploading,
+  setEnabled,
+  setOpacity,
+  setPosition,
+  handleUpload,
+  handleRemoveLogo,
+}) => {
+  const locked = !isPro;
+  const opacityPercent = Math.round(watermark.opacity * 100);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <h3 className="control-block-label text-sm font-bold text-[#A594F9]">Watermark</h3>
+        {locked && (
+          <span className="flex items-center gap-1 rounded-full bg-[#F6F3FF] px-2 py-0.5 text-[10px] font-semibold text-[#7C5CFC]">
+            <Lock className="w-3 h-3" />
+            PRO
+          </span>
+        )}
+      </div>
+
+      <p className="text-xs text-[#6B6B6B] dark:text-inherit mb-3">
+        {locked
+          ? "Exports include the Marvedge badge. Upgrade to PRO to use your own logo, adjust its transparency, or remove it."
+          : "Upload your own logo, adjust its transparency and placement — or turn the watermark off entirely."}
+      </p>
+
+      <fieldset disabled={locked || planLoading} className="space-y-4 disabled:opacity-60">
+        {/* Enable / disable — a PRO user may remove the watermark completely. */}
+        <label className="flex items-center justify-between gap-3 cursor-pointer">
+          <span className="text-xs font-semibold text-[#7C5CFC]">Show watermark on exports</span>
+          <span className="relative inline-flex items-center">
+            <input
+              type="checkbox"
+              checked={locked ? true : watermark.enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+              className="peer sr-only"
+            />
+            <span className="h-5 w-9 rounded-full bg-[#ede7fa] transition peer-checked:bg-[#8A76FC] peer-focus-visible:ring-2 peer-focus-visible:ring-[#A594F9]" />
+            <span className="absolute left-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-4" />
+          </span>
+        </label>
+
+        {/* Logo picker + preview */}
+        <div>
+          <span className="control-block-label block text-[#A594F9] font-semibold mb-2 text-xs">
+            Logo
+          </span>
+          <div className="flex items-center gap-3">
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-[#ede7fa] bg-[#F6F3FF]">
+              {previewUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={previewUrl}
+                  alt="Watermark preview"
+                  className="h-full w-full object-contain"
+                />
+              ) : (
+                <span className="text-[9px] font-semibold text-[#B0A5D3] text-center leading-tight px-1">
+                  Marvedge badge
+                </span>
+              )}
+            </div>
+
+            <div className="flex-1 space-y-2">
+              <div className="relative">
+                <input
+                  type="file"
+                  accept="image/png"
+                  onChange={handleUpload}
+                  disabled={locked || uploading}
+                  className="absolute inset-0 w-full h-full opacity-0 cursor-pointer disabled:cursor-not-allowed"
+                />
+                <div className="flex items-center justify-between rounded-lg border border-[#ede7fa] px-3 py-2 text-[#7C5CFC]">
+                  <span className="text-xs">
+                    {uploading ? "Uploading…" : watermark.assetUrl ? "Replace PNG" : "Upload PNG"}
+                  </span>
+                  <Upload className="w-4 h-4" />
+                </div>
+              </div>
+
+              {watermark.assetUrl && (
+                <button
+                  type="button"
+                  onClick={handleRemoveLogo}
+                  disabled={locked || uploading}
+                  className="flex items-center gap-1 text-[11px] font-semibold text-[#7C5CFC] hover:underline disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  <Trash2 className="w-3 h-3" />
+                  Use the Marvedge badge instead
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Transparency */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <span className="control-block-label text-[#A594F9] font-semibold text-xs">
+              Transparency
+            </span>
+            <span className="text-xs text-[#7C5CFC]">{opacityPercent}%</span>
+          </div>
+          <input
+            type="range"
+            min={WTM_OPACITY_MIN}
+            max={WTM_OPACITY_MAX}
+            step={0.05}
+            value={watermark.opacity}
+            onChange={(e) => setOpacity(Number(e.target.value))}
+            className="w-full accent-[#8A76FC] cursor-pointer disabled:cursor-not-allowed"
+          />
+        </div>
+
+        {/* Corner placement */}
+        <div>
+          <span className="control-block-label block text-[#A594F9] font-semibold mb-2 text-xs">
+            Placement
+          </span>
+          <div className="grid grid-cols-4 gap-2">
+            {WTM_POSITIONS.map((position) => {
+              const isActive = watermark.position === position;
+              return (
+                <button
+                  key={position}
+                  type="button"
+                  onClick={() => setPosition(position)}
+                  title={WTM_POSITION_LABELS[position]}
+                  aria-label={WTM_POSITION_LABELS[position]}
+                  aria-pressed={isActive}
+                  className={`relative h-10 rounded-lg border-2 bg-white transition-all disabled:cursor-not-allowed ${
+                    isActive
+                      ? "border-[#7C5CFC] shadow-md"
+                      : "border-[#ede7fa] hover:border-[#A594F9]"
+                  }`}
+                >
+                  <span
+                    className={`absolute h-2.5 w-2.5 rounded-sm ${CORNER_DOT_CLASS[position]} ${
+                      isActive ? "bg-[#7C5CFC]" : "bg-[#D6CCF7]"
+                    }`}
+                  />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  );
+};
+
+export default WatermarkEditor;

--- a/app/components/editorSidebar/wtm/useWatermarkSettings.ts
+++ b/app/components/editorSidebar/wtm/useWatermarkSettings.ts
@@ -1,0 +1,216 @@
+import React from "react";
+import axios from "axios";
+import { toast } from "react-hot-toast";
+import { useShallow } from "zustand/react/shallow";
+
+import type { WatermarkConfig, WtmPosition, WtmState } from "@/app/types/wtm";
+import { useEditorStore } from "@/app/store/editor/editorStore";
+import { isWtmAllowed } from "@/app/lib/wtm/access";
+import {
+  DEFAULT_WATERMARK,
+  WTM_OPACITY_MAX,
+  WTM_OPACITY_MIN,
+  clampNumber,
+} from "@/app/lib/wtm/watermark";
+import { uploadBlobToGcs } from "@/app/lib/gcsUploadClient";
+
+const MAX_LOGO_BYTES = 2 * 1024 * 1024; // 2 MB — a corner badge never needs more.
+
+export interface WatermarkSettings {
+  /** Whether the plan gate is still being resolved (renders as locked until known). */
+  planLoading: boolean;
+  /** PRO/ENTERPRISE — may customize or remove the watermark. */
+  isPro: boolean;
+  /** The config to render controls from (persisted values, or the defaults). */
+  watermark: WatermarkConfig;
+  /** True once this demo has its own persisted config (vs. showing defaults). */
+  hasConfig: boolean;
+  /** Object URL of a just-picked file, or the persisted asset URL — for preview. */
+  previewUrl: string | null;
+  uploading: boolean;
+  setEnabled: (enabled: boolean) => void;
+  setOpacity: (opacity: number) => void;
+  setPosition: (position: WtmPosition) => void;
+  handleUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  /** Drop the custom logo and fall back to the bundled Marvedge badge. */
+  handleRemoveLogo: () => void;
+}
+
+/**
+ * Owns the watermark half of the Branding panel (WTM-6.3).
+ *
+ * Reads/writes `editing.wtm.watermark` through the editor store's `wtm` slice —
+ * the existing autosave already serializes that field, so everything here
+ * persists into `Demo.editing.wtm` with no migration. The export payload picks
+ * the same config up (see useExportFlow), and the render engine bakes it in.
+ *
+ * The plan gate mirrors the server's: only PRO/ENTERPRISE may upload a logo,
+ * change opacity/placement, or switch the watermark off. This hook only decides
+ * what the UI offers — app/api/jobs/create/route.ts re-resolves the watermark
+ * from the user's real plan, so a FREE user always gets the forced Marvedge
+ * badge regardless of what is persisted here.
+ */
+export function useWatermarkSettings(): WatermarkSettings {
+  const { wtm, setWtm } = useEditorStore(
+    useShallow((s) => ({
+      wtm: s.wtm,
+      setWtm: s.setWtm,
+    }))
+  );
+
+  const [plan, setPlan] = React.useState<string | null>(null);
+  const [planLoading, setPlanLoading] = React.useState(true);
+  const [uploading, setUploading] = React.useState(false);
+  // Local preview for a file the user just picked: the upload bucket may be
+  // private, so the persisted https URL is not always renderable in the browser.
+  const [localPreviewUrl, setLocalPreviewUrl] = React.useState<string | null>(null);
+
+  // Same source of truth as the export modal's plan check (/api/user/export-count).
+  React.useEffect(() => {
+    let cancelled = false;
+    axios
+      .get("/api/user/export-count")
+      .then((res) => {
+        if (!cancelled && res.data && typeof res.data.plan === "string") {
+          setPlan(res.data.plan);
+        }
+      })
+      .catch((err) => console.error("Could not fetch plan for branding panel", err))
+      .finally(() => {
+        if (!cancelled) {
+          setPlanLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    return () => {
+      if (localPreviewUrl) {
+        URL.revokeObjectURL(localPreviewUrl);
+      }
+    };
+  }, [localPreviewUrl]);
+
+  const isPro = isWtmAllowed(plan);
+  const persisted = wtm?.watermark;
+  const watermark = persisted ?? DEFAULT_WATERMARK;
+
+  // Merge into the watermark config while preserving the rest of the WTM state
+  // (e.g. the forward-compat `webcam` key).
+  const updateWatermark = React.useCallback(
+    (patch: Partial<WatermarkConfig>) => {
+      setWtm((prev) => {
+        const base: WtmState = prev ?? {};
+        return {
+          ...base,
+          watermark: { ...DEFAULT_WATERMARK, ...base.watermark, ...patch },
+        };
+      });
+    },
+    [setWtm]
+  );
+
+  const setEnabled = React.useCallback(
+    (enabled: boolean) => updateWatermark({ enabled }),
+    [updateWatermark]
+  );
+
+  const setOpacity = React.useCallback(
+    (opacity: number) =>
+      updateWatermark({
+        opacity: clampNumber(opacity, WTM_OPACITY_MIN, WTM_OPACITY_MAX, DEFAULT_WATERMARK.opacity),
+      }),
+    [updateWatermark]
+  );
+
+  const setPosition = React.useCallback(
+    (position: WtmPosition) => updateWatermark({ position }),
+    [updateWatermark]
+  );
+
+  const handleUpload = React.useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      // Let the same file be re-picked after an error.
+      event.target.value = "";
+      if (!file) {
+        return;
+      }
+      if (file.type !== "image/png") {
+        toast.error("Watermark must be a PNG");
+        return;
+      }
+      if (file.size > MAX_LOGO_BYTES) {
+        toast.error("Watermark must be under 2 MB");
+        return;
+      }
+
+      const objectUrl = URL.createObjectURL(file);
+      setLocalPreviewUrl((prev) => {
+        if (prev) {
+          URL.revokeObjectURL(prev);
+        }
+        return objectUrl;
+      });
+
+      const toastId = toast.loading("Uploading watermark…");
+      setUploading(true);
+      try {
+        const uploaded = await uploadBlobToGcs({
+          blob: file,
+          filename: file.name || "watermark.png",
+          kind: "watermark",
+        });
+        // Prefer the https form: it is what the worker downloads and what the
+        // panel can preview after a reload. `url` (gs://) is normalized server-side.
+        updateWatermark({ enabled: true, assetUrl: uploaded.publicUrl || uploaded.url });
+        toast.success("Watermark uploaded", { id: toastId });
+      } catch (error) {
+        console.error("Watermark upload failed:", error);
+        toast.error("Failed to upload watermark", { id: toastId });
+        setLocalPreviewUrl((prev) => {
+          if (prev) {
+            URL.revokeObjectURL(prev);
+          }
+          return null;
+        });
+      } finally {
+        setUploading(false);
+      }
+    },
+    [updateWatermark]
+  );
+
+  const handleRemoveLogo = React.useCallback(() => {
+    setLocalPreviewUrl((prev) => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return null;
+    });
+    setWtm((prev) => {
+      const base: WtmState = prev ?? {};
+      const next: WatermarkConfig = { ...DEFAULT_WATERMARK, ...base.watermark };
+      // Drop assetUrl entirely so the worker falls back to the bundled badge.
+      delete next.assetUrl;
+      return { ...base, watermark: next };
+    });
+  }, [setWtm]);
+
+  return {
+    planLoading,
+    isPro,
+    watermark,
+    hasConfig: Boolean(persisted),
+    previewUrl: localPreviewUrl ?? watermark.assetUrl ?? null,
+    uploading,
+    setEnabled,
+    setOpacity,
+    setPosition,
+    handleUpload,
+    handleRemoveLogo,
+  };
+}

--- a/app/lib/gcsUploadClient.ts
+++ b/app/lib/gcsUploadClient.ts
@@ -2,6 +2,8 @@ export type GcsUploadKind =
   | "demo-source"
   | "export-source"
   | "background"
+  // WTM: a PRO user's custom watermark PNG (app/components/editorSidebar/wtm).
+  | "watermark"
   | "subtitle-source"
   | "generic";
 

--- a/app/lib/wtm/watermark.ts
+++ b/app/lib/wtm/watermark.ts
@@ -1,0 +1,84 @@
+// Shared watermark defaults + validation for WTM.
+//
+// Both ends of the feature need the same numbers and the same notion of a
+// "valid" config: the Branding panel seeds and edits `Demo.editing.wtm.watermark`
+// with them, and app/api/jobs/create/route.ts re-validates whatever the client
+// sends before it reaches the worker. Keeping them here stops the two from
+// drifting — the client copy is a convenience, the server copy is the authority.
+//
+// This module is isomorphic (no env, no node/browser APIs) so it can be imported
+// from a client component and from a route handler alike.
+
+import type { WatermarkConfig, WtmPosition } from "@/app/types/wtm";
+
+/** The four corners a watermark can be anchored to, in UI order. */
+export const WTM_POSITIONS: readonly WtmPosition[] = ["tl", "tr", "bl", "br"];
+
+/** Human labels for the corner picker. */
+export const WTM_POSITION_LABELS: Record<WtmPosition, string> = {
+  tl: "Top left",
+  tr: "Top right",
+  bl: "Bottom left",
+  br: "Bottom right",
+};
+
+/**
+ * The baseline watermark: a small, semi-transparent Marvedge badge in the
+ * bottom-right. This is exactly what FREE/anonymous exports are forced to use,
+ * and what a PRO user's config starts from before they customize it. No
+ * `assetUrl` → the worker falls back to its bundled default badge.
+ */
+export const DEFAULT_WATERMARK: WatermarkConfig = {
+  enabled: true,
+  opacity: 0.55,
+  position: "br",
+  scale: 0.08,
+};
+
+/** Bounds the render engine also clamps to (see cloudrun-worker/render.js). */
+export const WTM_OPACITY_MIN = 0;
+export const WTM_OPACITY_MAX = 1;
+export const WTM_SCALE_MIN = 0.01;
+export const WTM_SCALE_MAX = 0.5;
+
+export function isWtmPosition(value: unknown): value is WtmPosition {
+  return typeof value === "string" && (WTM_POSITIONS as readonly string[]).includes(value);
+}
+
+export function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, n));
+}
+
+/** gs:// URLs are not fetchable by the worker's http(s) downloader. */
+export function toHttpsUrl(url: string): string {
+  return url.startsWith("gs://") ? url.replace("gs://", "https://storage.googleapis.com/") : url;
+}
+
+/**
+ * Validate + clamp a watermark config coming from the client (or from a demo's
+ * persisted `editing.wtm`). `enabled: false` is preserved — that is a PRO user
+ * removing the watermark entirely, not a missing value. Returns undefined for
+ * anything that isn't an object, so callers can treat "no config" distinctly
+ * from "disabled".
+ */
+export function sanitizeWatermarkConfig(raw: unknown): WatermarkConfig | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const w = raw as Record<string, unknown>;
+  const assetUrl =
+    typeof w.assetUrl === "string" && w.assetUrl.trim().length > 0
+      ? toHttpsUrl(w.assetUrl.trim())
+      : undefined;
+  return {
+    enabled: Boolean(w.enabled),
+    ...(assetUrl ? { assetUrl } : {}),
+    opacity: clampNumber(w.opacity, WTM_OPACITY_MIN, WTM_OPACITY_MAX, DEFAULT_WATERMARK.opacity),
+    position: isWtmPosition(w.position) ? w.position : DEFAULT_WATERMARK.position,
+    scale: clampNumber(w.scale, WTM_SCALE_MIN, WTM_SCALE_MAX, DEFAULT_WATERMARK.scale),
+  };
+}


### PR DESCRIPTION
Let PRO/ENTERPRISE users upload their own PNG logo, set its transparency and corner placement, or remove the watermark entirely. FREE/anonymous users always get the forced Marvedge badge.

- lib/wtm/watermark.ts: shared, isomorphic watermark defaults + validation (DEFAULT_WATERMARK, corner list/labels, clamps, sanitizeWatermarkConfig) so the panel and jobs/create cannot drift. jobs/create now imports these instead of its own copies; the resolved values are unchanged.
- gcsUploadClient: new "watermark" GcsUploadKind (the upload route already namespaces objects by kind, so no route change is needed).
- BrandingPanel: a Watermark section (useWatermarkSettings + WatermarkEditor) with an enable/disable toggle, a PNG picker with preview, an opacity slider and a 4-corner placement picker. Writes editing.wtm.watermark via setWtm, which the existing autosave persists, so it round-trips across reloads. Plan is read from /api/user/export-count (the same source as the export modal); non-PRO users see the controls PRO-locked and read-only.
- Export: useExportFlow maps editing.wtm.watermark into the jobs/create payload as `watermark`, which PR2's engine renders. The key is omitted entirely for demos with no config, so non-WTM export requests are byte-for-byte unchanged.
- Server gate (behavior unchanged, comments clarified): jobs/create still resolves the effective watermark from the user's real plan — FREE/anon client input is ignored and forced to the Marvedge badge; PRO input is validated and clamped, including enabled:false.

The panel only renders behind NEXT_PUBLIC_WTM_ENABLED and the server path only runs behind WTM_ENABLED, so this is a no-op with the flags off.