### PR TITLE
feat(qr): surface the share QR in the export and share modals

### DIFF
--- a/app/(signed)/editor/components/EditorModals.tsx
+++ b/app/(signed)/editor/components/EditorModals.tsx
@@ -63,6 +63,7 @@ export default function EditorModals({
       <ExportResultModal
         isOpen={exportFlow.showExportResultModal}
         shareUrl={pendingExport?.shareUrl || null}
+        title={sidebarTitle}
         loading={exportFlow.resultActionLoading}
         onClose={() => {
           if (exportFlow.resultActionLoading) {

--- a/app/components/ExportResultModal.tsx
+++ b/app/components/ExportResultModal.tsx
@@ -3,9 +3,13 @@
 import { Copy } from "lucide-react";
 import toast from "react-hot-toast";
 
+import ShareQrCode from "./qr/ShareQrCode";
+
 interface ExportResultModalProps {
   isOpen: boolean;
   shareUrl?: string | null;
+  /** Demo title — names the QR downloads, as it already names the MP4. */
+  title?: string;
   loading?: boolean;
   onClose: () => void;
   onDownloadMp4: () => void;
@@ -15,6 +19,7 @@ interface ExportResultModalProps {
 export default function ExportResultModal({
   isOpen,
   shareUrl,
+  title,
   loading = false,
   onClose,
   onDownloadMp4,
@@ -35,7 +40,9 @@ export default function ExportResultModal({
     <div className="fixed inset-0 z-[99999] flex items-center justify-center">
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
 
-      <div className="relative w-full max-w-[560px] rounded-2xl border border-white bg-[#F8F8FC] p-6 shadow-[0_8px_32px_rgba(124,92,252,0.15)]">
+      {/* max-h/overflow so the QR can never push the action buttons off-screen
+          on a short viewport. */}
+      <div className="relative max-h-[90vh] w-full max-w-[560px] overflow-y-auto rounded-2xl border border-white bg-[#F8F8FC] p-6 shadow-[0_8px_32px_rgba(124,92,252,0.15)]">
         <h2 className="mb-2 text-2xl font-semibold text-[#8A76FC]">Export Complete</h2>
         <p className="mb-4 text-sm text-[#5E4FB2]">
           Download only as MP4, or generate a share link to save to your Exported Videos.
@@ -58,6 +65,14 @@ export default function ExportResultModal({
                 <Copy size={20} />
               </button>
             </div>
+
+            {/* Expanded by default: the QR is the point of this moment. */}
+            <ShareQrCode
+              url={shareUrl}
+              title={title}
+              feedback="toast"
+              className="mt-3 rounded-2xl border-[#D9D1FA]"
+            />
           </div>
         )}
 

--- a/app/components/ShareModal.tsx
+++ b/app/components/ShareModal.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Copy, Link2, X } from "lucide-react";
+import { ChevronDown, Copy, Link2, X } from "lucide-react";
+
+import { isShareQrEnabled } from "@/app/lib/qr";
+import ShareQrCode from "./qr/ShareQrCode";
 
 interface Props {
   apiPath: string;
@@ -14,6 +17,8 @@ export default function ShareModal({ apiPath, title, onClose }: Props) {
   const [copied, setCopied] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Collapsed by default so the modal keeps its current height until asked.
+  const [showQr, setShowQr] = useState(false);
 
   const headingTitle = useMemo(() => {
     if (!title?.trim()) {
@@ -70,13 +75,16 @@ export default function ShareModal({ apiPath, title, onClose }: Props) {
     setTimeout(() => setCopied(false), 1400);
   }
 
+  // The overflow lives on the backdrop, not the panel, because the floating link
+  // badge hangs outside the panel's box — py-16 is what gives it room, and
+  // `my-auto` on the panel keeps it centred until the content outgrows the screen.
   return (
     <div
-      className="fixed inset-0 z-[120] flex items-center justify-center bg-[rgba(26,17,58,0.2)] backdrop-blur-sm px-4"
+      className="fixed inset-0 z-[120] flex justify-center overflow-y-auto bg-[rgba(26,17,58,0.2)] backdrop-blur-sm px-4 py-16"
       onClick={onClose}
     >
       <div
-        className="relative w-full max-w-[620px] rounded-[28px] border border-[#CFC4FF] bg-white px-8 pb-8 pt-12 shadow-[0_24px_70px_rgba(84,65,160,0.22)]"
+        className="relative my-auto w-full max-w-[620px] rounded-[28px] border border-[#CFC4FF] bg-white px-8 pb-8 pt-12 shadow-[0_24px_70px_rgba(84,65,160,0.22)]"
         onClick={(e) => e.stopPropagation()}
       >
         <button
@@ -122,6 +130,31 @@ export default function ShareModal({ apiPath, title, onClose }: Props) {
             </button>
           </div>
           {copied && <p className="mt-2 text-sm font-medium text-[#6E56CF]">Copied to clipboard</p>}
+
+          {/* Only once there is a real link to encode — and gated here as well as
+              inside ShareQrCode, so the flag off leaves no dead toggle behind. */}
+          {isShareQrEnabled() && !loading && !error && link && (
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={() => setShowQr((prev) => !prev)}
+                aria-expanded={showQr}
+                className="inline-flex items-center gap-1.5 text-sm font-semibold text-[#6E56CF] transition hover:text-[#8B72F8]"
+              >
+                <ChevronDown
+                  className={`h-4 w-4 transition-transform ${showQr ? "rotate-180" : ""}`}
+                />
+                {showQr ? "Hide QR code" : "Show QR code"}
+              </button>
+              {showQr && (
+                <ShareQrCode
+                  url={link}
+                  title={title}
+                  className="mt-3 rounded-[28px] border-[#CFC4FF]"
+                />
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/app/components/qr/ShareQrCode.tsx
+++ b/app/components/qr/ShareQrCode.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import React from "react";
+import { Check, Copy, Download, Loader2 } from "lucide-react";
+import toast from "react-hot-toast";
+
+import { QR_SIZE_PRESETS, isShareQrEnabled } from "@/app/lib/qr";
+import { useShareQr, type ShareQrDownloadPreset } from "./useShareQr";
+
+export interface ShareQrCodeProps {
+  /** The share URL to encode. It already exists — the QR never mints a link. */
+  url: string;
+  /** Demo title, used to name the downloaded files. */
+  title?: string;
+  /** Host-modal card styling: radius and border, so this matches its surroundings. */
+  className?: string;
+  /**
+   * How a completed action is acknowledged. ExportResultModal already runs
+   * react-hot-toast for its link copy; ShareModal deliberately uses inline text
+   * and mounts no Toaster. Defaults to "inline", which is safe anywhere.
+   */
+  feedback?: "inline" | "toast";
+}
+
+/** How long an inline status line stays up. Matches ShareModal's copy feedback. */
+const STATUS_MS = 1400;
+
+/**
+ * A scannable QR for a share link, with PNG/SVG download and copy-to-clipboard.
+ *
+ * All rendering comes from the engine in app/lib/qr — this file draws no QR
+ * geometry and must not start to. One style only: the badge preset. There is
+ * deliberately no style prop (see MARVEDGE_QR_PRESET in app/lib/qr/presets.ts).
+ */
+export default function ShareQrCode(props: ShareQrCodeProps) {
+  // Guarded outside the card so the kill-switch costs nothing: with the flag off
+  // there is no hook, no matrix build, and no empty card left behind.
+  if (!isShareQrEnabled()) {
+    return null;
+  }
+  return <ShareQrCard {...props} />;
+}
+
+function ShareQrCard({ url, title, className = "", feedback = "inline" }: ShareQrCodeProps) {
+  const { svg, busy, canCopyImage, downloadPng, downloadSvg, copyImage } = useShareQr({
+    url,
+    title,
+  });
+  const [status, setStatus] = React.useState<string | null>(null);
+  const statusTimer = React.useRef<number | undefined>(undefined);
+
+  React.useEffect(() => {
+    return () => window.clearTimeout(statusTimer.current);
+  }, []);
+
+  const report = React.useCallback(
+    (message: string, failed = false) => {
+      if (feedback === "toast") {
+        if (failed) {
+          toast.error(message);
+        } else {
+          toast.success(message);
+        }
+        return;
+      }
+      window.clearTimeout(statusTimer.current);
+      setStatus(message);
+      statusTimer.current = window.setTimeout(() => setStatus(null), STATUS_MS);
+    },
+    [feedback]
+  );
+
+  const handlePng = async (preset: ShareQrDownloadPreset) => {
+    try {
+      await downloadPng(preset);
+      report(`QR downloaded — ${QR_SIZE_PRESETS[preset]}px PNG`);
+    } catch (error) {
+      console.error("QR PNG export failed:", error);
+      report("Could not download the QR code", true);
+    }
+  };
+
+  const handleSvg = async () => {
+    try {
+      await downloadSvg();
+      report("QR downloaded — SVG");
+    } catch (error) {
+      console.error("QR SVG export failed:", error);
+      report("Could not download the QR code", true);
+    }
+  };
+
+  const handleCopy = async () => {
+    try {
+      const outcome = await copyImage();
+      report(
+        outcome === "copied" ? "QR copied to clipboard" : "QR downloaded — copying unsupported"
+      );
+    } catch (error) {
+      console.error("QR copy failed:", error);
+      report("Could not copy the QR code", true);
+    }
+  };
+
+  return (
+    <div className={`border bg-white p-4 ${className}`}>
+      <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-start">
+        {/* The engine's markup goes in as-is. Nothing user-supplied reaches it:
+            the URL is encoded into the module matrix, never interpolated into the
+            SVG source (asserted in app/lib/qr/qr.test.ts). */}
+        <div
+          className="h-[160px] w-[160px] shrink-0 [&>svg]:h-full [&>svg]:w-full"
+          role="img"
+          aria-label={title ? `QR code for ${title}` : "QR code for the share link"}
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+
+        <div className="min-w-0 flex-1 text-center sm:text-left">
+          <p className="text-sm font-semibold text-[#2D1F61]">Scan to open</p>
+          <p className="mt-1 text-xs leading-relaxed text-[#8C82B4]">
+            Point a phone camera at the code, or save it for a slide or a print.
+          </p>
+
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <QrAction onClick={() => handlePng("download")} disabled={busy} icon={<Download />}>
+              PNG {QR_SIZE_PRESETS.download}
+            </QrAction>
+            <QrAction onClick={() => handlePng("print")} disabled={busy} icon={<Download />}>
+              PNG {QR_SIZE_PRESETS.print}
+            </QrAction>
+            <QrAction onClick={handleSvg} disabled={busy} icon={<Download />}>
+              SVG
+            </QrAction>
+            <QrAction
+              onClick={handleCopy}
+              disabled={busy}
+              icon={
+                busy ? <Loader2 className="animate-spin" /> : canCopyImage ? <Copy /> : <Download />
+              }
+            >
+              {canCopyImage ? "Copy" : "Save"}
+            </QrAction>
+          </div>
+
+          {feedback === "inline" && status && (
+            <p className="mt-2 flex items-center justify-center gap-1 text-xs font-medium text-[#6E56CF] sm:justify-start">
+              <Check className="h-3 w-3" />
+              {status}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** One compact action button. Kept local — nothing else needs this shape. */
+function QrAction({
+  onClick,
+  disabled,
+  icon,
+  children,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  icon: React.ReactElement<{ className?: string }>;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-[#E2DAFB] bg-[#F6F3FF] px-2 py-2 text-xs font-semibold text-[#7C5CFC] transition hover:bg-[#EAE5FB] disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {React.cloneElement(icon, {
+        className: `h-3.5 w-3.5 shrink-0 ${icon.props.className ?? ""}`,
+      })}
+      {children}
+    </button>
+  );
+}

--- a/app/components/qr/useShareQr.ts
+++ b/app/components/qr/useShareQr.ts
@@ -1,0 +1,218 @@
+"use client";
+
+import React from "react";
+
+import { QR_SIZE_PRESETS, renderQrSvg, renderQrSvgDataUri, type QrSizePreset } from "@/app/lib/qr";
+
+/** The two sizes the download menu offers. `screen` is what the card displays. */
+export type ShareQrDownloadPreset = Extract<QrSizePreset, "download" | "print">;
+
+/** What `copyImage` actually managed to do, so the caller can word its toast. */
+export type ShareQrCopyOutcome = "copied" | "downloaded";
+
+export interface UseShareQrOptions {
+  /** The share URL to encode. It already exists — the QR never mints a link. */
+  url: string;
+  /** Demo title, used only to name the downloaded files. */
+  title?: string;
+}
+
+export interface ShareQr {
+  /** Inline-able SVG markup for the on-screen QR, memoized per url. */
+  svg: string;
+  /** True while a rasterize/copy round-trip is in flight. */
+  busy: boolean;
+  /** Whether this browser can put an image on the clipboard at all. */
+  canCopyImage: boolean;
+  downloadPng: (preset: ShareQrDownloadPreset) => Promise<void>;
+  downloadSvg: () => Promise<void>;
+  /** Copies the PNG, falling back to downloading it where the API is missing. */
+  copyImage: () => Promise<ShareQrCopyOutcome>;
+}
+
+// Prefixed with "marvedge-qr-" at the call site, so this only needs to say what.
+const FILENAME_FALLBACK = "demo";
+
+/** Best-effort slug for a download filename — never empty, never path-ish. */
+function slugify(title: string | undefined): string {
+  const slug = (title ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48)
+    .replace(/-+$/g, "");
+  return slug || FILENAME_FALLBACK;
+}
+
+/**
+ * Rasterize an SVG `data:` URI into a PNG blob at `size` square.
+ *
+ * Untainted by construction: the mark is inlined as a `data:` URI in
+ * app/lib/qr/mark.ts, so nothing in this path is cross-origin and `toBlob` cannot
+ * throw a SecurityError. If it ever does, a remote `<img>` has crept into the
+ * pipeline — find it rather than routing around it.
+ */
+async function svgToPngBlob(dataUri: string, size: number): Promise<Blob> {
+  const image = new Image();
+  // Firefox sizes an SVG `<img>` from these rather than from the drawImage box.
+  image.width = size;
+  image.height = size;
+
+  await new Promise<void>((resolve, reject) => {
+    image.onload = () => resolve();
+    image.onerror = () => reject(new Error("Could not load the QR image"));
+    image.src = dataUri;
+  });
+
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Could not get a 2D canvas context");
+  }
+  context.drawImage(image, 0, 0, size, size);
+
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error("Could not encode the QR code as PNG"));
+      }
+    }, "image/png");
+  });
+}
+
+/** Save a blob under `filename` via a throwaway object URL. */
+function triggerDownload(blob: Blob, filename: string): void {
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  // Revoke on the next tick — Safari needs the object URL to outlive the click.
+  window.setTimeout(() => URL.revokeObjectURL(href), 0);
+}
+
+/**
+ * Owns everything stateful about a share QR so `<ShareQrCode />` stays
+ * presentational — the same component/hook split as
+ * app/components/editorSidebar/wtm/{WatermarkEditor.tsx,useWatermarkSettings.ts}.
+ *
+ * `renderQrSvg` is synchronous and quick, but each call builds a full matrix and
+ * embeds the ~8 kB mark data URI, so the on-screen render is cached per size for
+ * the life of a url. A share modal re-renders on every keystroke and toggle
+ * around it; the QR should not be rebuilt for any of them.
+ */
+export function useShareQr({ url, title }: UseShareQrOptions): ShareQr {
+  const [busy, setBusy] = React.useState(false);
+  // Detected in an effect rather than during render: `ClipboardItem` is absent on
+  // the server, and branching on it inline would desync hydration.
+  const [canCopyImage, setCanCopyImage] = React.useState(false);
+
+  React.useEffect(() => {
+    setCanCopyImage(
+      typeof ClipboardItem !== "undefined" && typeof navigator.clipboard?.write === "function"
+    );
+  }, []);
+
+  // Keyed by url so switching demos can never serve a stale matrix, and bounded
+  // to the entries of QR_SIZE_PRESETS.
+  const cacheRef = React.useRef<{ url: string; bySize: Map<number, string> }>({
+    url,
+    bySize: new Map(),
+  });
+
+  const renderAt = React.useCallback(
+    (size: number): string => {
+      if (cacheRef.current.url !== url) {
+        cacheRef.current = { url, bySize: new Map() };
+      }
+      const cached = cacheRef.current.bySize.get(size);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const svg = renderQrSvg({ url, size });
+      cacheRef.current.bySize.set(size, svg);
+      return svg;
+    },
+    [url]
+  );
+
+  const svg = React.useMemo(() => renderAt(QR_SIZE_PRESETS.screen), [renderAt]);
+
+  const filenameBase = React.useMemo(() => `marvedge-qr-${slugify(title)}`, [title]);
+
+  const rasterize = React.useCallback(
+    (size: number) => svgToPngBlob(renderQrSvgDataUri({ url, size }), size),
+    [url]
+  );
+
+  /** Flip `busy` around a handler, so every button can disable itself uniformly. */
+  const run = React.useCallback(async <T>(task: () => Promise<T>): Promise<T> => {
+    setBusy(true);
+    try {
+      return await task();
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const savePng = React.useCallback(
+    async (preset: ShareQrDownloadPreset) => {
+      const size = QR_SIZE_PRESETS[preset];
+      triggerDownload(await rasterize(size), `${filenameBase}-${size}.png`);
+    },
+    [rasterize, filenameBase]
+  );
+
+  const downloadPng = React.useCallback(
+    (preset: ShareQrDownloadPreset) => run(() => savePng(preset)),
+    [run, savePng]
+  );
+
+  const downloadSvg = React.useCallback(
+    () =>
+      run(async () => {
+        // Vector apart from the mark, which is a 512px PNG occupying ~22% of the
+        // code — so it is 1:1 or better up to ~2300px, and the modules themselves
+        // stay crisp at any size. `print` is only the nominal width/height a
+        // consumer sees before it scales the thing.
+        const blob = new Blob([renderAt(QR_SIZE_PRESETS.print)], {
+          type: "image/svg+xml;charset=utf-8",
+        });
+        triggerDownload(blob, `${filenameBase}.svg`);
+      }),
+    [run, renderAt, filenameBase]
+  );
+
+  const copyImage = React.useCallback(
+    (): Promise<ShareQrCopyOutcome> =>
+      run(async () => {
+        if (!canCopyImage) {
+          await savePng("download");
+          return "downloaded";
+        }
+        try {
+          // The blob is handed over as a promise on purpose: Safari only honours a
+          // ClipboardItem constructed synchronously inside the user gesture.
+          await navigator.clipboard.write([
+            new ClipboardItem({ "image/png": rasterize(QR_SIZE_PRESETS.download) }),
+          ]);
+          return "copied";
+        } catch {
+          // Firefox and Safari disagree on what write() accepts and when the
+          // permission is granted. A rejection here is a capability gap rather
+          // than a bug, so land the user on the file anyway.
+          await savePng("download");
+          return "downloaded";
+        }
+      }),
+    [run, canCopyImage, rasterize, savePng]
+  );
+
+  return { svg, busy, canCopyImage, downloadPng, downloadSvg, copyImage };
+}


### PR DESCRIPTION
Adds <ShareQrCode /> and its useShareQr hook, both built entirely on the PR 1 engine in app/lib/qr — no QR geometry is drawn here.

- ShareQrCode renders the engine's SVG inline. Safe by construction: the URL goes into the module matrix, never into the markup.
- useShareQr memoizes the render per (url, size) and owns the PNG/SVG download and clipboard handlers, mirroring the WatermarkEditor + useWatermarkSettings split.
- PNG export is data: URI -> <img> -> canvas -> toBlob, so the canvas is never tainted. 1024px and 2048px are offered.
- Copy uses ClipboardItem with a promised Blob (Safari's requirement) and falls back to the PNG download where the API is missing.
- ExportResultModal shows it expanded; ShareModal keeps it behind a "Show QR code" toggle. Both modals now scroll rather than clip on a short viewport.

One style only — the badge preset. No style prop, no style toggle.