### PR TITLE
fix(middleware): treat marvedge.com as the main domain

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -21,11 +21,21 @@ export default async function middleware(req: NextRequest, event: NextFetchEvent
   }
 
   // 2. Subdomain & Custom domain routing
-  const mainDomains = ["marvedge.io", "localhost:3000", "marvedge.vercel.app"];
-  const isMainDomain = mainDomains.includes(hostname);
-  const isSubdomain = hostname.endsWith(".localhost:3000") || hostname.endsWith(".marvedge.io");
+  // The apex domain the app itself is served from. Anything that is not this
+  // domain (or a dev/preview host) is treated as a customer hub.
+  const rootDomain = process.env.NEXT_PUBLIC_ROOT_DOMAIN || "marvedge.com";
+  const devDomain = "localhost:3000";
 
-  if (!isMainDomain || isSubdomain) {
+  const isMainDomain =
+    hostname === rootDomain ||
+    hostname === `www.${rootDomain}` ||
+    hostname === devDomain ||
+    hostname.endsWith(".vercel.app"); // production + preview deployments
+  const isSubdomain =
+    !isMainDomain &&
+    (hostname.endsWith(`.${rootDomain}`) || hostname.endsWith(`.${devDomain}`));
+
+  if (!isMainDomain) {
     const domainKey = isSubdomain ? hostname.split(".")[0] : hostname.split(":")[0];
     console.log(
       `[Middleware] Subdomain/custom domain detected: "${hostname}" (Key: "${domainKey}"). Rewriting path to /hub/${domainKey}${url.pathname}`
@@ -34,7 +44,7 @@ export default async function middleware(req: NextRequest, event: NextFetchEvent
     // Redirect dashboard or auth pages back to the main domain
     if (url.pathname.startsWith("/dashboard") || url.pathname.startsWith("/auth")) {
       const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-      const targetDomain = hostname.endsWith(".localhost:3000") ? "localhost:3000" : "marvedge.io";
+      const targetDomain = hostname.endsWith(`.${devDomain}`) ? devDomain : rootDomain;
       return NextResponse.redirect(`${protocol}://${targetDomain}${url.pathname}${url.search}`);
     }
 


### PR DESCRIPTION
The main-domain whitelist still listed marvedge.io, which no longer resolves. Requests to marvedge.com therefore fell through to the custom-domain branch and were rewritten to /hub/marvedge.com, where the hubSettings lookup found no match and returned notFound() - serving a 404 for every page on the marketing site.

Derive the root domain from NEXT_PUBLIC_ROOT_DOMAIN (default marvedge.com) instead of a hardcoded list, and:

- treat www. as a main domain, so it is not rewritten to /hub/www....
- match .vercel.app by suffix so branch preview deployments resolve; only the exact marvedge.vercel.app host worked before
- point the dashboard/auth redirect at the live domain instead of the dead .io one
- drop the redundant `|| isSubdomain` branch, which could never fire

Verified locally: with the previous middleware, a request with a marvedge.com Host header returns 404; with this change it returns 200.