### PR TITLE
feat(qr): server QR endpoint, hub surface, and scan attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,163 @@ WTM needs no new vendor or API key — it is pure ffmpeg on the existing GCS /
 Cloud Run worker. Both flags are enabled on staging/QA; leave them blank in
 production until the feature is signed off. See `.env.example` for the full list.
 
+## Shareable-Link QR Codes (QR)
+
+Every share link can also be a **branded QR code**: deep-purple rounded modules on
+white with the Marvedge mark at the centre, offered wherever a share URL already
+exists. It is purely derived — the QR renders a link that already exists, mints
+nothing, writes nothing, and never touches the export path. No DB migration, no
+new vendor, no new API key. The only dependency is `qrcode-generator`, a
+zero-dependency matrix library.
+
+### Where it shows up
+
+| Surface                                  | What appears                                                                                                                |
+| :--------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------- |
+| `app/components/ExportResultModal.tsx`   | The QR, shown as soon as a `shareUrl` exists — the "after the demo is generated" moment.                                    |
+| `app/components/ShareModal.tsx`          | The same QR, collapsed behind a "Show QR code" toggle so the modal does not balloon.                                        |
+| `app/hub/[domain]/share/[slug]/page.tsx` | A "scan to open" card on the customer hub share page, encoding **the customer's own domain**.                               |
+| `GET /api/qr?url=…&size=…`               | A cacheable `image/svg+xml` render, for the places a React component cannot reach (an `<img>` in an email, a slide, a PDF). |
+
+The demos list (`app/(signed)/demos/`) has **no share affordance at all** today,
+even though `app/api/demos/[id]/share/route.ts` exists and works. That gap is
+noted rather than filled here — a QR belongs next to a share button, and building
+the share flow is its own change.
+
+### `GET /api/qr`
+
+Returns SVG with `Cache-Control: public, max-age=31536000, immutable` — the output
+is a pure function of the query. Unauthenticated, because it renders a link that
+is already public, and `size` is the only knob besides `url`. There is
+deliberately **no `style` param**.
+
+The `url` must resolve to a Marvedge-owned share URL or the route answers `400`.
+Allowed: the `NEXT_PUBLIC_APP_URL` origin, the root domain plus `www` and any hub
+subdomain, the host the request itself arrived on (which is how a custom hub
+domain validates, without a DB lookup), and loopback off production. Everything
+else is refused, including look-alikes such as `marvedge.com.evil.example` and
+credential tricks such as `https://marvedge.com@evil.example/`. The path must also
+look like a share path, so the endpoint cannot brand `/auth/signin`.
+
+Two things about that check are easy to get wrong:
+
+- **`sanitizeQrOptions()` / `toQrTargetUrl()` are not a host check.** They validate
+  scheme, length and shape only, and deliberately not the host — the engine is
+  isomorphic and cannot know the request origin. The allowlist in
+  `app/lib/share/qrTarget.ts` layers on top of them. Rendering an arbitrary URL
+  inside a Marvedge-branded QR is a phishing primitive; there is no "allow any
+  URL" escape hatch and adding one re-opens it.
+- **The route never queries the database.** A public unauthenticated endpoint that
+  404s on unknown slugs is an oracle for which share ids exist, so validation is
+  by URL shape only.
+
+**Custom domains.** `app/api/demos/[id]/share/route.ts` builds share URLs as
+`NEXT_PUBLIC_APP_URL || request.nextUrl.origin`, which is right for a creator
+copying a link on marvedge.com. It is wrong on a customer hub: a visitor reading
+`https://demos.acme.com/share/abc` is served by `/hub/acme/share/abc` through the
+`middleware.ts` rewrite, and a QR encoding `marvedge.com/share/abc` would walk them
+off the customer's white-labeled domain mid-scan. Hub pages therefore resolve the
+origin from the **request host** and ignore `NEXT_PUBLIC_APP_URL` — see
+`hubShareUrl()` in `app/lib/share/qrTarget.ts`, which carries the rule and its
+tests.
+
+### Scan attribution
+
+The URL _encoded in the QR_ carries `?src=qr`; the copy-to-clipboard link stays
+clean, so a pasted link is never miscounted as a scan. The decoration lives in one
+helper (`withQrSource()`), applied at the two places a QR is produced — the client
+renderer and `/api/qr` — and is read back by
+`app/share/[slug]/hooks/useViewTracking.ts`, which passes `source: "qr"` to
+`/api/views`.
+
+**That source is logged, not stored.** `model View` has no column for it and there
+is no events table, so persisting it would need a `prisma/schema.prisma` change and
+a migration, which this feature deliberately does not carry. Scan volume is
+visible in the server logs today (`[Views] QR scan: …`), and the client already
+sends the field — adding the column later is a one-line change in
+`app/api/views/route.ts`, with history from that day forward.
+
+### One style, on purpose
+
+`QrStyle` is `"badge" | "branded"` and **only `badge` is surfaced**. There is no
+style toggle, no style prop and no style query param, and adding one is a product
+decision rather than a UI improvement. `branded` (the mark drawn large and tinted
+behind the modules) stays in the engine and stays covered by `qr.test.ts`, but
+nothing offers it. The reason is _not_ scannability — both were phone-verified at
+200 px. Badge won on **mark legibility**: it draws the mark solid `#2D1F61`, while
+`branded`'s 22% tint reads as a smudge once the URL pushes the code past ~40
+modules. The point of the feature is that every scan carries the mark.
+
+### Scannability is the acceptance criterion
+
+These invariants are enforced in `app/lib/qr/` and covered by its tests. They are
+not style preferences — break one and codes silently stop scanning for some
+fraction of cameras, which no visual review catches:
+
+| Rule                                             | Why                                                                                  |
+| :----------------------------------------------- | :----------------------------------------------------------------------------------- |
+| **ECC level `H`** (30% recovery), always         | Buys the error budget the logo knockout and rounded modules spend.                   |
+| **Quiet zone ≥ 4 modules**                       | Scanners fail without it far more often than for any styling reason.                 |
+| **Logo occlusion ≤ 25% linear** (≈6% of area)    | Well inside the `H` budget, with room left for print and camera noise.               |
+| **Finder patterns stay solid dark-on-light**     | Rounding their corners is safe; tinting, occluding, or backing them with art is not. |
+| **Timing patterns (row/col 6) never occluded**   | The knockout must stay centred and small enough never to reach them.                 |
+| **Contrast ≥ 4:1** between module and light cell | Checked in code (`assertQrContrast`), not by eyeballing.                             |
+
+If a change makes an assertion in `app/lib/qr/qr.test.ts` fail, the change is
+wrong — do not edit the test to match.
+
+### The brand mark asset
+
+`public/qr/marvedge-mark.png` is **generated, not hand-edited**. `scripts/qr/make-mark.mjs`
+derives it from the source logo at build time: it chroma-keys the flat periwinkle
+field out, recolours the mark to `#2D1F61`, trims and re-centres it, and writes
+both the PNG and `app/lib/qr/mark.ts`, which inlines the same bytes as a `data:`
+URI. The engine uses the constant, never the file path — a remote `src` would taint
+the canvas the client-side PNG export draws into and `toBlob()` would throw. To
+change the mark, edit the script and re-run it.
+
+> `dither: 0` in that script is load-bearing. sharp's PNG palette encoder dithers
+> by default, which scatters off-hue pixels through what should be one flat colour
+> and quietly breaks the "art and modules share one colour" invariant.
+
+### If a QR won't scan
+
+1. **Check the size it is rendered at.** Below roughly 4 px per module a camera
+   cannot resolve it. A long URL means a higher QR version, more modules, and a
+   larger minimum size — shorten the URL before shrinking the code.
+2. **Check the quiet zone survived.** A CSS `overflow: hidden`, a tight flex
+   container, or a crop that clips the white border is the single most common
+   cause. The engine emits it; a layout can still cut it off.
+3. **Check contrast end to end.** The engine guarantees ≥ 4:1 for the colours it is
+   given, but a parent with a coloured or textured background showing through a
+   transparent container defeats it. The QR needs an opaque light ground.
+4. **Check nothing was overlaid on it.** A badge, a caption, or a hover effect on
+   top of the finder or timing patterns breaks decoding even when it looks fine.
+5. **Check the target URL actually resolves.** A QR for an unshared or deleted demo
+   scans perfectly and then lands on a 404 — `/api/qr` validates URL _shape_, never
+   existence, by design.
+6. **Only then suspect the engine.** Run `npm test`; the QR suite rasterizes and
+   decodes real codes across versions.
+
+### Environment variables
+
+| Variable                       | Where                      | Purpose                                                                                                            |
+| :----------------------------- | :------------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SHARE_QR_ENABLED` | Next app (client + server) | Kill-switch for the whole QR surface. **Defaults to ON** when unset — only an explicit `false` or `0` disables it. |
+| `NEXT_PUBLIC_APP_URL`          | Next app                   | Already required. The QR endpoint's primary allowed origin.                                                        |
+| `NEXT_PUBLIC_ROOT_DOMAIN`      | Next app                   | Already used by `middleware.ts`. Also allows hub subdomains of it. Defaults to `marvedge.com`.                     |
+
+`NEXT_PUBLIC_SHARE_QR_ENABLED` deliberately defaults **on**, unlike the AVS and WTM
+flags above, which default off. Those change the artefact — with WTM on, a FREE
+export gets a watermark burned into the video — so "unset" has to mean "behave
+exactly as before". The QR surface is derived, read-only and additive, and leaves
+no state behind, so its flag is a kill-switch for pulling the surface during an
+incident rather than a rollout gate. With it off, `<ShareQrCode />` renders nothing
+and `/api/qr` returns 404. Note the value is inlined into the client bundle at
+build time: flipping it needs a rebuild for the client, only a restart for the
+server.
+
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/api/qr/route.ts
+++ b/app/api/qr/route.ts
@@ -1,0 +1,84 @@
+// GET /api/qr?url=...&size=... -> image/svg+xml
+//
+// A cacheable server-rendered QR for a share link, for the places a React
+// component cannot reach: an <img> in an email, a slide, a PDF, an OG image.
+//
+// Unauthenticated on purpose — it renders a link that is already public, and
+// requiring a session would make it useless in exactly those contexts. That is
+// also why it must never touch the database: an authenticated-feeling 404 for an
+// unknown slug would turn this into an oracle for which share ids exist. The URL
+// is validated by SHAPE and ORIGIN only.
+//
+// There is deliberately no `style` param. `badge` is the one style the product
+// surfaces (see MARVEDGE_QR_PRESET in app/lib/qr/presets.ts), and a public
+// endpoint should not carry a knob for a style no UI offers.
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { isShareQrEnabled, renderQrSvg, sanitizeQrOptions } from "@/app/lib/qr";
+import { toMarvedgeShareUrl, withQrSource } from "@/app/lib/share/qrTarget";
+
+/**
+ * The response is a pure function of the query string, so it can be cached
+ * forever. A different QR is a different `url`, which is a different cache key.
+ */
+const IMMUTABLE = "public, max-age=31536000, immutable";
+
+/** One message for every rejection — see toMarvedgeShareUrl on why. */
+const REJECTED = "url must be a Marvedge share link";
+
+function badRequest(message: string) {
+  return NextResponse.json(
+    { error: message },
+    // Never cached: whether a URL is allowed depends on the request host, and a
+    // cached 400 would outlive a hub domain being configured.
+    { status: 400, headers: { "Cache-Control": "no-store" } }
+  );
+}
+
+export async function GET(request: NextRequest) {
+  // The kill-switch pulls the whole surface, so this reads as "no such endpoint"
+  // rather than "bad input".
+  if (!isShareQrEnabled()) {
+    return NextResponse.json(
+      { error: "Not found" },
+      { status: 404, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+
+  const params = request.nextUrl.searchParams;
+
+  // Origin allowlist. sanitizeQrOptions() below checks scheme and shape but
+  // deliberately not the host — that check is this route's, and it goes first.
+  const target = toMarvedgeShareUrl(params.get("url"), {
+    requestHost: request.headers.get("host"),
+  });
+  if (!target) {
+    return badRequest(REJECTED);
+  }
+
+  // `size` is untrusted, so it goes through the engine's sanitizer, which clamps
+  // it to the scannable range and drops NaN. Everything else comes from the
+  // preset — no colours, no quiet zone, no logo are accepted off the wire.
+  const options = sanitizeQrOptions({ url: withQrSource(target), size: params.get("size") });
+  if (!options) {
+    return badRequest(REJECTED);
+  }
+
+  return new NextResponse(renderQrSvg(options), {
+    status: 200,
+    headers: {
+      "Content-Type": "image/svg+xml; charset=utf-8",
+      "Cache-Control": IMMUTABLE,
+      // The host takes part in the allowlist decision, so it takes part in the
+      // cache key. The bytes are identical across hosts; this stops a cached
+      // response from being replayed as evidence that some other host allowed it.
+      Vary: "Host",
+      // Inert by construction — the engine emits shapes and one data: <image>,
+      // never a <script> or a remote href. Stated in a header so it stays that
+      // way if someone navigates to this URL directly.
+      "Content-Security-Policy": "default-src 'none'; img-src data:; style-src 'unsafe-inline'",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -1,9 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/app/lib/prisma";
+import { QR_SOURCE_VALUE } from "@/app/lib/share/qrTarget";
+
+/**
+ * Attribution for a view, currently only "qr" — set when the visitor arrived by
+ * scanning a share QR, which encodes the share URL with `?src=qr`.
+ *
+ * NOT PERSISTED, and that is a deliberate stopping point rather than an
+ * oversight. `model View` has no column this could go in (id, demoId,
+ * exportedVideoId, timestamp, duration) and there is no events table, so storing
+ * it would mean a prisma/schema.prisma change and a migration — out of scope for
+ * the QR work, which is otherwise purely additive. It is logged instead, so scan
+ * volume is observable in the server logs today, and the client already sends it:
+ * whoever adds the column writes one line here and gets history from that day on.
+ */
+function readViewSource(raw: unknown): typeof QR_SOURCE_VALUE | undefined {
+  return raw === QR_SOURCE_VALUE ? QR_SOURCE_VALUE : undefined;
+}
 
 export async function POST(req: NextRequest) {
   try {
-    const { demoId, exportedVideoId, duration, viewId } = await req.json();
+    const { demoId, exportedVideoId, duration, viewId, source } = await req.json();
 
     if (viewId && duration !== undefined) {
       // Update existing view with new duration
@@ -35,6 +52,14 @@ export async function POST(req: NextRequest) {
         duration: 0,
       },
     });
+
+    // Only ever the literal "qr" or nothing — never the caller's string, which
+    // would put arbitrary input into a log line.
+    if (readViewSource(source)) {
+      console.log(
+        `[Views] QR scan: view=${view.id} demo=${demoId || "-"} video=${exportedVideoId || "-"}`
+      );
+    }
 
     const response = NextResponse.json({ success: true, viewId: view.id });
     // Set a cookie that expires in 1 hour

--- a/app/components/qr/useShareQr.ts
+++ b/app/components/qr/useShareQr.ts
@@ -3,6 +3,7 @@
 import React from "react";
 
 import { QR_SIZE_PRESETS, renderQrSvg, renderQrSvgDataUri, type QrSizePreset } from "@/app/lib/qr";
+import { withQrSource } from "@/app/lib/share/qrTarget";
 
 /** The two sizes the download menu offers. `screen` is what the card displays. */
 export type ShareQrDownloadPreset = Extract<QrSizePreset, "download" | "print">;
@@ -108,6 +109,10 @@ function triggerDownload(blob: Blob, filename: string): void {
  * around it; the QR should not be rebuilt for any of them.
  */
 export function useShareQr({ url, title }: UseShareQrOptions): ShareQr {
+  // The only place the client-side QR picks up its scan tag. Callers keep passing
+  // the clean share URL — the one behind copy-to-clipboard — and only the encoded
+  // copy carries `?src=qr`, so a pasted link is never counted as a scan.
+  const encodedUrl = React.useMemo(() => withQrSource(url), [url]);
   const [busy, setBusy] = React.useState(false);
   // Detected in an effect rather than during render: `ClipboardItem` is absent on
   // the server, and branching on it inline would desync hydration.
@@ -122,24 +127,24 @@ export function useShareQr({ url, title }: UseShareQrOptions): ShareQr {
   // Keyed by url so switching demos can never serve a stale matrix, and bounded
   // to the entries of QR_SIZE_PRESETS.
   const cacheRef = React.useRef<{ url: string; bySize: Map<number, string> }>({
-    url,
+    url: encodedUrl,
     bySize: new Map(),
   });
 
   const renderAt = React.useCallback(
     (size: number): string => {
-      if (cacheRef.current.url !== url) {
-        cacheRef.current = { url, bySize: new Map() };
+      if (cacheRef.current.url !== encodedUrl) {
+        cacheRef.current = { url: encodedUrl, bySize: new Map() };
       }
       const cached = cacheRef.current.bySize.get(size);
       if (cached !== undefined) {
         return cached;
       }
-      const svg = renderQrSvg({ url, size });
+      const svg = renderQrSvg({ url: encodedUrl, size });
       cacheRef.current.bySize.set(size, svg);
       return svg;
     },
-    [url]
+    [encodedUrl]
   );
 
   const svg = React.useMemo(() => renderAt(QR_SIZE_PRESETS.screen), [renderAt]);
@@ -147,8 +152,8 @@ export function useShareQr({ url, title }: UseShareQrOptions): ShareQr {
   const filenameBase = React.useMemo(() => `marvedge-qr-${slugify(title)}`, [title]);
 
   const rasterize = React.useCallback(
-    (size: number) => svgToPngBlob(renderQrSvgDataUri({ url, size }), size),
-    [url]
+    (size: number) => svgToPngBlob(renderQrSvgDataUri({ url: encodedUrl, size }), size),
+    [encodedUrl]
   );
 
   /** Flip `busy` around a handler, so every button can disable itself uniformly. */

--- a/app/hub/[domain]/share/[slug]/page.tsx
+++ b/app/hub/[domain]/share/[slug]/page.tsx
@@ -1,5 +1,7 @@
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { prisma } from "@/app/lib/prisma";
+import { hubShareUrl } from "@/app/lib/share/qrTarget";
 import ShareVideoPageClient from "@/app/share/[slug]/ShareVideoPageClient";
 
 type PageProps = {
@@ -135,6 +137,14 @@ export default async function BrandedSharePage({ params }: PageProps) {
 
   const fallbackColor = settings?.accentColor || "#F3F0FC";
 
+  // The QR has to carry the CUSTOMER's domain. This page is only ever reached
+  // through the middleware.ts rewrite of https://<their-domain>/share/<slug>, so
+  // the request host is that domain and NEXT_PUBLIC_APP_URL — which the share API
+  // routes use, correctly, for creator-facing links minted on marvedge.com —
+  // would be the wrong origin here. `slug` is echoed back rather than
+  // demo.publicLink so the QR resolves to the same URL the visitor is reading.
+  const shareQrUrl = hubShareUrl((await headers()).get("host"), slug);
+
   return (
     <ShareVideoPageClient
       title={demo.title}
@@ -148,6 +158,7 @@ export default async function BrandedSharePage({ params }: PageProps) {
       }
       demoId={demo.id}
       ctas={demo.ctas}
+      shareQrUrl={shareQrUrl}
     />
   );
 }

--- a/app/lib/share/qrTarget.test.ts
+++ b/app/lib/share/qrTarget.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_ROOT_DOMAIN,
+  QR_SOURCE_PARAM,
+  QR_SOURCE_VALUE,
+  hubShareUrl,
+  qrViewSource,
+  toMarvedgeShareUrl,
+  withQrSource,
+} from "./qrTarget";
+
+// The allowlist reads env at call time, so each test sets the deployment it means
+// rather than inheriting whatever the runner happened to have.
+const ENV_KEYS = ["NEXT_PUBLIC_APP_URL", "NEXT_PUBLIC_ROOT_DOMAIN", "NODE_ENV"] as const;
+const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+/** Assign through the index signature — NODE_ENV is a readonly literal in TS. */
+function setEnv(key: (typeof ENV_KEYS)[number], value: string | undefined): void {
+  if (value === undefined) {
+    delete (process.env as Record<string, string | undefined>)[key];
+  } else {
+    (process.env as Record<string, string | undefined>)[key] = value;
+  }
+}
+
+/** The shape of production: real app URL, real root domain, NODE_ENV=production. */
+function asProduction(): void {
+  setEnv("NEXT_PUBLIC_APP_URL", `https://${DEFAULT_ROOT_DOMAIN}`);
+  setEnv("NEXT_PUBLIC_ROOT_DOMAIN", DEFAULT_ROOT_DOMAIN);
+  setEnv("NODE_ENV", "production");
+}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    setEnv(key, saved[key]);
+  }
+});
+
+describe("toMarvedgeShareUrl — origin allowlist", () => {
+  beforeEach(asProduction);
+
+  it("accepts a share URL on the configured app origin", () => {
+    expect(toMarvedgeShareUrl(`https://${DEFAULT_ROOT_DOMAIN}/share/abc123`)).toBe(
+      `https://${DEFAULT_ROOT_DOMAIN}/share/abc123`
+    );
+  });
+
+  it("accepts the exported-video share path and www", () => {
+    expect(toMarvedgeShareUrl(`https://${DEFAULT_ROOT_DOMAIN}/share/video/vid_1`)).toBeDefined();
+    expect(toMarvedgeShareUrl(`https://www.${DEFAULT_ROOT_DOMAIN}/share/abc`)).toBeDefined();
+  });
+
+  it("accepts a hub subdomain of the root domain", () => {
+    expect(toMarvedgeShareUrl(`https://acme.${DEFAULT_ROOT_DOMAIN}/share/abc`)).toBeDefined();
+  });
+
+  it("accepts a custom hub domain only when it is the requesting host", () => {
+    const url = "https://demos.acme.com/share/abc";
+    expect(toMarvedgeShareUrl(url, { requestHost: "demos.acme.com" })).toBeDefined();
+    // The same URL requested from marvedge.com — which is what a victim's browser
+    // would send for an embedded https://marvedge.com/api/qr?url=... — is refused.
+    expect(toMarvedgeShareUrl(url, { requestHost: DEFAULT_ROOT_DOMAIN })).toBeUndefined();
+    expect(toMarvedgeShareUrl(url)).toBeUndefined();
+  });
+
+  it("rejects an off-origin https URL", () => {
+    expect(toMarvedgeShareUrl("https://evil.example/share/abc")).toBeUndefined();
+  });
+
+  it("rejects look-alike hosts rather than substring-matching the root domain", () => {
+    for (const host of [
+      `${DEFAULT_ROOT_DOMAIN}.evil.example`,
+      `evil-${DEFAULT_ROOT_DOMAIN}`,
+      `${DEFAULT_ROOT_DOMAIN}evil.com`,
+      `not${DEFAULT_ROOT_DOMAIN}`,
+    ]) {
+      expect(toMarvedgeShareUrl(`https://${host}/share/abc`), host).toBeUndefined();
+    }
+  });
+
+  it("rejects a URL whose credentials dress it up as ours", () => {
+    expect(
+      toMarvedgeShareUrl(`https://${DEFAULT_ROOT_DOMAIN}@evil.example/share/abc`)
+    ).toBeUndefined();
+    expect(toMarvedgeShareUrl(`https://user:pw@${DEFAULT_ROOT_DOMAIN}/share/abc`)).toBeUndefined();
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    for (const url of [
+      "javascript:alert(1)",
+      `javascript:fetch("https://${DEFAULT_ROOT_DOMAIN}/share/a")`,
+      "data:text/html,<script>alert(1)</script>",
+      "file:///etc/passwd",
+    ]) {
+      expect(toMarvedgeShareUrl(url), url).toBeUndefined();
+    }
+  });
+
+  it("rejects junk and non-strings", () => {
+    for (const value of ["", "   ", "not a url", null, undefined, 42, {}, []]) {
+      expect(toMarvedgeShareUrl(value), JSON.stringify(value)).toBeUndefined();
+    }
+  });
+
+  it("rejects localhost on a production deployment", () => {
+    expect(toMarvedgeShareUrl("http://localhost:3000/share/abc")).toBeUndefined();
+  });
+
+  it("accepts localhost off production, so dev works without extra config", () => {
+    setEnv("NODE_ENV", "development");
+    expect(toMarvedgeShareUrl("http://localhost:3000/share/abc")).toBeDefined();
+    expect(toMarvedgeShareUrl("http://127.0.0.1:3000/share/abc")).toBeDefined();
+  });
+});
+
+describe("toMarvedgeShareUrl — path shape", () => {
+  beforeEach(asProduction);
+
+  it("accepts the three share paths the product serves", () => {
+    for (const path of ["/share/abc", "/share/video/v1", "/hub/acme/share/abc", "/share/abc/"]) {
+      expect(toMarvedgeShareUrl(`https://${DEFAULT_ROOT_DOMAIN}${path}`), path).toBeDefined();
+    }
+  });
+
+  it("refuses to brand a non-share page on an origin we own", () => {
+    // The origin passes; the path does not. Without this, /api/qr would mint a
+    // Marvedge-branded QR for the login page or a password reset link.
+    for (const path of ["/", "/dashboard", "/auth/signin", "/settings/billing", "/share"]) {
+      expect(toMarvedgeShareUrl(`https://${DEFAULT_ROOT_DOMAIN}${path}`), path).toBeUndefined();
+    }
+  });
+});
+
+describe("withQrSource", () => {
+  it("tags the URL as the QR copy", () => {
+    expect(withQrSource("https://marvedge.com/share/abc")).toBe(
+      `https://marvedge.com/share/abc?${QR_SOURCE_PARAM}=${QR_SOURCE_VALUE}`
+    );
+  });
+
+  it("is idempotent, so a double pass cannot produce src=qr&src=qr", () => {
+    const once = withQrSource("https://marvedge.com/share/abc");
+    expect(withQrSource(once)).toBe(once);
+  });
+
+  it("preserves existing query params and the fragment", () => {
+    const tagged = withQrSource("https://marvedge.com/share/abc?utm_source=email#top");
+    expect(tagged).toContain("utm_source=email");
+    expect(tagged).toContain(`${QR_SOURCE_PARAM}=${QR_SOURCE_VALUE}`);
+    expect(tagged.endsWith("#top")).toBe(true);
+  });
+
+  it("returns an unparseable input untouched rather than guessing", () => {
+    expect(withQrSource("not a url")).toBe("not a url");
+  });
+});
+
+describe("qrViewSource", () => {
+  it("reads the tag a scan arrives with", () => {
+    expect(qrViewSource("?src=qr")).toBe(QR_SOURCE_VALUE);
+    expect(qrViewSource("?utm_source=email&src=qr")).toBe(QR_SOURCE_VALUE);
+  });
+
+  it("is undefined for a plain link click", () => {
+    for (const search of ["", "?", "?utm_source=email", null, undefined]) {
+      expect(qrViewSource(search), String(search)).toBeUndefined();
+    }
+  });
+
+  it("never echoes an arbitrary value back to the caller", () => {
+    // Whatever src says, the only thing that leaves here is "qr" or nothing —
+    // this value ends up in a log line.
+    expect(qrViewSource("?src=qr%0aINJECTED")).toBeUndefined();
+    expect(qrViewSource("?src=email")).toBeUndefined();
+  });
+});
+
+describe("hubShareUrl", () => {
+  it("encodes the customer's own domain, not marvedge.com", () => {
+    setEnv("NEXT_PUBLIC_APP_URL", `https://${DEFAULT_ROOT_DOMAIN}`);
+    expect(hubShareUrl("demos.acme.com", "abc")).toBe("https://demos.acme.com/share/abc");
+  });
+
+  it("keeps the port and drops to http for a local hub", () => {
+    expect(hubShareUrl("acme.localhost:3000", "abc")).toBe("http://acme.localhost:3000/share/abc");
+  });
+
+  it("produces a URL the QR endpoint will accept from that same host", () => {
+    asProduction();
+    const url = hubShareUrl("demos.acme.com", "abc");
+    expect(toMarvedgeShareUrl(url, { requestHost: "demos.acme.com" })).toBe(url);
+  });
+
+  it("is undefined when there is no usable host or slug", () => {
+    expect(hubShareUrl(null, "abc")).toBeUndefined();
+    expect(hubShareUrl("", "abc")).toBeUndefined();
+    expect(hubShareUrl("demos.acme.com", "")).toBeUndefined();
+  });
+});

--- a/app/lib/share/qrTarget.ts
+++ b/app/lib/share/qrTarget.ts
@@ -1,0 +1,258 @@
+// Where a share QR's target URL comes from, and what is allowed to be one.
+//
+// Three jobs live here that app/lib/qr/ deliberately does NOT do:
+//
+//  1. The `?src=qr` decoration. The engine encodes whatever URL it is handed and
+//     has no opinion about query params, so the decoration belongs to the caller.
+//     It lives in ONE helper rather than a string concat at each surface, because
+//     the moment two call sites spell it differently the analytics quietly split.
+//  2. The origin allowlist. `toQrTargetUrl()` in app/lib/qr/sanitize.ts validates
+//     the SCHEME AND SHAPE ONLY and deliberately not the host — the engine is
+//     isomorphic and cannot know the request origin. Deciding a host is ours is
+//     this module's job, and calling sanitizeQrOptions() alone is NOT a host check.
+//  3. Resolving a hub page's own origin, so a QR on a customer's white-labeled
+//     domain encodes that domain rather than marvedge.com.
+//
+// This file reads `process.env` and a request host, which is exactly why it is
+// not in app/lib/qr/ — that directory stays isomorphic and env-free so one code
+// path serves a client component and a route handler alike.
+
+// Relative, like app/lib/qr/qr.test.ts's own imports: there is no vitest config
+// resolving the "@/" alias, and this module is unit-tested.
+import { toQrTargetUrl } from "../qr";
+
+/** The query param scans are tagged with, and the only value we ever write. */
+export const QR_SOURCE_PARAM = "src";
+export const QR_SOURCE_VALUE = "qr";
+
+/** Fallback when NEXT_PUBLIC_ROOT_DOMAIN is unset. Matches middleware.ts. */
+export const DEFAULT_ROOT_DOMAIN = "marvedge.com";
+
+/**
+ * Share paths the product actually serves, and the only paths a QR may encode:
+ *   /share/<slug>              · the public demo page
+ *   /share/video/<id>          · the exported-video page
+ *   /hub/<domain>/share/<slug> · the same demo page under a customer hub
+ *
+ * This is a SHAPE check on purpose. Looking the slug up in the database would
+ * turn a public, cacheable, unauthenticated endpoint into an oracle for "does
+ * this share id exist" — so the route never touches the DB, and a QR for a
+ * nonexistent slug simply renders and then 404s when scanned, exactly as pasting
+ * the same link into a browser would.
+ *
+ * It also narrows the blast radius of the origin allowlist: even on a host we
+ * own, /api/qr cannot brand an arbitrary page — only a share link.
+ */
+const SHARE_PATHNAME = /^\/(?:hub\/[^/]+\/)?share\/(?:video\/)?[^/]+\/?$/;
+
+/** Lowercased root domain with any port stripped. */
+function rootDomain(): string {
+  return hostnameOf(process.env.NEXT_PUBLIC_ROOT_DOMAIN) ?? DEFAULT_ROOT_DOMAIN;
+}
+
+/** The configured app origin, or undefined when NEXT_PUBLIC_APP_URL is unusable. */
+function appOrigin(): string | undefined {
+  const raw = process.env.NEXT_PUBLIC_APP_URL;
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The bare hostname of a `Host` header or a bare domain — port stripped, IPv6
+ * brackets preserved, lowercased. Parsing rather than splitting on ":" so
+ * `[::1]:3000` does not become `[`.
+ */
+function hostnameOf(host: string | null | undefined): string | undefined {
+  const trimmed = host?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    return new URL(`https://${trimmed}`).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Loopback in any of the spellings a dev machine produces. */
+function isLocalHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname.endsWith(".localhost")
+  );
+}
+
+/**
+ * Whether `target` sits on an origin Marvedge owns.
+ *
+ * Every arm matches on a full hostname — exact equality, or a dot-anchored
+ * suffix. Never `includes()` and never a bare `endsWith(root)`, both of which
+ * would wave through the classic look-alike `marvedge.com.evil.example`.
+ */
+function isAllowedShareOrigin(target: URL, requestHost: string | null | undefined): boolean {
+  const hostname = target.hostname.toLowerCase();
+
+  // Dev only. Gated on NODE_ENV so a production deployment cannot be talked into
+  // branding a QR for someone's local server.
+  if (process.env.NODE_ENV !== "production" && isLocalHostname(hostname)) {
+    return true;
+  }
+
+  // The configured app origin, compared as an origin so an http:// target does
+  // not pass on the strength of an https:// config.
+  const configured = appOrigin();
+  if (configured && target.origin === configured) {
+    return true;
+  }
+
+  // The apex, www, and any hub subdomain of the root domain (acme.marvedge.com).
+  const root = rootDomain();
+  if (hostname === root || hostname === `www.${root}` || hostname.endsWith(`.${root}`)) {
+    return true;
+  }
+
+  // A customer hub on its own custom domain. There is no DB lookup here and it is
+  // not an "allow any host" escape hatch: the target must equal the host THIS
+  // request arrived on, and a host only reaches this deployment because it was
+  // configured as a hub domain and pointed at us.
+  //
+  // The attack this closes is an official-looking embeddable URL — someone
+  // passing off https://marvedge.com/api/qr?url=<evil> as a Marvedge QR. A
+  // victim's browser loading that sends `Host: marvedge.com`, so the arm below
+  // cannot fire for it. Spoofing the header only works against yourself, and
+  // anyone willing to do that could run a QR library locally instead.
+  const own = hostnameOf(requestHost);
+  if (own && hostname === own) {
+    return true;
+  }
+
+  return false;
+}
+
+export interface MarvedgeShareUrlOptions {
+  /** The request's `Host` header, so a custom hub domain validates as its own. */
+  requestHost?: string | null;
+}
+
+/**
+ * Normalize `raw` into a Marvedge-owned share URL, or undefined if it is not one.
+ *
+ * Layered on top of the engine's shape check, never instead of it: a QR is an
+ * instruction a stranger's phone follows, and rendering an arbitrary URL inside a
+ * Marvedge-branded code is a phishing primitive. There is deliberately no
+ * "allow any URL" option — adding one re-opens exactly that.
+ *
+ * Returns one undefined for every kind of rejection. The caller answers 400
+ * without saying which arm failed, so the endpoint stays uninformative to probing.
+ */
+export function toMarvedgeShareUrl(
+  raw: unknown,
+  { requestHost }: MarvedgeShareUrlOptions = {}
+): string | undefined {
+  // Scheme, length and general shape first — this is what rejects `javascript:`,
+  // `data:` and junk. It does NOT check the host; the rest of this function does.
+  const normalized = toQrTargetUrl(raw);
+  if (!normalized) {
+    return undefined;
+  }
+
+  let target: URL;
+  try {
+    target = new URL(normalized);
+  } catch {
+    return undefined;
+  }
+
+  // https://marvedge.com@evil.example/ — the host is evil.example and the checks
+  // below already resolve it correctly, but a share link never legitimately
+  // carries credentials, so refuse to put one in a QR at all.
+  if (target.username || target.password) {
+    return undefined;
+  }
+
+  if (!isAllowedShareOrigin(target, requestHost)) {
+    return undefined;
+  }
+
+  if (!SHARE_PATHNAME.test(target.pathname)) {
+    return undefined;
+  }
+
+  return target.toString();
+}
+
+/**
+ * Tag a share URL as the QR copy of itself.
+ *
+ * Applied only to the URL that gets ENCODED — the link behind copy-to-clipboard
+ * stays clean, so a pasted link is never miscounted as a scan. Idempotent
+ * (`set`, not `append`) because both the client renderer and /api/qr call it and
+ * a URL can legitimately reach one of them already tagged.
+ *
+ * A URL this cannot parse is returned untouched rather than guessed at; the
+ * engine rejects it a moment later.
+ */
+export function withQrSource(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.set(QR_SOURCE_PARAM, QR_SOURCE_VALUE);
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Read the attribution back off a location, for the view-tracking payload.
+ *
+ * Returns the literal "qr" or undefined — never the raw param. The value reaches
+ * a server log, and echoing an arbitrary query string into one is how log
+ * injection starts.
+ */
+export function qrViewSource(
+  search: string | null | undefined
+): typeof QR_SOURCE_VALUE | undefined {
+  if (!search) {
+    return undefined;
+  }
+  const value = new URLSearchParams(search).get(QR_SOURCE_PARAM);
+  return value === QR_SOURCE_VALUE ? QR_SOURCE_VALUE : undefined;
+}
+
+/**
+ * The absolute share URL to encode on a hub page, resolved from the request host.
+ *
+ * THE RESOLUTION RULE, and why it differs from the share API routes:
+ * app/api/demos/[id]/share/route.ts builds `NEXT_PUBLIC_APP_URL || origin`, which
+ * is right for the creator-facing modal — that link is minted on marvedge.com by
+ * a signed-in owner. It is WRONG on a customer hub. A visitor reading
+ * https://demos.acme.com/share/abc is served by /hub/acme/share/abc through the
+ * middleware.ts rewrite, and a QR encoding marvedge.com/share/abc would walk them
+ * off the customer's white-labeled domain onto ours mid-scan.
+ *
+ * So hub pages resolve the origin from the REQUEST HOST and ignore
+ * NEXT_PUBLIC_APP_URL entirely. The path is the pre-rewrite public one
+ * (/share/<slug>), not the internal /hub/<domain>/... the rewrite produces.
+ *
+ * Returns undefined when there is no usable host, which reads as "no QR here"
+ * rather than a QR pointing somewhere wrong.
+ */
+export function hubShareUrl(host: string | null | undefined, slug: string): string | undefined {
+  const hostname = hostnameOf(host);
+  if (!hostname || !slug) {
+    return undefined;
+  }
+  // Keep the port: a dev hub runs on acme.localhost:3000 and dropping it yields a
+  // URL that does not resolve. Only loopback is served over http.
+  const authority = host!.trim().toLowerCase();
+  const protocol = isLocalHostname(hostname) ? "http" : "https";
+  return `${protocol}://${authority}/share/${encodeURIComponent(slug)}`;
+}

--- a/app/share/[slug]/ShareVideoPageClient.tsx
+++ b/app/share/[slug]/ShareVideoPageClient.tsx
@@ -3,6 +3,8 @@
 import { useSession } from "next-auth/react";
 import type { CSSProperties } from "react";
 
+import ShareQrCode from "@/app/components/qr/ShareQrCode";
+
 import { useViewTracking } from "./hooks/useViewTracking";
 import { getPreviewStage } from "./utils/previewStage";
 import ShareHeader from "./components/ShareHeader";
@@ -18,6 +20,18 @@ type ShareVideoPageClientProps = {
   demoId?: string;
   videoId?: string;
   ctas?: ShareCta[];
+  /**
+   * Absolute URL for this page's own "scan to keep watching" QR, or omitted for
+   * no QR. Passed in rather than derived from `window.location` so the caller
+   * decides the origin — which is the whole point on a customer hub, where the
+   * QR must carry the customer's domain (see hubShareUrl in
+   * app/lib/share/qrTarget.ts).
+   *
+   * Only the hub page passes it today. Whether the marvedge.com share page should
+   * show one too is still open (QR-Implementation-Plan.md §5 Q3) — it is this one
+   * prop away, deliberately not decided here.
+   */
+  shareQrUrl?: string;
 };
 
 export default function ShareVideoPageClient({
@@ -29,6 +43,7 @@ export default function ShareVideoPageClient({
   demoId,
   videoId,
   ctas = [],
+  shareQrUrl,
 }: ShareVideoPageClientProps) {
   const videoRef = useViewTracking(demoId, videoId);
 
@@ -83,6 +98,19 @@ export default function ShareVideoPageClient({
         </div>
 
         <ShareCtaButtons ctas={ctas} demoId={demoId} />
+
+        {/* "Take this with you" — the visitor is on a desktop, the QR moves the
+            demo to their phone. ShareQrCode returns null when the kill-switch is
+            off, so no empty card is left behind. */}
+        {shareQrUrl && (
+          <div className="mx-auto mt-8 w-full max-w-md">
+            <ShareQrCode
+              url={shareQrUrl}
+              title={title}
+              className="rounded-2xl border-[#BEB0F8]/60 shadow-[0_16px_40px_rgba(76,57,162,0.18)]"
+            />
+          </div>
+        )}
 
         {!isLoggedIn && <ShareSignupCTA />}
       </section>

--- a/app/share/[slug]/hooks/useViewTracking.ts
+++ b/app/share/[slug]/hooks/useViewTracking.ts
@@ -1,16 +1,24 @@
 import { useEffect, useRef, useState } from "react";
 
+import { qrViewSource } from "@/app/lib/share/qrTarget";
+
 export function useViewTracking(demoId?: string, videoId?: string) {
   const [viewId, setViewId] = useState<string | null>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const watchedDurationRef = useRef<number>(0);
 
   useEffect(() => {
+    // Where this view came from. A QR encodes the share URL with `?src=qr`, so a
+    // scan is distinguishable from a link click; anything else is left off the
+    // payload entirely rather than sent as "direct", which keeps the request
+    // byte-identical to what it was before QR existed.
+    const source = qrViewSource(window.location.search);
+
     // Record a view when the page loads
     fetch("/api/views", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ demoId, exportedVideoId: videoId }),
+      body: JSON.stringify({ demoId, exportedVideoId: videoId, ...(source ? { source } : {}) }),
     })
       .then((res) => res.json())
       .then((data) => {


### PR DESCRIPTION
Adds GET /api/qr?url=&size= returning image/svg+xml from the PR 1 engine, cached immutably since the output is a pure function of the query. No `style` param — badge is the only style the product surfaces.

The origin allowlist is the point of app/lib/share/qrTarget.ts. toQrTargetUrl() validates scheme and shape only and deliberately not the host, so the route layers a host check on top: the NEXT_PUBLIC_APP_URL origin, the root domain plus www and hub subdomains, the host the request arrived on (how a custom hub domain validates, with no DB lookup), and loopback off production. Look-alikes such as marvedge.com.evil.example, credential tricks, and non-http(s) schemes are refused, and the path must look like a share path so the endpoint cannot brand /auth/signin. The route never queries the DB — a public endpoint that 404s on unknown slugs would be an oracle for which share ids exist.

Scan attribution: withQrSource() tags the encoded URL with ?src=qr in one helper applied at both places a QR is produced, leaving the copy-to-clipboard link clean. useViewTracking reads it back and sends source: qr to /api/views. That source is LOGGED, NOT STORED: model View has no column for it and there is no events table, so persisting it would need a migration this feature does not carry. The client already sends the field.

Custom domains: hub share pages resolve the origin from the request host rather than NEXT_PUBLIC_APP_URL, so a QR on a customer's white-labeled domain encodes that domain instead of walking the visitor onto marvedge.com mid-scan.

The demos list has no share affordance wired to /api/demos/[id]/share at all, so there is nowhere to put a QR there yet; the gap is documented rather than filled with a new share flow.

Verified: 24 new unit tests over the allowlist, the ?src=qr helper and the hub origin rule; jsQR decodes the endpoint's output back to the tagged URL at 200, 512 and 1024px, including from a hub host; the three attack cases return 400; the kill-switch returns 404. lint, tsc --noEmit, 75 tests and build all clean.