### PR TITLE
fix(bdh): correctness, tenancy & production-safety fixes for BrandedDEMO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,3 +104,46 @@ NEXT_PUBLIC_WTM_ENABLED="true"
 # composited sources are written under.
 # WTM_COMPOSITE_FPS="30"
 # WTM_COMPOSITE_PREFIX="wtm-composite/"
+
+# ---------------------------------------------------------------------------
+# BDH — Branded Demo Hub & custom domain hosting
+# ---------------------------------------------------------------------------
+
+# Apex the app itself is served from. Requests to any other host are treated as
+# a customer hub, so this must match production exactly.
+NEXT_PUBLIC_ROOT_DOMAIN="marvedge.com"
+
+# Apex that customer hub subdomains hang off (`acme-cmn5tm26.<hub root>`).
+# Leave blank to serve hubs as subdomains of NEXT_PUBLIC_ROOT_DOMAIN. Set it
+# only when hubs live on a separate apex from the app.
+NEXT_PUBLIC_HUB_ROOT_DOMAIN=""
+
+# Record customers point their custom domain's CNAME at, shown in the DNS
+# verification card in Settings → Branding.
+NEXT_PUBLIC_HUB_CNAME_TARGET="hub-ingress.marvedge.io"
+
+# Cloudflare SSL for SaaS — provisions custom hostnames and their DV
+# certificates. Without all three, custom domains are mocked in development and
+# rejected outright in production (they are never silently faked).
+CF_ZONE_ID=""
+CF_AUTH_EMAIL=""
+CF_AUTH_KEY=""
+
+# BDH kill switches. Unlike AVS/WTM these are opt-OUT: the hub is already live,
+# so leave them blank to keep it on. Set to "false" to disable — BDH_ENABLED
+# turns off the hub APIs and cron, NEXT_PUBLIC_BDH_ENABLED turns off hub host
+# routing in middleware so every host serves the normal app.
+BDH_ENABLED=""
+NEXT_PUBLIC_BDH_ENABLED=""
+
+# Shared secret for the Vercel Cron job that polls pending domain verifications
+# (/api/cron/hub-domains, scheduled in vercel.json). Vercel sends it as
+# `Authorization: Bearer $CRON_SECRET`. Required in production — without it the
+# route refuses to run rather than exposing an open maintenance endpoint.
+CRON_SECRET=""
+
+# Opt-in for the reconciliation sweep to actually DELETE Cloudflare hostnames
+# that no longer have a hub behind them. Off by default: the sweep only logs
+# orphans, because deleting from a shared zone is irreversible. Set to "true"
+# once you have confirmed the zone holds nothing but Marvedge hub hostnames.
+BDH_RECONCILE_DELETE=""

--- a/app/(signed)/editor/utils/videoHandlers.ts
+++ b/app/(signed)/editor/utils/videoHandlers.ts
@@ -96,7 +96,14 @@ async function uploadDemoSourceVideo(videoUrl: string): Promise<string | null> {
 }
 
 interface DemoConflictParams {
-  data: { title: string; description: string };
+  data: {
+    title: string;
+    description: string;
+    tags?: string[];
+    integrations?: string[];
+    userRoles?: string[];
+    featured?: boolean;
+  };
   editingToSave: Record<string, unknown>;
   conflictData: unknown;
   setSidebarTitle: (title: string) => void;
@@ -126,6 +133,12 @@ async function handleDemoConflict({
         id: existingId,
         title: data.title,
         description: data.description,
+        // Carry the hub taxonomy through too, otherwise anything the user
+        // entered in the save modal is silently dropped on a 409.
+        tags: data.tags || [],
+        integrations: data.integrations || [],
+        userRoles: data.userRoles || [],
+        featured: typeof data.featured === "boolean" ? data.featured : false,
         editing: editingToSave,
       });
       if (setDemoSaved) {
@@ -168,17 +181,74 @@ async function handleDemoConflict({
   setShowSaveDemoModal(false);
 }
 
-export async function handleSaveDemo(
-  data: {
-    title: string;
-    description: string;
-    tags?: string[];
-    integrations?: string[];
-    userRoles?: string[];
-    featured?: boolean;
-  },
+interface SaveDemoData {
+  title: string;
+  description: string;
+  tags?: string[];
+  integrations?: string[];
+  userRoles?: string[];
+  featured?: boolean;
+}
+
+/**
+ * Update a demo that already exists.
+ *
+ * Such a demo must never be re-POSTed (that 409s) nor have its raw video
+ * re-uploaded, and its editing state is owned by the autosave loop — so this
+ * writes only the fields the save modal actually edits. That is what makes
+ * tags, roles and "Featured" curatable after the first save (BDH-4.3 /
+ * BDH-4.4) instead of being frozen at creation time.
+ */
+async function updateExistingDemoDetails(
+  demoId: string,
+  data: SaveDemoData,
   params: SaveDemoParams
-) {
+): Promise<void> {
+  const {
+    setSavingDemo,
+    setSidebarTitle,
+    setSidebarDescription,
+    setShowSaveDemoModal,
+    setDemoSaved,
+    setSavedDemoId,
+    onSaveSuccess,
+  } = params;
+
+  try {
+    await axios.patch("/api/demo", {
+      id: demoId,
+      title: data.title,
+      description: data.description,
+      tags: data.tags || [],
+      integrations: data.integrations || [],
+      userRoles: data.userRoles || [],
+      featured: typeof data.featured === "boolean" ? data.featured : false,
+    });
+
+    setSidebarTitle(data.title);
+    setSidebarDescription(data.description);
+    if (setDemoSaved) {
+      setDemoSaved(true);
+    }
+    if (setSavedDemoId) {
+      setSavedDemoId(demoId);
+    }
+    if (onSaveSuccess) {
+      onSaveSuccess();
+    }
+    toast.dismiss();
+    toast.success("Demo details updated!");
+    setShowSaveDemoModal(false);
+  } catch (updateErr) {
+    console.error("Failed to update demo details:", updateErr);
+    toast.dismiss();
+    toast.error("Failed to update demo details");
+  } finally {
+    setSavingDemo(false);
+  }
+}
+
+export async function handleSaveDemo(data: SaveDemoData, params: SaveDemoParams) {
   const {
     videoUrl,
     currentSegments,
@@ -217,15 +287,14 @@ export async function handleSaveDemo(
     const existingDemoId = savedDemoId ?? urlDemoId ?? null;
 
     if (existingDemoId) {
-      toast.dismiss();
-      toast.error("This demo has already been saved!");
-      setSavingDemo(false);
+      await updateExistingDemoDetails(existingDemoId, data, params);
       return;
     }
 
+    // Past this point the demo is new: the existing-demo branch above returned.
     // First, upload source video to GCS if it's a blob URL
     let sourceVideoUrl = videoUrl;
-    if (!existingDemoId && videoUrl.startsWith("blob:")) {
+    if (videoUrl.startsWith("blob:")) {
       const uploadedUrl = await uploadDemoSourceVideo(videoUrl);
       if (!uploadedUrl) {
         return;
@@ -253,27 +322,16 @@ export async function handleSaveDemo(
     };
 
     try {
-      const response = existingDemoId
-        ? await axios.patch("/api/demo", {
-            id: existingDemoId,
-            title: data.title,
-            description: data.description,
-            tags: data.tags || [],
-            integrations: data.integrations || [],
-            userRoles: data.userRoles || [],
-            featured: typeof data.featured === "boolean" ? data.featured : false,
-            editing: editingToSave,
-          })
-        : await axios.post("/api/demo", {
-            title: data.title,
-            description: data.description,
-            videoUrl: sourceVideoUrl,
-            tags: data.tags || [],
-            integrations: data.integrations || [],
-            userRoles: data.userRoles || [],
-            featured: typeof data.featured === "boolean" ? data.featured : false,
-            editing: editingToSave,
-          });
+      const response = await axios.post("/api/demo", {
+        title: data.title,
+        description: data.description,
+        videoUrl: sourceVideoUrl,
+        tags: data.tags || [],
+        integrations: data.integrations || [],
+        userRoles: data.userRoles || [],
+        featured: typeof data.featured === "boolean" ? data.featured : false,
+        editing: editingToSave,
+      });
       console.log("Demo saved/updated:", response.data);
 
       // Set the saved state
@@ -281,7 +339,7 @@ export async function handleSaveDemo(
         setDemoSaved(true);
       }
       if (setSavedDemoId) {
-        setSavedDemoId(getDemoIdFromApiResponse(response.data) || existingDemoId);
+        setSavedDemoId(getDemoIdFromApiResponse(response.data));
       }
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {

--- a/app/(signed)/settings/components/BrandingTab.tsx
+++ b/app/(signed)/settings/components/BrandingTab.tsx
@@ -3,6 +3,11 @@
 import { useState, useEffect, useRef } from "react";
 import { toast } from "react-hot-toast";
 import Image from "next/image";
+import { HUB_CNAME_TARGET, HUB_ROOT_DOMAIN } from "@/app/lib/hubDomain";
+
+const MAX_LOGO_BYTES = 2 * 1024 * 1024;
+const POLL_INTERVAL_MS = 30_000;
+const MAX_BACKGROUND_POLLS = 20;
 
 interface HubSettingsData {
   logoUrl: string | null;
@@ -11,7 +16,7 @@ interface HubSettingsData {
   accentColor: string;
   hubTitle: string;
   hubDescription: string;
-  subdomainPrefix: string;
+  subdomain: string;
   userId: string;
   customDomain: string | null;
   sslStatus: string;
@@ -29,6 +34,8 @@ export default function BrandingTab() {
   const [saving, setSaving] = useState(false);
   const [verifying, setVerifying] = useState(false);
   const [logoUploading, setLogoUploading] = useState(false);
+  const [customDomainAllowed, setCustomDomainAllowed] = useState(false);
+  const [demoCounts, setDemoCounts] = useState({ total: 0, public: 0 });
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [form, setForm] = useState<HubSettingsData>({
@@ -38,7 +45,7 @@ export default function BrandingTab() {
     accentColor: "#F3F0FC",
     hubTitle: "",
     hubDescription: "",
-    subdomainPrefix: "",
+    subdomain: "",
     userId: "",
     customDomain: "",
     sslStatus: "pending",
@@ -52,9 +59,8 @@ export default function BrandingTab() {
         if (res.ok) {
           const data = await res.json();
           if (data.success && data.settings) {
-            const fullSub = data.settings.subdomain || "";
-            const dashIdx = fullSub.lastIndexOf("-");
-            const prefix = dashIdx !== -1 ? fullSub.substring(0, dashIdx) : "user";
+            setCustomDomainAllowed(!!data.customDomainAllowed);
+            setDemoCounts({ total: data.demoCount || 0, public: data.publicDemoCount || 0 });
             setForm({
               logoUrl: data.settings.logoUrl || null,
               brandColor: data.settings.brandColor || "#7C5CFC",
@@ -62,7 +68,7 @@ export default function BrandingTab() {
               accentColor: data.settings.accentColor || "#F3F0FC",
               hubTitle: data.settings.hubTitle || "",
               hubDescription: data.settings.hubDescription || "",
-              subdomainPrefix: prefix,
+              subdomain: data.settings.subdomain || "",
               userId: data.settings.userId || "",
               customDomain: data.settings.customDomain || "",
               sslStatus: data.settings.sslStatus || "pending",
@@ -95,13 +101,25 @@ export default function BrandingTab() {
       return;
     }
 
+    // Enforce the limits the copy below promises, before spending an upload.
+    if (!file.type.startsWith("image/")) {
+      toast.error("Logo must be an image file (PNG, JPG or WEBP).");
+      e.target.value = "";
+      return;
+    }
+    if (file.size > MAX_LOGO_BYTES) {
+      toast.error("Logo is too large. Maximum size is 2MB.");
+      e.target.value = "";
+      return;
+    }
+
     setLogoUploading(true);
     const uploadToast = toast.loading("Uploading logo...");
 
     try {
       const formData = new FormData();
       formData.append("file", file);
-      formData.append("upload_preset", "upload_preset_1"); // standard preset configured
+      formData.append("upload_preset", process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET || "");
 
       const res = await fetch("/api/upload", {
         method: "POST",
@@ -124,6 +142,8 @@ export default function BrandingTab() {
       toast.error("Failed to upload logo. Please try again.", { id: uploadToast });
     } finally {
       setLogoUploading(false);
+      // Allow re-selecting the same file after a failure.
+      e.target.value = "";
     }
   };
 
@@ -143,24 +163,31 @@ export default function BrandingTab() {
           accentColor: form.accentColor,
           hubTitle: form.hubTitle,
           hubDescription: form.hubDescription,
-          subdomain: form.subdomainPrefix,
+          subdomain: form.subdomain,
           customDomain: form.customDomain || null,
         }),
       });
 
       const data = await res.json();
       if (res.ok && data.success) {
-        const fullSub = data.settings.subdomain || "";
-        const dashIdx = fullSub.lastIndexOf("-");
-        const prefix = dashIdx !== -1 ? fullSub.substring(0, dashIdx) : "user";
+        const savedSubdomain = data.settings.subdomain || "";
         setForm((prev) => ({
           ...prev,
-          subdomainPrefix: prefix,
+          subdomain: savedSubdomain,
           userId: data.settings.userId || prev.userId,
+          customDomain: data.settings.customDomain || "",
           sslStatus: data.settings.sslStatus || "pending",
           dnsVerification: data.settings.dnsVerification || null,
         }));
-        toast.success("Hub branding settings saved!", { id: saveToast });
+        // The server may hand back a disambiguated name if the one requested was
+        // taken — say so rather than letting the field silently change.
+        if (savedSubdomain && savedSubdomain !== form.subdomain) {
+          toast.success(`Saved. Your hub is at ${savedSubdomain}.${HUB_ROOT_DOMAIN}`, {
+            id: saveToast,
+          });
+        } else {
+          toast.success("Hub branding settings saved!", { id: saveToast });
+        }
       } else {
         throw new Error(data.error || "Save failed");
       }
@@ -207,6 +234,48 @@ export default function BrandingTab() {
       setVerifying(false);
     }
   };
+
+  // While a certificate is still being issued, refresh quietly in the background
+  // so the card flips to "active" on its own. The cron job (see
+  // app/api/cron/hub-domains) does the same server-side for users who navigated
+  // away; this only makes the open page feel live.
+  useEffect(() => {
+    if (loading || !form.customDomain || form.sslStatus === "active") {
+      return;
+    }
+
+    let cancelled = false;
+    // Certificate issuance takes minutes, not hours. Stop after ~10 minutes so a
+    // forgotten open tab cannot poll Cloudflare indefinitely — the cron keeps
+    // working regardless, and the manual button is always there.
+    let remaining = MAX_BACKGROUND_POLLS;
+
+    const timer = setInterval(async () => {
+      if (remaining-- <= 0) {
+        clearInterval(timer);
+        return;
+      }
+      try {
+        const res = await fetch("/api/hub/verify", { method: "POST" });
+        const data = await res.json();
+        if (cancelled || !res.ok || !data.success) {
+          return;
+        }
+        setForm((prev) => ({
+          ...prev,
+          sslStatus: data.sslStatus || prev.sslStatus,
+          dnsVerification: data.dnsVerification || prev.dnsVerification,
+        }));
+      } catch {
+        // Background refresh — stay silent and try again on the next tick.
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [loading, form.customDomain, form.sslStatus]);
 
   if (loading) {
     return (
@@ -391,25 +460,41 @@ export default function BrandingTab() {
                   <input
                     type="text"
                     id="subdomain"
-                    name="subdomainPrefix"
-                    value={form.subdomainPrefix}
+                    name="subdomain"
+                    value={form.subdomain}
                     onChange={handleChange}
                     className="p-2.5 text-sm focus:outline-none w-full text-right font-medium"
                     placeholder="my-company"
                   />
                   <span className="bg-gray-100 dark:bg-[#151229] px-3 flex items-center border-l dark:border-l-[rgba(255,255,255,0.08)] text-sm text-gray-500 font-medium whitespace-nowrap">
-                    -{form.userId ? form.userId.substring(0, 8) : "xxxxxxxx"}.marvedge.io
+                    .{HUB_ROOT_DOMAIN}
                   </span>
                 </div>
                 <p className="text-xs text-gray-400">
-                  Serve your demo hub instantly at this address.
+                  Serve your demo hub instantly at this address. If the name is already taken we
+                  will add a short unique suffix.
                 </p>
+                {form.subdomain && (
+                  <a
+                    href={`https://${form.subdomain}.${HUB_ROOT_DOMAIN}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs font-semibold text-[#7C5CFC] hover:underline w-fit"
+                  >
+                    Open my hub ↗
+                  </a>
+                )}
               </div>
 
               {/* Custom Domain */}
               <div className="flex flex-col gap-1.5">
                 <label htmlFor="customDomain" className="text-sm font-semibold text-gray-600">
                   Custom Domain (CNAME / White-Label)
+                  {!customDomainAllowed && (
+                    <span className="ml-2 px-2 py-0.5 rounded-full bg-[#F3F0FC] text-[#7C5CFC] text-[10px] font-bold uppercase tracking-wider align-middle">
+                      Pro
+                    </span>
+                  )}
                 </label>
                 <input
                   type="text"
@@ -417,11 +502,16 @@ export default function BrandingTab() {
                   name="customDomain"
                   value={form.customDomain || ""}
                   onChange={handleChange}
+                  disabled={!customDomainAllowed}
                   placeholder="e.g. demos.mycompany.com"
-                  className="border border-gray-200 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-[#7C5CFC] w-full font-medium"
+                  className={`border border-gray-200 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-[#7C5CFC] w-full font-medium ${
+                    customDomainAllowed ? "" : "bg-gray-50 text-gray-400 cursor-not-allowed"
+                  }`}
                 />
                 <p className="text-xs text-gray-400">
-                  Map your own custom domain by pointing its CNAME record to Marvedge.
+                  {customDomainAllowed
+                    ? "Map your own custom domain by pointing its CNAME record to Marvedge."
+                    : "Serving your hub on your own domain is available on PRO and ENTERPRISE plans. Your Marvedge subdomain above works on every plan."}
                 </p>
               </div>
             </div>
@@ -442,6 +532,23 @@ export default function BrandingTab() {
 
         {/* Verification Status Card */}
         <div className="space-y-6">
+          {/* Hub contents. A demo is only published to the hub once it has a
+              public share link, which is invisible from the editor otherwise. */}
+          <div className="card bg-white rounded-xl border border-[#ede7fa] dark:border-[rgba(255,255,255,0.08)] p-6 space-y-2">
+            <h3 className="text-lg font-semibold text-gray-700 dark:text-white border-b dark:border-b-[rgba(255,255,255,0.08)] pb-2">
+              Demos in your hub
+            </h3>
+            <p className="text-3xl font-bold text-[#7C5CFC]">
+              {demoCounts.public}
+              <span className="text-base font-medium text-gray-400"> of {demoCounts.total}</span>
+            </p>
+            <p className="text-xs text-gray-400 leading-relaxed">
+              {demoCounts.public === 0
+                ? "Your hub is empty. Demos appear here once you share them publicly from the demo list."
+                : "Only demos you have shared publicly appear in your hub. Share a demo to add it."}
+            </p>
+          </div>
+
           <div className="card bg-white rounded-xl border border-[#ede7fa] dark:border-[rgba(255,255,255,0.08)] p-6 space-y-6 sticky top-6">
             <h3 className="text-lg font-semibold text-gray-700 dark:text-white border-b dark:border-b-[rgba(255,255,255,0.08)] pb-2">
               Verification Status
@@ -508,7 +615,7 @@ export default function BrandingTab() {
                         </div>
                         <div>
                           <span className="text-gray-400 dark:text-gray-500">Points to:</span>{" "}
-                          hub-ingress.marvedge.io
+                          {form.dnsVerification?.cnameTarget || HUB_CNAME_TARGET}
                         </div>
                       </div>
                     </div>

--- a/app/(signed)/settings/components/SettingsTabs.tsx
+++ b/app/(signed)/settings/components/SettingsTabs.tsx
@@ -1,4 +1,5 @@
 import { TABS } from "../../../lib/constants";
+import { isBdhRoutingEnabled } from "@/app/lib/bdh/flags";
 
 type SettingsTabsProps = {
   activeTab: string;
@@ -6,9 +7,13 @@ type SettingsTabsProps = {
 };
 
 export default function SettingsTabs({ activeTab, setActiveTab }: SettingsTabsProps) {
+  // With BDH off the hub APIs return 404, so don't offer a tab that can only
+  // fail. NEXT_PUBLIC_BDH_ENABLED is inlined at build time and safe on the client.
+  const tabs = isBdhRoutingEnabled() ? TABS : TABS.filter((tab) => tab !== "Branding");
+
   return (
     <div className="tabs flex flex-wrap items-center gap-2 px-2 sm:px-4 md:px-8 pb-3 pt-4 bg-white border-b border-gray-200 overflow-x-auto">
-      {TABS.map((tab) => (
+      {tabs.map((tab) => (
         <button
           key={tab}
           className={`tab flex-1 min-w-[120px] px-3 sm:px-6 py-2 border rounded-lg text-base sm:text-lg font-medium transition-colors focus:outline-none whitespace-nowrap ${

--- a/app/api/cron/hub-domains/route.ts
+++ b/app/api/cron/hub-domains/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/prisma";
+import {
+  deleteCustomDomain,
+  getCustomDomainStatus,
+  listCustomHostnames,
+} from "@/app/lib/cloudflare";
+import { isBdhEnabled } from "@/app/lib/bdh/flags";
+
+/**
+ * Asynchronous custom-domain maintenance (PRD §4.3 / §4.4).
+ *
+ * PRD §4.3 requires an asynchronous backend process that verifies ownership and
+ * requests SSL certificates rather than relying on the user sitting on the
+ * settings page hitting refresh. §4.4 additionally requires that a hostname
+ * belonging to a deleted account is removed from the zone, since it would
+ * otherwise keep routing to us.
+ *
+ * This route covers both and is driven by Vercel Cron (see vercel.json):
+ *
+ *   1. Poll every hub whose SSL is not yet active and persist the latest status,
+ *      so a domain flips to "active" on its own once DNS propagates.
+ *   2. Sweep the zone for hostnames with no hub behind them any more.
+ *
+ * The sweep is REPORT-ONLY by default. Deleting hostnames from a zone we may
+ * share with other things is destructive and irreversible, so actually removing
+ * orphans requires opting in with BDH_RECONCILE_DELETE=true. Until then it logs
+ * loudly, which is enough to act on.
+ */
+
+// Bounded so one run cannot exceed the serverless execution limit.
+const MAX_DOMAINS_PER_RUN = 25;
+
+function isAuthorized(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+
+  // Without a configured secret, only allow this outside production so local
+  // runs work but a public deployment never exposes an open maintenance route.
+  if (!secret) {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  // Vercel Cron sends `Authorization: Bearer $CRON_SECRET`.
+  const header = req.headers.get("authorization") || "";
+  return header === `Bearer ${secret}`;
+}
+
+export async function GET(req: NextRequest) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!isBdhEnabled()) {
+    return NextResponse.json({ success: true, skipped: "BDH disabled" });
+  }
+
+  const startedAt = Date.now();
+  const checked: Array<{ hostname: string; sslStatus: string | null }> = [];
+  const errors: string[] = [];
+
+  try {
+    // 1. Poll hubs whose certificate has not been issued yet.
+    const pending = await prisma.hubSettings.findMany({
+      where: {
+        customDomain: { not: null },
+        cloudflareId: { not: null },
+        NOT: { sslStatus: "active" },
+      },
+      select: { id: true, customDomain: true, cloudflareId: true, sslStatus: true },
+      orderBy: { updatedAt: "asc" },
+      take: MAX_DOMAINS_PER_RUN,
+    });
+
+    for (const hub of pending) {
+      const status = await getCustomDomainStatus(hub.cloudflareId!, hub.customDomain!);
+
+      if (!status.success) {
+        errors.push(`${hub.customDomain}: ${status.error}`);
+        continue;
+      }
+
+      await prisma.hubSettings.update({
+        where: { id: hub.id },
+        data: {
+          sslStatus: status.sslStatus || hub.sslStatus,
+          dnsVerification: status.dnsVerification
+            ? JSON.parse(JSON.stringify(status.dnsVerification))
+            : undefined,
+        },
+      });
+
+      checked.push({ hostname: hub.customDomain!, sslStatus: status.sslStatus ?? null });
+    }
+
+    // 2. Reconcile the zone against our records to catch orphaned hostnames.
+    const orphans: string[] = [];
+    const deleted: string[] = [];
+    const zone = await listCustomHostnames();
+
+    if (!zone.success) {
+      errors.push(`zone listing: ${zone.error}`);
+    } else if (zone.hostnames.length > 0) {
+      const known = await prisma.hubSettings.findMany({
+        where: { customDomain: { not: null } },
+        select: { customDomain: true },
+      });
+      const knownSet = new Set(known.map((row) => row.customDomain));
+
+      for (const entry of zone.hostnames) {
+        if (knownSet.has(entry.hostname)) {
+          continue;
+        }
+
+        orphans.push(entry.hostname);
+
+        if (process.env.BDH_RECONCILE_DELETE === "true") {
+          const removal = await deleteCustomDomain(entry.id);
+          if (removal.success) {
+            deleted.push(entry.hostname);
+          } else {
+            errors.push(`orphan ${entry.hostname}: ${removal.error}`);
+          }
+        }
+      }
+
+      if (orphans.length > 0 && process.env.BDH_RECONCILE_DELETE !== "true") {
+        console.warn(
+          `[hub-domains] ${orphans.length} Cloudflare hostname(s) have no hub behind them and are still routing: ${orphans.join(", ")}. Set BDH_RECONCILE_DELETE=true to remove them automatically.`
+        );
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      durationMs: Date.now() - startedAt,
+      polled: checked.length,
+      activated: checked.filter((c) => c.sslStatus === "active").length,
+      orphans,
+      deleted,
+      errors,
+    });
+  } catch (error) {
+    console.error("[hub-domains] cron failed:", error);
+    return NextResponse.json(
+      { success: false, error: (error as Error).message, errors },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/demo/route.ts
+++ b/app/api/demo/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/app/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/lib/auth/options";
 import { revalidatePath } from "next/cache";
+import { normalizeTaxonomy } from "@/app/lib/bdh/taxonomy";
 
 export async function GET(req: NextRequest) {
   try {
@@ -111,9 +112,9 @@ export async function POST(req: NextRequest) {
         videoUrl,
         editing: editing || null,
         userId, // attach logged-in user
-        tags: Array.isArray(tags) ? tags : [],
-        integrations: Array.isArray(integrations) ? integrations : [],
-        userRoles: Array.isArray(userRoles) ? userRoles : [],
+        tags: normalizeTaxonomy(tags) ?? [],
+        integrations: normalizeTaxonomy(integrations) ?? [],
+        userRoles: normalizeTaxonomy(userRoles) ?? [],
         featured: typeof featured === "boolean" ? featured : false,
       },
     });
@@ -166,15 +167,19 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
     }
 
+    const normalizedTags = normalizeTaxonomy(tags);
+    const normalizedIntegrations = normalizeTaxonomy(integrations);
+    const normalizedUserRoles = normalizeTaxonomy(userRoles);
+
     // Use a single write to both enforce ownership and avoid extra round trips.
     const updateData: Record<string, unknown> = {
       ...(typeof exportedUrl === "string" ? { exportedUrl } : {}),
       ...(typeof editing !== "undefined" ? { editing } : {}),
       ...(typeof title === "string" ? { title } : {}),
       ...(typeof description === "string" ? { description } : {}),
-      ...(Array.isArray(tags) ? { tags } : {}),
-      ...(Array.isArray(integrations) ? { integrations } : {}),
-      ...(Array.isArray(userRoles) ? { userRoles } : {}),
+      ...(normalizedTags ? { tags: normalizedTags } : {}),
+      ...(normalizedIntegrations ? { integrations: normalizedIntegrations } : {}),
+      ...(normalizedUserRoles ? { userRoles: normalizedUserRoles } : {}),
       ...(typeof featured === "boolean" ? { featured } : {}),
     };
 

--- a/app/api/hub/route.ts
+++ b/app/api/hub/route.ts
@@ -3,9 +3,141 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/lib/auth/options";
 import { prisma } from "@/app/lib/prisma";
 import { registerCustomDomain, deleteCustomDomain } from "@/app/lib/cloudflare";
+import {
+  isClaimableSubdomain,
+  normalizeSubdomainLabel,
+  RESERVED_SUBDOMAINS,
+  validateCustomDomain,
+} from "@/app/lib/hubDomain";
+import { isCustomDomainAllowed } from "@/app/lib/bdh/access";
+import { isBdhEnabled } from "@/app/lib/bdh/flags";
+
+/**
+ * Hosts next.config.ts allows `next/image` to load from. A logoUrl outside this
+ * list makes the public hub page throw at render time, so reject it on write
+ * rather than letting one bad save take the whole hub down.
+ */
+const ALLOWED_LOGO_HOSTS = ["res.cloudinary.com", "lh3.googleusercontent.com"];
+
+function normalizeLogoUrl(value: unknown): { ok: true; url: string | null } | { ok: false } {
+  if (value === null || value === undefined || value === "") {
+    return { ok: true, url: null };
+  }
+  if (typeof value !== "string") {
+    return { ok: false };
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "https:" || !ALLOWED_LOGO_HOSTS.includes(parsed.hostname)) {
+      return { ok: false };
+    }
+    return { ok: true, url: parsed.toString() };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** Hex colours only — the value is injected into the public hub's style scope. */
+function normalizeColor(value: unknown, fallback: string): string {
+  return typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value.trim())
+    ? value.trim().toLowerCase()
+    : fallback;
+}
+
+/** Deterministic per-user suffix used to disambiguate a taken subdomain. */
+function subdomainSuffix(userId: string): string {
+  return userId.substring(0, 8);
+}
+
+/**
+ * Subdomain for a user who has not chosen one.
+ *
+ * `user-<first 8 of cuid>` is NOT unique on its own: those 8 characters are "c"
+ * plus 7 of the 8 base36 timestamp characters, so they only resolve to about
+ * 36ms. Two accounts created in the same window generate the same name, and the
+ * unique index then turns their first hub load into a 500 that locks them out of
+ * the Branding tab entirely. Probe first and add a discriminator on collision.
+ */
+async function defaultSubdomain(userId: string): Promise<string> {
+  const base = `user-${subdomainSuffix(userId)}`;
+
+  for (const candidate of [base, ...Array.from({ length: 5 }, () => `${base}-${randomLabel()}`)]) {
+    const taken = await prisma.hubSettings.findFirst({
+      where: { subdomain: candidate, NOT: { userId } },
+      select: { id: true },
+    });
+    if (!taken) {
+      return candidate;
+    }
+  }
+
+  // Astronomically unlikely; a fully random name still beats a hard failure.
+  return `${base}-${randomLabel()}${randomLabel()}`;
+}
+
+function randomLabel(): string {
+  return Math.random().toString(36).slice(2, 8);
+}
+
+/**
+ * Resolve the subdomain a save should land on.
+ *
+ * A customer gets the clean name they asked for (`acme.marvedge.com`) when it is
+ * free — the PRD's sales-leader story is someone reading a URL out loud. Only if
+ * it is taken do we fall back to the disambiguated `acme-cmn5tm26` form.
+ *
+ * An existing subdomain is never changed unless the user actually edited it:
+ * their hub URL is already in circulation, and silently rotating it would break
+ * every link a prospect has.
+ */
+async function resolveSubdomain(
+  requested: string,
+  userId: string,
+  current: string | null
+): Promise<{ ok: true; subdomain: string } | { ok: false; error: string }> {
+  const label = normalizeSubdomainLabel(requested);
+
+  // Nothing usable submitted: keep what they have, or generate a default.
+  if (!label) {
+    return { ok: true, subdomain: current || (await defaultSubdomain(userId)) };
+  }
+
+  // Unchanged — including the case where they re-submitted the suffixed form.
+  if (label === current) {
+    return { ok: true, subdomain: current };
+  }
+
+  if (RESERVED_SUBDOMAINS.has(label)) {
+    return { ok: false, error: `"${label}" is reserved. Please choose another subdomain.` };
+  }
+
+  const suffixed = `${label}-${subdomainSuffix(userId)}`;
+  if (suffixed === current) {
+    return { ok: true, subdomain: current };
+  }
+
+  const candidates = isClaimableSubdomain(label) ? [label, suffixed] : [suffixed];
+
+  const taken = await prisma.hubSettings.findMany({
+    where: { subdomain: { in: candidates }, NOT: { userId } },
+    select: { subdomain: true },
+  });
+  const takenSet = new Set(taken.map((row) => row.subdomain));
+
+  const available = candidates.find((candidate) => !takenSet.has(candidate));
+  if (!available) {
+    return { ok: false, error: "That subdomain is already in use. Please choose another." };
+  }
+
+  return { ok: true, subdomain: available };
+}
 
 export async function GET() {
   try {
+    if (!isBdhEnabled()) {
+      return NextResponse.json({ error: "Demo Hub is not enabled." }, { status: 404 });
+    }
+
     const session = await getServerSession(authOptions);
     if (!session || (!session.user?.id && !session.user?.email)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -22,21 +154,46 @@ export async function GET() {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
-    // If hub settings do not exist, create a default hub settings profile
+    // If hub settings do not exist, create a default hub settings profile.
+    // Two tabs opening Settings at once would both try to create one, so treat a
+    // lost race as success and return the row the winner wrote.
     if (!user.hubSettings) {
-      const defaultSubdomain = `user-${user.id.substring(0, 8)}`;
-      const settings = await prisma.hubSettings.create({
-        data: {
-          userId: user.id,
-          subdomain: defaultSubdomain,
-          hubTitle: `${user.name || "My"} Product Hub`,
-          hubDescription: "Browse all our product interactive tours.",
-        },
+      const settings = await prisma.hubSettings
+        .create({
+          data: {
+            userId: user.id,
+            subdomain: await defaultSubdomain(user.id),
+            hubTitle: `${user.name || "My"} Product Hub`,
+            hubDescription: "Browse all our product interactive tours.",
+          },
+        })
+        .catch(async () => prisma.hubSettings.findUnique({ where: { userId: user.id } }));
+
+      if (!settings) {
+        return NextResponse.json({ error: "Failed to create hub settings" }, { status: 500 });
+      }
+
+      return NextResponse.json({
+        success: true,
+        settings,
+        customDomainAllowed: isCustomDomainAllowed(user.plan),
       });
-      return NextResponse.json({ success: true, settings });
     }
 
-    return NextResponse.json({ success: true, settings: user.hubSettings });
+    // Surfaced in the settings UI: a demo only reaches the hub once it has been
+    // shared publicly, which is otherwise invisible to the user.
+    const [demoCount, publicDemoCount] = await Promise.all([
+      prisma.demo.count({ where: { userId: user.id } }),
+      prisma.demo.count({ where: { userId: user.id, isPublic: true } }),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      settings: user.hubSettings,
+      customDomainAllowed: isCustomDomainAllowed(user.plan),
+      demoCount,
+      publicDemoCount,
+    });
   } catch (error) {
     console.error("GET /api/hub error:", error);
     return NextResponse.json({ error: "Failed to fetch hub settings" }, { status: 500 });
@@ -45,6 +202,10 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
+    if (!isBdhEnabled()) {
+      return NextResponse.json({ error: "Demo Hub is not enabled." }, { status: 404 });
+    }
+
     const session = await getServerSession(authOptions);
     if (!session || (!session.user?.id && !session.user?.email)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -73,26 +234,49 @@ export async function POST(req: NextRequest) {
       customDomain,
     } = body;
 
-    // Enforce static unique ID suffix on subdomain
-    const cleanPrefix = subdomain
-      ? subdomain
-          .trim()
-          .toLowerCase()
-          .replace(/[^a-z0-9-]/g, "")
-      : "user";
-    const finalSubdomain = `${cleanPrefix || "user"}-${user.id.substring(0, 8)}`;
+    const finalSubdomain = await resolveSubdomain(
+      typeof subdomain === "string" ? subdomain : "",
+      user.id,
+      user.hubSettings?.subdomain ?? null
+    );
 
-    if (finalSubdomain !== user.hubSettings?.subdomain) {
-      const existingSubdomain = await prisma.hubSettings.findUnique({
-        where: { subdomain: finalSubdomain },
-      });
-      if (existingSubdomain) {
-        return NextResponse.json({ error: "Subdomain is already in use" }, { status: 400 });
+    if (!finalSubdomain.ok) {
+      return NextResponse.json({ error: finalSubdomain.error }, { status: 400 });
+    }
+
+    // Validate custom domain shape before it reaches Cloudflare
+    let cleanCustomDomain: string | null = null;
+    if (typeof customDomain === "string" && customDomain.trim()) {
+      const validated = validateCustomDomain(customDomain);
+      if (!validated.ok) {
+        return NextResponse.json({ error: validated.error }, { status: 400 });
       }
+      cleanCustomDomain = validated.hostname;
+    }
+
+    // Mapping your own domain is the paid, white-label half of the hub; the hub
+    // and its Marvedge subdomain stay free. Only gate an actual change, so a
+    // lapsed user editing colours doesn't get blocked by their existing domain.
+    if (
+      cleanCustomDomain !== (user.hubSettings?.customDomain ?? null) &&
+      cleanCustomDomain !== null &&
+      !isCustomDomainAllowed(user.plan)
+    ) {
+      return NextResponse.json(
+        { error: "Custom domains are available on PRO and ENTERPRISE plans." },
+        { status: 403 }
+      );
+    }
+
+    const logo = normalizeLogoUrl(logoUrl);
+    if (!logo.ok) {
+      return NextResponse.json(
+        { error: "Logo must be an uploaded image URL served over HTTPS." },
+        { status: 400 }
+      );
     }
 
     // Validate custom domain uniqueness if changed
-    const cleanCustomDomain = customDomain ? customDomain.trim().toLowerCase() : null;
     if (cleanCustomDomain && cleanCustomDomain !== user.hubSettings?.customDomain) {
       const existingCustomDomain = await prisma.hubSettings.findUnique({
         where: { customDomain: cleanCustomDomain },
@@ -107,10 +291,18 @@ export async function POST(req: NextRequest) {
     let dnsVerification = user.hubSettings?.dnsVerification || null;
 
     // If custom domain is updated, trigger Cloudflare API integration
-    if (cleanCustomDomain !== user.hubSettings?.customDomain) {
-      // 1. Delete previous custom hostname from Cloudflare if it exists
+    if (cleanCustomDomain !== (user.hubSettings?.customDomain ?? null)) {
+      // 1. Delete previous custom hostname from Cloudflare if it exists. Bail on
+      // failure rather than orphaning a hostname that still routes to us.
       if (user.hubSettings?.cloudflareId) {
-        await deleteCustomDomain(user.hubSettings.cloudflareId);
+        const removal = await deleteCustomDomain(user.hubSettings.cloudflareId);
+        if (!removal.success) {
+          console.error("Cloudflare removal error during save:", removal.error);
+          return NextResponse.json(
+            { error: `Could not release the previous domain: ${removal.error}` },
+            { status: 502 }
+          );
+        }
       }
 
       if (cleanCustomDomain) {
@@ -134,41 +326,63 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    const settingsData = {
+      logoUrl: logo.url,
+      brandColor: normalizeColor(brandColor, "#7c5cfc"),
+      textColor: normalizeColor(textColor, "#111827"),
+      accentColor: normalizeColor(accentColor, "#f3f0fc"),
+      hubTitle:
+        typeof hubTitle === "string" && hubTitle.trim()
+          ? hubTitle.trim().slice(0, 120)
+          : `${user.name || "My"} Product Hub`,
+      hubDescription: typeof hubDescription === "string" ? hubDescription.trim().slice(0, 500) : "",
+      subdomain: finalSubdomain.subdomain,
+      customDomain: cleanCustomDomain,
+      cloudflareId,
+      sslStatus,
+      dnsVerification: dnsVerification ? JSON.parse(JSON.stringify(dnsVerification)) : null,
+    };
+
     // Update settings
     const updatedSettings = await prisma.hubSettings.upsert({
       where: { userId: user.id },
-      create: {
-        userId: user.id,
-        logoUrl,
-        brandColor: brandColor || "#7C5CFC",
-        textColor: textColor || "#111827",
-        accentColor: accentColor || "#F3F0FC",
-        hubTitle: hubTitle || `${user.name || "My"} Product Hub`,
-        hubDescription: hubDescription || "",
-        subdomain: finalSubdomain,
-        customDomain: cleanCustomDomain,
-        cloudflareId,
-        sslStatus,
-        dnsVerification: dnsVerification ? JSON.parse(JSON.stringify(dnsVerification)) : null,
-      },
-      update: {
-        logoUrl,
-        brandColor: brandColor || "#7C5CFC",
-        textColor: textColor || "#111827",
-        accentColor: accentColor || "#F3F0FC",
-        hubTitle: hubTitle || `${user.name || "My"} Product Hub`,
-        hubDescription: hubDescription || "",
-        subdomain: finalSubdomain,
-        customDomain: cleanCustomDomain,
-        cloudflareId,
-        sslStatus,
-        dnsVerification: dnsVerification ? JSON.parse(JSON.stringify(dnsVerification)) : null,
-      },
+      create: { userId: user.id, ...settingsData },
+      update: settingsData,
     });
 
     return NextResponse.json({ success: true, settings: updatedSettings });
   } catch (error) {
+    // The uniqueness probes above are check-then-write, so a concurrent save can
+    // still lose the race at the index. Say which field clashed instead of
+    // reporting a generic failure the user cannot act on.
+    const conflict = uniqueConstraintTarget(error);
+    if (conflict) {
+      return NextResponse.json(
+        {
+          error: `That ${conflict === "customDomain" ? "custom domain" : "subdomain"} was just taken. Please choose another.`,
+        },
+        { status: 409 }
+      );
+    }
+
     console.error("POST /api/hub error:", error);
     return NextResponse.json({ error: "Failed to save hub settings" }, { status: 500 });
   }
+}
+
+/** Field name behind a Prisma P2002 unique-constraint failure, if that's what this is. */
+function uniqueConstraintTarget(error: unknown): "subdomain" | "customDomain" | null {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return null;
+  }
+  if ((error as { code?: unknown }).code !== "P2002") {
+    return null;
+  }
+
+  const target = (error as { meta?: { target?: unknown } }).meta?.target;
+  const fields = Array.isArray(target) ? target.map(String) : [String(target ?? "")];
+  if (fields.some((field) => field.includes("customDomain"))) {
+    return "customDomain";
+  }
+  return "subdomain";
 }

--- a/app/api/hub/verify/route.ts
+++ b/app/api/hub/verify/route.ts
@@ -3,9 +3,14 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/lib/auth/options";
 import { prisma } from "@/app/lib/prisma";
 import { getCustomDomainStatus } from "@/app/lib/cloudflare";
+import { isBdhEnabled } from "@/app/lib/bdh/flags";
 
 export async function POST() {
   try {
+    if (!isBdhEnabled()) {
+      return NextResponse.json({ error: "Demo Hub is not enabled." }, { status: 404 });
+    }
+
     const session = await getServerSession(authOptions);
     if (!session || (!session.user?.id && !session.user?.email)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/user/delete/route.ts
+++ b/app/api/user/delete/route.ts
@@ -17,13 +17,23 @@ export async function DELETE() {
       include: { hubSettings: true },
     });
 
+    // PRD §4.4: a deleted account must not leave a custom hostname routing to us.
+    // A Cloudflare failure must not trap the user in an account they asked to
+    // delete, so log the orphan loudly instead — the /api/cron/hub-domains sweep
+    // reconciles the zone against our records and reports anything left behind.
     if (userWithHubSettings?.hubSettings?.cloudflareId) {
+      const { cloudflareId, customDomain } = userWithHubSettings.hubSettings;
       try {
         const { deleteCustomDomain } = await import("@/app/lib/cloudflare");
-        await deleteCustomDomain(userWithHubSettings.hubSettings.cloudflareId);
+        const removal = await deleteCustomDomain(cloudflareId);
+        if (!removal.success) {
+          console.error(
+            `[account-delete] ORPHANED Cloudflare hostname ${customDomain} (${cloudflareId}) still routes to us: ${removal.error}`
+          );
+        }
       } catch (cfError) {
         console.error(
-          "Failed to delete Cloudflare custom hostname during account deletion:",
+          `[account-delete] ORPHANED Cloudflare hostname ${customDomain} (${cloudflareId}) still routes to us:`,
           cfError
         );
       }

--- a/app/components/SaveDemoModal.tsx
+++ b/app/components/SaveDemoModal.tsx
@@ -36,6 +36,11 @@ export default function SaveDemoModal({
   const [integrations, setIntegrations] = useState("");
   const [userRoles, setUserRoles] = useState("");
   const [featured, setFeatured] = useState(false);
+  // Set when the editor is working on a demo that already exists. Such a demo
+  // can still be updated — the hub taxonomy below is meant to be curated over
+  // time — so "already saved" must not lock the form.
+  const [existingDemoId, setExistingDemoId] = useState<string | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
 
   // Update internal state when props change
   useEffect(() => {
@@ -45,27 +50,46 @@ export default function SaveDemoModal({
 
   // Load existing metadata if editing an existing demo
   useEffect(() => {
-    if (isOpen) {
-      const demoId = new URLSearchParams(window.location.search).get("demoId");
-      if (demoId) {
-        fetch(`/api/demo?id=${demoId}`)
-          .then((res) => res.json())
-          .then((data) => {
-            if (data.success && data.demo) {
-              setTags((data.demo.tags || []).join(", "));
-              setIntegrations((data.demo.integrations || []).join(", "));
-              setUserRoles((data.demo.userRoles || []).join(", "));
-              setFeatured(!!data.demo.featured);
-            }
-          })
-          .catch((err) => console.error("Error loading demo metadata:", err));
-      } else {
-        setTags("");
-        setIntegrations("");
-        setUserRoles("");
-        setFeatured(false);
-      }
+    if (!isOpen) {
+      return;
     }
+
+    const demoId = new URLSearchParams(window.location.search).get("demoId");
+    setExistingDemoId(demoId);
+    setLoadFailed(false);
+
+    if (!demoId) {
+      setTags("");
+      setIntegrations("");
+      setUserRoles("");
+      setFeatured(false);
+      return;
+    }
+
+    // Saving sends every one of these fields, so a failed load would blank the
+    // demo's existing taxonomy. Ignore a stale response and surface failures.
+    let cancelled = false;
+    fetch(`/api/demo?id=${encodeURIComponent(demoId)}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((data) => {
+        if (cancelled || !data.success || !data.demo) {
+          return;
+        }
+        setTags((data.demo.tags || []).join(", "));
+        setIntegrations((data.demo.integrations || []).join(", "));
+        setUserRoles((data.demo.userRoles || []).join(", "));
+        setFeatured(!!data.demo.featured);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("Error loading demo metadata:", err);
+          setLoadFailed(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [isOpen]);
 
   const handleSave = () => {
@@ -122,6 +146,15 @@ export default function SaveDemoModal({
             <X size={24} />
           </button>
         </div>
+
+        {/* Saving would overwrite the fields we failed to read, so block it and
+            say why rather than quietly wiping the demo's hub taxonomy. */}
+        {loadFailed && (
+          <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            Could not load this demo&apos;s existing tags and settings. Close and reopen this dialog
+            before saving, so they are not overwritten.
+          </div>
+        )}
 
         {/* Form */}
         <div className="space-y-4">
@@ -195,21 +228,29 @@ export default function SaveDemoModal({
           </div>
 
           {/* Featured Checkbox */}
-          <div className="flex items-center gap-2 pt-2">
-            <input
-              type="checkbox"
-              id="featured"
-              checked={featured}
-              onChange={(e) => setFeatured(e.target.checked)}
-              className="w-4 h-4 rounded text-[#7C5CFC] border-gray-300 focus:ring-[#7C5CFC]"
-              disabled={processing}
-            />
-            <label
-              htmlFor="featured"
-              className="text-sm font-medium text-gray-700 cursor-pointer select-none"
-            >
-              Mark as Featured Demo
-            </label>
+          <div className="pt-2">
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="featured"
+                checked={featured}
+                onChange={(e) => setFeatured(e.target.checked)}
+                className="w-4 h-4 rounded text-[#7C5CFC] border-gray-300 focus:ring-[#7C5CFC]"
+                disabled={processing}
+              />
+              <label
+                htmlFor="featured"
+                className="text-sm font-medium text-gray-700 cursor-pointer select-none"
+              >
+                Mark as Featured Demo
+              </label>
+            </div>
+            {/* Hub visibility is driven by the demo's public share link, so
+                saying so here stops "Featured" looking like it does nothing. */}
+            <p className="text-xs text-gray-500 mt-1.5 ml-6">
+              Tags, roles and Featured apply to your Demo Hub. A demo only appears there once you
+              have shared it publicly.
+            </p>
           </div>
         </div>
 
@@ -220,15 +261,23 @@ export default function SaveDemoModal({
           </Button>
           <Button
             onClick={handleSave}
-            disabled={!title.trim() || processing || isSaved}
+            disabled={!title.trim() || processing || loadFailed || (isSaved && !existingDemoId)}
             className={`flex-1 flex items-center gap-2 text-white ${
-              isSaved
+              isSaved && !existingDemoId
                 ? "bg-green-600 hover:bg-green-600 cursor-not-allowed"
                 : "bg-[#7C5CFC] hover:bg-[#8A76FC]"
             }`}
           >
             <Image src="/icons/1.png" alt="Save" width={16} height={16} />
-            {isSaved ? "✓ Saved" : processing ? "Saving..." : "Save Demo"}
+            {existingDemoId
+              ? processing
+                ? "Updating..."
+                : "Update Demo"
+              : isSaved
+                ? "✓ Saved"
+                : processing
+                  ? "Saving..."
+                  : "Save Demo"}
           </Button>
         </div>
       </div>

--- a/app/hub/[domain]/HubClient.tsx
+++ b/app/hub/[domain]/HubClient.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Search, Play, Award, Zap, Layers, Eye } from "lucide-react";
+import { hubHostname } from "@/app/lib/hubDomain";
 
 interface SerializedDemo {
   id: string;
@@ -35,11 +36,18 @@ interface HubClientProps {
   demos: SerializedDemo[];
 }
 
+type HubTab = "featured" | "most-watched" | "newest";
+
 export default function HubClient({ settings, demos }: HubClientProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedIntegration, setSelectedIntegration] = useState<string>("all");
   const [selectedRole, setSelectedRole] = useState<string>("all");
-  const [activeTab, setActiveTab] = useState<"featured" | "most-watched" | "newest">("featured");
+
+  // Only offer "Featured" when something is actually featured — otherwise the
+  // hub's landing view is an empty state for every customer who hasn't curated
+  // their library yet.
+  const hasFeatured = useMemo(() => demos.some((d) => d.featured), [demos]);
+  const [activeTab, setActiveTab] = useState<HubTab>(hasFeatured ? "featured" : "newest");
 
   // Collect unique integrations and roles for filter dropdowns
   const allIntegrations = useMemo(() => {
@@ -102,16 +110,15 @@ export default function HubClient({ settings, demos }: HubClientProps) {
     "--hub-brand": settings.brandColor,
     "--hub-text": settings.textColor,
     "--hub-accent": settings.accentColor,
-    "--hub-accent-hover": settings.brandColor + "15", // 8% opacity of brand color
   } as React.CSSProperties;
 
   return (
     <div
       style={hubStyles}
-      className="min-h-screen bg-gray-50 flex flex-col antialiased text-gray-900 font-sans"
+      className="min-h-screen bg-[var(--hub-accent)] flex flex-col antialiased text-[var(--hub-text)] font-sans"
     >
       {/* Header */}
-      <header className="bg-white border-b border-gray-150 py-4 px-6 md:px-12 flex flex-col md:flex-row items-center justify-between gap-4 shadow-sm sticky top-0 z-40">
+      <header className="bg-white border-b border-gray-200 py-4 px-6 md:px-12 flex flex-col md:flex-row items-center justify-between gap-4 shadow-sm sticky top-0 z-40">
         <div className="flex items-center gap-3">
           <div className="relative w-12 h-12 rounded-lg bg-gray-100 flex items-center justify-center overflow-hidden shrink-0">
             {settings.logoUrl ? (
@@ -123,10 +130,10 @@ export default function HubClient({ settings, demos }: HubClientProps) {
             )}
           </div>
           <div>
-            <h1 className="text-lg font-bold tracking-tight text-gray-800">{settings.hubTitle}</h1>
-            <p className="text-xs text-gray-400 font-medium">
-              {settings.customDomain ? settings.customDomain : `${settings.subdomain}.marvedge.io`}
-            </p>
+            <h1 className="text-lg font-bold tracking-tight text-[var(--hub-text)]">
+              {settings.hubTitle}
+            </h1>
+            <p className="text-xs text-gray-400 font-medium">{hubHostname(settings)}</p>
           </div>
         </div>
 
@@ -147,7 +154,7 @@ export default function HubClient({ settings, demos }: HubClientProps) {
 
       {/* Hero Showcase Intro */}
       <section className="bg-white px-6 py-12 md:py-16 md:px-12 border-b border-gray-100 text-center max-w-4xl mx-auto w-full mt-6 rounded-2xl shadow-sm">
-        <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight text-gray-900 mb-4">
+        <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight text-[var(--hub-text)] mb-4">
           Explore Our Interactive Product Tours
         </h2>
         <p className="text-base text-gray-500 max-w-2xl mx-auto leading-relaxed">
@@ -198,17 +205,19 @@ export default function HubClient({ settings, demos }: HubClientProps) {
         {/* Category Tabs Header */}
         <div className="flex items-center justify-between border-b border-gray-200 pb-2">
           <div className="flex gap-6">
-            <button
-              onClick={() => setActiveTab("featured")}
-              className={`pb-3 font-semibold text-sm transition-colors border-b-2 flex items-center gap-1.5 ${
-                activeTab === "featured"
-                  ? "border-[var(--hub-brand)] text-[var(--hub-brand)]"
-                  : "border-transparent text-gray-400 hover:text-gray-600"
-              }`}
-            >
-              <Award size={16} />
-              Featured
-            </button>
+            {hasFeatured && (
+              <button
+                onClick={() => setActiveTab("featured")}
+                className={`pb-3 font-semibold text-sm transition-colors border-b-2 flex items-center gap-1.5 ${
+                  activeTab === "featured"
+                    ? "border-[var(--hub-brand)] text-[var(--hub-brand)]"
+                    : "border-transparent text-gray-400 hover:text-gray-600"
+                }`}
+              >
+                <Award size={16} />
+                Featured
+              </button>
+            )}
             <button
               onClick={() => setActiveTab("most-watched")}
               className={`pb-3 font-semibold text-sm transition-colors border-b-2 flex items-center gap-1.5 ${
@@ -240,7 +249,7 @@ export default function HubClient({ settings, demos }: HubClientProps) {
 
         {/* Demos Grid */}
         {filteredDemos.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center bg-white rounded-2xl border border-gray-150">
+          <div className="flex flex-col items-center justify-center py-20 text-center bg-white rounded-2xl border border-gray-200">
             <Layers size={48} className="text-gray-300 mb-3" />
             <h3 className="text-lg font-bold text-gray-700">No demos found</h3>
             <p className="text-gray-400 text-sm max-w-xs mt-1">
@@ -256,7 +265,7 @@ export default function HubClient({ settings, demos }: HubClientProps) {
               return (
                 <div
                   key={demo.id}
-                  className="bg-white rounded-2xl border border-gray-150 overflow-hidden flex flex-col shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300 group"
+                  className="bg-white rounded-2xl border border-gray-200 overflow-hidden flex flex-col shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300 group"
                 >
                   {/* Thumbnail / Aspect Preview */}
                   <div className="aspect-video bg-slate-900 flex items-center justify-center relative overflow-hidden shrink-0">
@@ -275,10 +284,11 @@ export default function HubClient({ settings, demos }: HubClientProps) {
                       {demo.viewsCount} views
                     </div>
 
-                    {/* Gradient backing */}
-                    <div className="absolute inset-0 bg-gradient-to-br from-indigo-500/20 to-purple-500/20" />
-                    <span className="text-2xl font-black tracking-widest text-white/10 uppercase select-none">
-                      Marvedge
+                    {/* Brand-tinted backing. The hub is white-label, so the
+                        placeholder carries the customer's name, not ours. */}
+                    <div className="absolute inset-0 bg-[var(--hub-brand)] opacity-25" />
+                    <span className="text-2xl font-black tracking-widest text-white/10 uppercase select-none px-4 text-center line-clamp-2">
+                      {settings.hubTitle}
                     </span>
                   </div>
 
@@ -286,7 +296,7 @@ export default function HubClient({ settings, demos }: HubClientProps) {
                   <div className="p-5 flex-1 flex flex-col justify-between">
                     <div>
                       {/* Title & Description */}
-                      <h3 className="font-bold text-lg text-gray-800 line-clamp-1 mb-1.5 group-hover:text-[var(--hub-brand)] transition-colors">
+                      <h3 className="font-bold text-lg text-[var(--hub-text)] line-clamp-1 mb-1.5 group-hover:text-[var(--hub-brand)] transition-colors">
                         {demo.title}
                       </h3>
                       <p className="text-sm text-gray-500 line-clamp-2 leading-relaxed mb-4">
@@ -344,7 +354,7 @@ export default function HubClient({ settings, demos }: HubClientProps) {
       </main>
 
       {/* Footer */}
-      <footer className="bg-white border-t border-gray-150 py-6 text-center text-xs text-gray-400 mt-12 shrink-0">
+      <footer className="bg-white border-t border-gray-200 py-6 text-center text-xs text-gray-400 mt-12 shrink-0">
         <div className="max-w-7xl mx-auto px-6">
           Powered by <span className="font-bold text-gray-500">Marvedge</span> Demo Hub &copy;{" "}
           {new Date().getFullYear()}

--- a/app/hub/[domain]/page.tsx
+++ b/app/hub/[domain]/page.tsx
@@ -1,12 +1,63 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { prisma } from "@/app/lib/prisma";
+import { hubHostname } from "@/app/lib/hubDomain";
+import { isBdhEnabled } from "@/app/lib/bdh/flags";
 import HubClient from "./HubClient";
 
 type PageProps = {
   params: Promise<{ domain: string }>;
 };
 
+/** Max characters of subtitle text shipped per demo for client-side search. */
+const SUBTITLE_SEARCH_LIMIT = 2000;
+
+// The hub is white-label: inherit the customer's title/description rather than
+// the Marvedge root layout metadata.
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { domain } = await params;
+
+  const settings = await prisma.hubSettings.findFirst({
+    where: { OR: [{ subdomain: domain }, { customDomain: domain }] },
+    select: {
+      hubTitle: true,
+      hubDescription: true,
+      logoUrl: true,
+      subdomain: true,
+      customDomain: true,
+      user: { select: { name: true } },
+    },
+  });
+
+  if (!settings) {
+    return { title: "Hub not found" };
+  }
+
+  const title = settings.hubTitle || `${settings.user.name || "Product"} Demo Hub`;
+  const description = settings.hubDescription || `Browse interactive product tours from ${title}.`;
+
+  // The same hub is reachable at its subdomain, its custom domain, and the
+  // internal /hub/[key] path. Point search engines at the branded hostname so
+  // those don't compete as duplicates.
+  const canonical = `https://${hubHostname(settings)}`;
+
+  return {
+    title,
+    description,
+    icons: settings.logoUrl ? { icon: settings.logoUrl } : undefined,
+    alternates: { canonical },
+    openGraph: { title, description, type: "website", url: canonical },
+  };
+}
+
 export default async function HubPage({ params }: PageProps) {
+  // With the hub switched off, middleware stops rewriting hub hosts here — but
+  // /hub/[domain] is still directly reachable on the app domain, so the page has
+  // to honour the kill switch itself.
+  if (!isBdhEnabled()) {
+    notFound();
+  }
+
   const { domain } = await params;
 
   // Find settings
@@ -38,9 +89,8 @@ export default async function HubPage({ params }: PageProps) {
       isPublic: true,
     },
     include: {
-      views: {
-        select: { id: true },
-      },
+      // Count views in SQL instead of pulling every view row back.
+      _count: { select: { views: true } },
     },
     orderBy: {
       createdAt: "desc",
@@ -60,9 +110,14 @@ export default async function HubPage({ params }: PageProps) {
     integrations: d.integrations,
     userRoles: d.userRoles,
     featured: d.featured,
-    viewsCount: d.views.length,
+    viewsCount: d._count.views,
     subtitlesText: Array.isArray(d.subtitles)
-      ? (d.subtitles as { text?: string }[]).map((cue) => cue.text || "").join(" ")
+      ? (d.subtitles as { text?: string }[])
+          .map((cue) => cue.text || "")
+          .join(" ")
+          // Subtitles are only used to seed client-side search (BDH-4.3); cap the
+          // per-demo payload so a hub with long transcripts stays lightweight.
+          .slice(0, SUBTITLE_SEARCH_LIMIT)
       : "",
   }));
 

--- a/app/hub/[domain]/share/[slug]/page.tsx
+++ b/app/hub/[domain]/share/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { prisma } from "@/app/lib/prisma";
 import ShareVideoPageClient from "@/app/share/[slug]/ShareVideoPageClient";
+import { isBdhEnabled } from "@/app/lib/bdh/flags";
 
 type PageProps = {
   params: Promise<{ domain: string; slug: string }>;
@@ -101,6 +102,12 @@ function backgroundStyleFromEditing(editing: unknown, fallbackColor: string) {
 }
 
 export default async function BrandedSharePage({ params }: PageProps) {
+  // Mirrors the hub index: the kill switch has to hold on the directly
+  // reachable /hub/... path too, not just on rewritten hub hosts.
+  if (!isBdhEnabled()) {
+    notFound();
+  }
+
   const { domain, slug } = await params;
 
   // Find settings to apply brand colors
@@ -110,9 +117,17 @@ export default async function BrandedSharePage({ params }: PageProps) {
     },
   });
 
+  if (!settings) {
+    notFound();
+  }
+
+  // Scope the lookup to the hub owner: a branded domain must only ever serve its
+  // own demos, otherwise any tenant's public demo renders under someone else's
+  // logo and colours.
   const demo = await prisma.demo.findFirst({
     where: {
       isPublic: true,
+      userId: settings.userId,
       OR: [{ publicLink: slug }, { id: slug }],
     },
     select: {
@@ -133,7 +148,7 @@ export default async function BrandedSharePage({ params }: PageProps) {
     notFound();
   }
 
-  const fallbackColor = settings?.accentColor || "#F3F0FC";
+  const fallbackColor = settings.accentColor || "#F3F0FC";
 
   return (
     <ShareVideoPageClient

--- a/app/lib/bdh/access.ts
+++ b/app/lib/bdh/access.ts
@@ -1,0 +1,26 @@
+// PRO-gate for BDH custom domains, mirroring the split WTM uses.
+//
+// The hub itself is free for everyone: any user gets a branded showcase at their
+// Marvedge subdomain (`acme.marvedge.com`), with logo, colours, search and
+// collections. That is the growth surface and gating it would defeat the point.
+//
+// Mapping your OWN domain (`demos.mycompany.com`) is the paid, white-label half.
+// It is also the only part with a marginal cost to us — Cloudflare SSL for SaaS
+// bills per custom hostname — so an unbounded free tier would let anyone spend
+// our money. PRO and ENTERPRISE only, exactly like the customizable watermark.
+//
+// The User.plan column is a plain string defaulting to "FREE" (see
+// prisma/schema.prisma), with paid tiers stored as "PRO" / "ENTERPRISE".
+
+const CUSTOM_DOMAIN_ALLOWED_PLANS = ["PRO", "ENTERPRISE"] as const;
+
+/**
+ * Whether a user on the given plan may map a custom domain to their hub. Server
+ * routes should call this after resolving the user's plan and reject when it
+ * returns false; the hub and its Marvedge subdomain stay available regardless.
+ */
+export function isCustomDomainAllowed(plan: string | null | undefined): boolean {
+  return (
+    typeof plan === "string" && (CUSTOM_DOMAIN_ALLOWED_PLANS as readonly string[]).includes(plan)
+  );
+}

--- a/app/lib/bdh/flags.test.ts
+++ b/app/lib/bdh/flags.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { isBdhEnabled, isBdhRoutingEnabled } from "./flags";
+import { isCustomDomainAllowed } from "./access";
+
+const original = {
+  server: process.env.BDH_ENABLED,
+  client: process.env.NEXT_PUBLIC_BDH_ENABLED,
+};
+
+afterEach(() => {
+  process.env.BDH_ENABLED = original.server;
+  process.env.NEXT_PUBLIC_BDH_ENABLED = original.client;
+});
+
+// BDH is opt-OUT, the reverse of AVS/WTM: it already ships enabled, so an unset
+// variable must keep it on. Getting this backwards silently disables a live
+// feature on the next deploy.
+describe("BDH flags", () => {
+  it("stays enabled when unset", () => {
+    delete process.env.BDH_ENABLED;
+    delete process.env.NEXT_PUBLIC_BDH_ENABLED;
+    expect(isBdhEnabled()).toBe(true);
+    expect(isBdhRoutingEnabled()).toBe(true);
+  });
+
+  it("stays enabled for any value that is not an explicit off switch", () => {
+    process.env.BDH_ENABLED = "true";
+    expect(isBdhEnabled()).toBe(true);
+
+    process.env.BDH_ENABLED = "";
+    expect(isBdhEnabled()).toBe(true);
+  });
+
+  it("disables only on an explicit false or 0", () => {
+    process.env.BDH_ENABLED = "false";
+    expect(isBdhEnabled()).toBe(false);
+
+    process.env.BDH_ENABLED = "0";
+    expect(isBdhEnabled()).toBe(false);
+
+    process.env.NEXT_PUBLIC_BDH_ENABLED = "false";
+    expect(isBdhRoutingEnabled()).toBe(false);
+  });
+});
+
+describe("isCustomDomainAllowed", () => {
+  it("allows paid plans", () => {
+    expect(isCustomDomainAllowed("PRO")).toBe(true);
+    expect(isCustomDomainAllowed("ENTERPRISE")).toBe(true);
+  });
+
+  it("refuses free and unknown plans", () => {
+    expect(isCustomDomainAllowed("FREE")).toBe(false);
+    expect(isCustomDomainAllowed(null)).toBe(false);
+    expect(isCustomDomainAllowed(undefined)).toBe(false);
+    expect(isCustomDomainAllowed("pro")).toBe(false);
+  });
+});

--- a/app/lib/bdh/flags.ts
+++ b/app/lib/bdh/flags.ts
@@ -1,0 +1,31 @@
+// Feature flags for BDH (Branded Demo Hub & Hosting Infrastructure).
+//
+// Unlike AVS and WTM, BDH is opt-OUT rather than opt-in: it already shipped to
+// master and is serving traffic, so an unset env var must keep it working. Only
+// an explicit "false"/"0" disables it. The flag exists as an ops lever — hub
+// routing lives in middleware and affects every request, so being able to switch
+// it off without a revert is worth the indirection.
+//
+//   - BDH_ENABLED             — server-only master switch (never sent to browser).
+//   - NEXT_PUBLIC_BDH_ENABLED — client-safe switch; also read by middleware,
+//                               which needs a build-inlined value at the edge.
+
+const disabled = (value: string | undefined): boolean => value === "false" || value === "0";
+
+/**
+ * Server-side BDH master switch, gating the hub settings and domain APIs. Reads
+ * the server-only `BDH_ENABLED` env var, so this must only be called from server
+ * code (API routes, server components).
+ */
+export function isBdhEnabled(): boolean {
+  return !disabled(process.env.BDH_ENABLED);
+}
+
+/**
+ * Client-safe switch gating hub host routing and the Branding settings tab.
+ * Reads `NEXT_PUBLIC_BDH_ENABLED`, which Next inlines at build time so it is
+ * safe to call from client components and from middleware at the edge.
+ */
+export function isBdhRoutingEnabled(): boolean {
+  return !disabled(process.env.NEXT_PUBLIC_BDH_ENABLED);
+}

--- a/app/lib/bdh/taxonomy.test.ts
+++ b/app/lib/bdh/taxonomy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { MAX_TAXONOMY_ENTRIES, MAX_TAXONOMY_LENGTH, normalizeTaxonomy } from "./taxonomy";
+
+describe("normalizeTaxonomy", () => {
+  it("returns undefined for anything that is not an array", () => {
+    // Callers rely on this to tell "field omitted" from "field cleared", which
+    // is what stops a PATCH without tags from wiping the demo's tags.
+    expect(normalizeTaxonomy(undefined)).toBeUndefined();
+    expect(normalizeTaxonomy(null)).toBeUndefined();
+    expect(normalizeTaxonomy("slack,hubspot")).toBeUndefined();
+    expect(normalizeTaxonomy({ 0: "slack" })).toBeUndefined();
+  });
+
+  it("distinguishes an explicitly emptied list from an omitted one", () => {
+    expect(normalizeTaxonomy([])).toEqual([]);
+  });
+
+  it("trims entries and drops blanks", () => {
+    expect(normalizeTaxonomy(["  Slack  ", "", "   ", "HubSpot"])).toEqual(["Slack", "HubSpot"]);
+  });
+
+  it("de-duplicates so one filter pill is not rendered twice", () => {
+    expect(normalizeTaxonomy(["Slack", " Slack ", "Slack"])).toEqual(["Slack"]);
+  });
+
+  it("drops non-string entries rather than letting Prisma 500", () => {
+    expect(normalizeTaxonomy([1, "Slack", null, { a: 1 }, ["x"], true, "Zoom"])).toEqual([
+      "Slack",
+      "Zoom",
+    ]);
+  });
+
+  it("caps the number of entries", () => {
+    const many = Array.from({ length: MAX_TAXONOMY_ENTRIES + 20 }, (_, i) => `tag-${i}`);
+    expect(normalizeTaxonomy(many)).toHaveLength(MAX_TAXONOMY_ENTRIES);
+  });
+
+  it("caps the length of each entry", () => {
+    const long = "x".repeat(MAX_TAXONOMY_LENGTH + 50);
+    expect(normalizeTaxonomy([long])).toEqual(["x".repeat(MAX_TAXONOMY_LENGTH)]);
+  });
+
+  it("preserves the author's ordering", () => {
+    expect(normalizeTaxonomy(["Zoom", "Ada", "Manager"])).toEqual(["Zoom", "Ada", "Manager"]);
+  });
+});

--- a/app/lib/bdh/taxonomy.ts
+++ b/app/lib/bdh/taxonomy.ts
@@ -1,0 +1,44 @@
+// Normalization for the demo taxonomy that powers the hub's search and filters
+// (BDH-4.3 Meta Taxonomy Search, BDH-4.4 Category Collections).
+//
+// These values are supplied by the client, stored as Postgres TEXT[], and then
+// rendered on a public hub page and shipped to every visitor as filter options.
+// So they are normalized on the way in rather than trusted:
+//
+//   - non-strings are dropped, because Prisma rejects them with a 500 rather
+//     than a useful validation error;
+//   - entries are trimmed and de-duplicated, so "Slack" and " slack " don't
+//     become two filter pills;
+//   - both the entry count and each entry's length are bounded, so one demo
+//     cannot bloat the payload every hub visitor downloads.
+
+export const MAX_TAXONOMY_ENTRIES = 25;
+export const MAX_TAXONOMY_LENGTH = 60;
+
+/**
+ * Normalize one taxonomy array (tags / integrations / userRoles).
+ *
+ * Returns `undefined` when the input is not an array at all, which callers use
+ * to distinguish "field omitted, leave it alone" from "field set to empty".
+ */
+export function normalizeTaxonomy(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim().slice(0, MAX_TAXONOMY_LENGTH);
+    if (trimmed) {
+      seen.add(trimmed);
+    }
+    if (seen.size >= MAX_TAXONOMY_ENTRIES) {
+      break;
+    }
+  }
+
+  return Array.from(seen);
+}

--- a/app/lib/cloudflare.ts
+++ b/app/lib/cloudflare.ts
@@ -1,3 +1,5 @@
+import { HUB_CNAME_TARGET } from "./hubDomain";
+
 export interface CloudflareHostnameResponse {
   success: boolean;
   id?: string;
@@ -13,6 +15,30 @@ export interface CloudflareHostnameResponse {
   error?: string;
 }
 
+const MOCK_ID_PREFIX = "mock_cf_hostname_";
+
+/**
+ * Cloudflare is only mocked outside production. In production, missing
+ * credentials must surface as an error — otherwise a customer is told their
+ * domain is registered and SSL is active when nothing was ever provisioned.
+ */
+function isMockable(): boolean {
+  return process.env.NODE_ENV !== "production";
+}
+
+const MISSING_CREDENTIALS_ERROR =
+  "Custom domains are not configured on this deployment. Set CF_ZONE_ID, CF_AUTH_EMAIL and CF_AUTH_KEY.";
+
+function mockVerification(customHostname: string) {
+  return {
+    cnameTarget: HUB_CNAME_TARGET,
+    txtRecordName: `_cf-custom-hostname.${customHostname}`,
+    txtRecordValue: "vc-mock-ownership-verification-token-123456789",
+    sslTxtName: `_acme-challenge.${customHostname}`,
+    sslTxtValue: "vc-mock-ssl-acme-validation-token-abcdefgh",
+  };
+}
+
 export async function registerCustomDomain(
   customHostname: string
 ): Promise<CloudflareHostnameResponse> {
@@ -21,22 +47,23 @@ export async function registerCustomDomain(
   const CF_AUTH_KEY = process.env.CF_AUTH_KEY;
 
   if (!CF_ZONE_ID || !CF_AUTH_EMAIL || !CF_AUTH_KEY) {
+    if (!isMockable()) {
+      console.error(
+        "Cloudflare environment variables are missing; refusing to fake a custom hostname registration in production."
+      );
+      return { success: false, error: MISSING_CREDENTIALS_ERROR };
+    }
+
     console.warn(
       "Cloudflare environment variables are missing. Using mock response for development."
     );
     // Return mock verification records for development/localhost testing
     return {
       success: true,
-      id: "mock_cf_hostname_" + Math.random().toString(36).substring(7),
+      id: MOCK_ID_PREFIX + Math.random().toString(36).substring(7),
       status: "pending",
       sslStatus: "pending",
-      dnsVerification: {
-        cnameTarget: "hub-ingress.marvedge.io",
-        txtRecordName: `_cf-custom-hostname.${customHostname}`,
-        txtRecordValue: "vc-mock-ownership-verification-token-123456789",
-        sslTxtName: `_acme-challenge.${customHostname}`,
-        sslTxtValue: "vc-mock-ssl-acme-validation-token-abcdefgh",
-      },
+      dnsVerification: mockVerification(customHostname),
     };
   }
 
@@ -78,7 +105,7 @@ export async function registerCustomDomain(
     const result = data.result;
 
     // Extract DNS verification records
-    const cnameTarget = "hub-ingress.marvedge.io";
+    const cnameTarget = HUB_CNAME_TARGET;
     const txtRecordName =
       result.ownership_verification?.name || `_cf-custom-hostname.${customHostname}`;
     const txtRecordValue = result.ownership_verification?.value || "";
@@ -123,12 +150,18 @@ export async function deleteCustomDomain(
     return { success: true };
   }
 
-  if (
-    cloudflareId.startsWith("mock_cf_hostname_") ||
-    !CF_ZONE_ID ||
-    !CF_AUTH_EMAIL ||
-    !CF_AUTH_KEY
-  ) {
+  if (cloudflareId.startsWith(MOCK_ID_PREFIX)) {
+    console.log("Mock deleting custom hostname:", cloudflareId);
+    return { success: true };
+  }
+
+  if (!CF_ZONE_ID || !CF_AUTH_EMAIL || !CF_AUTH_KEY) {
+    if (!isMockable()) {
+      // A real hostname exists in Cloudflare but we cannot reach the API to
+      // remove it — report the failure so the orphan is not silently ignored.
+      console.error("Cloudflare credentials missing; cannot delete hostname", cloudflareId);
+      return { success: false, error: MISSING_CREDENTIALS_ERROR };
+    }
     console.log("Mock deleting custom hostname:", cloudflareId);
     return { success: true };
   }
@@ -171,25 +204,22 @@ export async function getCustomDomainStatus(
     return { success: false, error: "Missing Cloudflare ID" };
   }
 
-  if (
-    cloudflareId.startsWith("mock_cf_hostname_") ||
-    !CF_ZONE_ID ||
-    !CF_AUTH_EMAIL ||
-    !CF_AUTH_KEY
-  ) {
+  const isMock =
+    cloudflareId.startsWith(MOCK_ID_PREFIX) || !CF_ZONE_ID || !CF_AUTH_EMAIL || !CF_AUTH_KEY;
+
+  if (isMock && !isMockable()) {
+    // Never report a mocked hostname as verified in production.
+    return { success: false, error: MISSING_CREDENTIALS_ERROR };
+  }
+
+  if (isMock) {
     // Mock transitioning from pending to active for testing
     return {
       success: true,
       id: cloudflareId,
       status: "active",
       sslStatus: "active",
-      dnsVerification: {
-        cnameTarget: "hub-ingress.marvedge.io",
-        txtRecordName: `_cf-custom-hostname.${customHostname}`,
-        txtRecordValue: "vc-mock-ownership-verification-token-123456789",
-        sslTxtName: `_acme-challenge.${customHostname}`,
-        sslTxtValue: "vc-mock-ssl-acme-validation-token-abcdefgh",
-      },
+      dnsVerification: mockVerification(customHostname),
     };
   }
 
@@ -216,7 +246,7 @@ export async function getCustomDomainStatus(
     }
 
     const result = data.result;
-    const cnameTarget = "hub-ingress.marvedge.io";
+    const cnameTarget = HUB_CNAME_TARGET;
     const txtRecordName =
       result.ownership_verification?.name || `_cf-custom-hostname.${customHostname}`;
     const txtRecordValue = result.ownership_verification?.value || "";
@@ -241,6 +271,85 @@ export async function getCustomDomainStatus(
         sslTxtValue,
       },
     };
+  } catch (error) {
+    return { success: false, error: (error as Error).message };
+  }
+}
+
+export interface CloudflareHostnameSummary {
+  id: string;
+  hostname: string;
+  status?: string;
+  sslStatus?: string;
+}
+
+/**
+ * Enumerate every custom hostname on the zone. Used by the reconciliation sweep
+ * to spot hostnames that still route to us but no longer have a hub behind them
+ * (PRD §4.4 — a deleted account must not leave its subdomain live).
+ */
+export async function listCustomHostnames(): Promise<
+  { success: true; hostnames: CloudflareHostnameSummary[] } | { success: false; error: string }
+> {
+  const CF_ZONE_ID = process.env.CF_ZONE_ID;
+  const CF_AUTH_EMAIL = process.env.CF_AUTH_EMAIL;
+  const CF_AUTH_KEY = process.env.CF_AUTH_KEY;
+
+  if (!CF_ZONE_ID || !CF_AUTH_EMAIL || !CF_AUTH_KEY) {
+    // Nothing to reconcile against without credentials; not an error in dev.
+    return isMockable()
+      ? { success: true, hostnames: [] }
+      : { success: false, error: MISSING_CREDENTIALS_ERROR };
+  }
+
+  const hostnames: CloudflareHostnameSummary[] = [];
+  const perPage = 50;
+  // Bounded so a huge zone can never spin the cron indefinitely.
+  const maxPages = 20;
+
+  try {
+    for (let page = 1; page <= maxPages; page++) {
+      const url = `https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/custom_hostnames?page=${page}&per_page=${perPage}`;
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          "X-Auth-Email": CF_AUTH_EMAIL,
+          "X-Auth-Key": CF_AUTH_KEY,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        return { success: false, error: await response.text() };
+      }
+
+      const data = await response.json();
+      if (!data.success) {
+        return { success: false, error: data.errors?.[0]?.message || "Cloudflare API error" };
+      }
+
+      const batch = (data.result || []) as Array<{
+        id: string;
+        hostname: string;
+        status?: string;
+        ssl?: { status?: string };
+      }>;
+
+      for (const row of batch) {
+        hostnames.push({
+          id: row.id,
+          hostname: row.hostname,
+          status: row.status,
+          sslStatus: row.ssl?.status,
+        });
+      }
+
+      if (batch.length < perPage) {
+        break;
+      }
+    }
+
+    return { success: true, hostnames };
   } catch (error) {
     return { success: false, error: (error as Error).message };
   }

--- a/app/lib/hubDomain.test.ts
+++ b/app/lib/hubDomain.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyHost,
+  hubHostname,
+  isClaimableSubdomain,
+  mainAppOrigin,
+  normalizeSubdomainLabel,
+  stripPort,
+  validateCustomDomain,
+} from "./hubDomain";
+
+// These tests pin the default configuration (NEXT_PUBLIC_ROOT_DOMAIN unset ->
+// "marvedge.com"). The classification is load-bearing: misrouting the app's own
+// apex rewrites every page to a hub and takes the whole site down.
+
+describe("stripPort", () => {
+  it("removes the port from host headers", () => {
+    expect(stripPort("localhost:3000")).toBe("localhost");
+    expect(stripPort("demos.mycompany.com")).toBe("demos.mycompany.com");
+  });
+
+  it("keeps bracketed IPv6 literals intact", () => {
+    expect(stripPort("[::1]:3000")).toBe("[::1]");
+  });
+});
+
+describe("classifyHost", () => {
+  it("treats the app's own domain as main", () => {
+    expect(classifyHost("marvedge.com").kind).toBe("main");
+    expect(classifyHost("www.marvedge.com").kind).toBe("main");
+    expect(classifyHost("MARVEDGE.COM").kind).toBe("main");
+  });
+
+  it("treats dev and Vercel hosts as main on any port", () => {
+    expect(classifyHost("localhost:3000").kind).toBe("main");
+    expect(classifyHost("localhost:3001").kind).toBe("main");
+    expect(classifyHost("127.0.0.1:3000").kind).toBe("main");
+    expect(classifyHost("marvedge.vercel.app").kind).toBe("main");
+    expect(classifyHost("marvedge-git-feature-x.vercel.app").kind).toBe("main");
+  });
+
+  it("maps a hub subdomain to its label", () => {
+    expect(classifyHost("acme-cmn5tm26.marvedge.com")).toEqual({
+      kind: "subdomain",
+      domainKey: "acme-cmn5tm26",
+    });
+  });
+
+  it("supports subdomain routing locally on any port", () => {
+    expect(classifyHost("acme-cmn5tm26.localhost:3000")).toEqual({
+      kind: "subdomain",
+      domainKey: "acme-cmn5tm26",
+    });
+  });
+
+  it("maps a mapped custom domain to its full hostname, without the port", () => {
+    expect(classifyHost("demos.mycompany.com")).toEqual({
+      kind: "custom",
+      domainKey: "demos.mycompany.com",
+    });
+    expect(classifyHost("demos.mycompany.com:3000")).toEqual({
+      kind: "custom",
+      domainKey: "demos.mycompany.com",
+    });
+  });
+
+  it("falls back to the app rather than hijacking ambiguous hosts", () => {
+    // Multi-label subdomains are not hub keys.
+    expect(classifyHost("a.b.marvedge.com").kind).toBe("main");
+    expect(classifyHost("").kind).toBe("main");
+  });
+});
+
+describe("mainAppOrigin", () => {
+  it("preserves the local port so dev redirects do not dead-end", () => {
+    expect(mainAppOrigin("acme.localhost:3001")).toBe("http://localhost:3001");
+  });
+
+  it("sends hub visitors back to the app apex over https", () => {
+    expect(mainAppOrigin("demos.mycompany.com")).toBe("https://marvedge.com");
+  });
+});
+
+describe("validateCustomDomain", () => {
+  it("accepts a normal delegated hostname", () => {
+    expect(validateCustomDomain("  Demos.MyCompany.com ")).toEqual({
+      ok: true,
+      hostname: "demos.mycompany.com",
+    });
+  });
+
+  it("strips a trailing dot and any port", () => {
+    expect(validateCustomDomain("demos.mycompany.com.")).toEqual({
+      ok: true,
+      hostname: "demos.mycompany.com",
+    });
+  });
+
+  it("rejects malformed input before it reaches Cloudflare", () => {
+    for (const bad of [
+      "",
+      "notadomain",
+      "https://demos.mycompany.com",
+      "demos.mycompany.com/path",
+      "has space.com",
+      "-leadinghyphen.com",
+    ]) {
+      expect(validateCustomDomain(bad).ok, bad).toBe(false);
+    }
+  });
+
+  it("rejects domains we control, which cannot be Cloudflare custom hostnames", () => {
+    expect(validateCustomDomain("marvedge.com").ok).toBe(false);
+    expect(validateCustomDomain("acme.marvedge.com").ok).toBe(false);
+    expect(validateCustomDomain("evil.vercel.app").ok).toBe(false);
+  });
+});
+
+describe("normalizeSubdomainLabel", () => {
+  it("lowercases and strips characters illegal in a DNS label", () => {
+    expect(normalizeSubdomainLabel("  Acme Corp!  ")).toBe("acmecorp");
+    expect(normalizeSubdomainLabel("my-company")).toBe("my-company");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(normalizeSubdomainLabel("--acme--")).toBe("acme");
+  });
+
+  it("caps the label at the 63-character DNS limit without a trailing hyphen", () => {
+    const label = normalizeSubdomainLabel("a".repeat(70));
+    expect(label).toHaveLength(63);
+
+    const hyphenated = normalizeSubdomainLabel(`${"a".repeat(62)}-extra`);
+    expect(hyphenated?.endsWith("-")).toBe(false);
+  });
+
+  it("returns null when nothing usable survives", () => {
+    expect(normalizeSubdomainLabel("!!!")).toBeNull();
+    expect(normalizeSubdomainLabel("   ")).toBeNull();
+  });
+});
+
+describe("isClaimableSubdomain", () => {
+  it("allows ordinary names", () => {
+    expect(isClaimableSubdomain("acme")).toBe(true);
+  });
+
+  it("refuses reserved platform names", () => {
+    for (const reserved of ["www", "api", "admin", "hub", "marvedge", "hub-ingress"]) {
+      expect(isClaimableSubdomain(reserved), reserved).toBe(false);
+    }
+  });
+
+  it("refuses names too short to be distinctive", () => {
+    expect(isClaimableSubdomain("ab")).toBe(false);
+  });
+});
+
+describe("hubHostname", () => {
+  it("prefers the custom domain when one is mapped", () => {
+    expect(hubHostname({ subdomain: "acme", customDomain: "demos.mycompany.com" })).toBe(
+      "demos.mycompany.com"
+    );
+  });
+
+  it("falls back to the Marvedge subdomain", () => {
+    expect(hubHostname({ subdomain: "acme", customDomain: null })).toBe("acme.marvedge.com");
+  });
+});

--- a/app/lib/hubDomain.ts
+++ b/app/lib/hubDomain.ts
@@ -1,0 +1,222 @@
+/**
+ * Single source of truth for the domains the Branded Demo Hub is served from.
+ *
+ * The middleware, the settings UI and the public hub all need to agree on which
+ * hostnames are "the app" and which are a customer hub, so every one of them
+ * reads from here instead of hard-coding a domain.
+ *
+ * - NEXT_PUBLIC_ROOT_DOMAIN      apex the app itself is served from.
+ * - NEXT_PUBLIC_HUB_ROOT_DOMAIN  apex customer hub subdomains hang off
+ *                                (`acme-cmn5tm26.<hub root>`). Defaults to the
+ *                                app root, so a single-domain deploy needs no
+ *                                extra configuration.
+ * - NEXT_PUBLIC_HUB_CNAME_TARGET record customers point their CNAME at.
+ */
+export const ROOT_DOMAIN = (process.env.NEXT_PUBLIC_ROOT_DOMAIN || "marvedge.com").toLowerCase();
+
+export const HUB_ROOT_DOMAIN = (
+  process.env.NEXT_PUBLIC_HUB_ROOT_DOMAIN || ROOT_DOMAIN
+).toLowerCase();
+
+export const HUB_CNAME_TARGET = (
+  process.env.NEXT_PUBLIC_HUB_CNAME_TARGET || "hub-ingress.marvedge.io"
+).toLowerCase();
+
+/** Apexes whose single-label subdomains resolve to a hub. */
+const HUB_APEXES = Array.from(new Set([ROOT_DOMAIN, HUB_ROOT_DOMAIN]));
+
+/** Hostnames that are always the app itself, never a hub. */
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]", "::1"]);
+
+export type HubHost =
+  /** The app itself — render the normal marketing/app routes. */
+  | { kind: "main"; domainKey: null }
+  /** `acme-cmn5tm26.marvedge.com` — key is the subdomain label. */
+  | { kind: "subdomain"; domainKey: string }
+  /** `demos.mycompany.com` — key is the full hostname. */
+  | { kind: "custom"; domainKey: string };
+
+const MAIN: HubHost = { kind: "main", domainKey: null };
+
+/**
+ * Drop the port from a Host header value. Handles bracketed IPv6 literals
+ * (`[::1]:3000`) so local development on any port resolves the same way.
+ */
+export function stripPort(host: string): string {
+  if (host.startsWith("[")) {
+    const close = host.indexOf("]");
+    return close === -1 ? host : host.slice(0, close + 1);
+  }
+  const colon = host.indexOf(":");
+  return colon === -1 ? host : host.slice(0, colon);
+}
+
+/**
+ * Decide whether an incoming Host header is the app, a hub subdomain, or a
+ * mapped custom domain. Anything ambiguous falls back to "main" so an
+ * unexpected host degrades to the normal app rather than a 404 hub.
+ */
+export function classifyHost(rawHost: string): HubHost {
+  const host = stripPort(rawHost).trim().toLowerCase();
+  if (!host) {
+    return MAIN;
+  }
+
+  // Local dev and Vercel production/preview deployments are always the app.
+  if (LOCAL_HOSTS.has(host) || host.endsWith(".vercel.app")) {
+    return MAIN;
+  }
+
+  // `acme.localhost:3000` — lets subdomain routing be exercised locally.
+  if (host.endsWith(".localhost")) {
+    const key = host.slice(0, -".localhost".length);
+    return key && key !== "www" && !key.includes(".")
+      ? { kind: "subdomain", domainKey: key }
+      : MAIN;
+  }
+
+  for (const apex of HUB_APEXES) {
+    if (host === apex || host === `www.${apex}`) {
+      return MAIN;
+    }
+    if (host.endsWith(`.${apex}`)) {
+      const key = host.slice(0, host.length - apex.length - 1);
+      // Only single-label subdomains are hub keys; deeper hosts are not hubs.
+      return key && !key.includes(".") ? { kind: "subdomain", domainKey: key } : MAIN;
+    }
+  }
+
+  return { kind: "custom", domainKey: host };
+}
+
+/**
+ * Origin to send a visitor back to when they hit an app-only route (dashboard,
+ * auth) on a hub host. Preserves the local port so dev redirects don't dead-end.
+ */
+export function mainAppOrigin(rawHost: string): string {
+  const host = stripPort(rawHost).toLowerCase();
+  if (LOCAL_HOSTS.has(host) || host.endsWith(".localhost")) {
+    const colon = rawHost.lastIndexOf(":");
+    const port = colon > rawHost.lastIndexOf("]") ? rawHost.slice(colon) : "";
+    return `http://localhost${port}`;
+  }
+  return `https://${ROOT_DOMAIN}`;
+}
+
+/** Public hostname a hub is reachable at, for display in the UI. */
+export function hubHostname(settings: {
+  subdomain?: string | null;
+  customDomain?: string | null;
+}): string {
+  if (settings.customDomain) {
+    return settings.customDomain;
+  }
+  return settings.subdomain ? `${settings.subdomain}.${HUB_ROOT_DOMAIN}` : HUB_ROOT_DOMAIN;
+}
+
+/**
+ * Subdomains a customer may not claim: platform hostnames, the routing gateway,
+ * and the usual infrastructure names. Claiming any of these would shadow a real
+ * host or let a tenant impersonate Marvedge itself.
+ */
+export const RESERVED_SUBDOMAINS = new Set([
+  "admin",
+  "api",
+  "app",
+  "assets",
+  "auth",
+  "blog",
+  "cdn",
+  "dashboard",
+  "demo",
+  "demos",
+  "dev",
+  "docs",
+  "ftp",
+  "help",
+  "hub",
+  "hub-ingress",
+  "internal",
+  "localhost",
+  "login",
+  "mail",
+  "marvedge",
+  "ns1",
+  "ns2",
+  "preview",
+  "public",
+  "root",
+  "settings",
+  "share",
+  "smtp",
+  "staging",
+  "static",
+  "status",
+  "support",
+  "test",
+  "user",
+  "webmail",
+  "www",
+]);
+
+/**
+ * Normalize a user-supplied subdomain into a legal DNS label. Returns null when
+ * nothing usable survives, so the caller can fall back to a generated name.
+ */
+export function normalizeSubdomainLabel(input: string): string | null {
+  const label = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 63)
+    .replace(/-+$/g, "");
+
+  return label || null;
+}
+
+/**
+ * Whether a normalized label may be claimed as-is. Reserved names and labels
+ * short enough to be confusable are pushed to the suffixed form instead.
+ */
+export function isClaimableSubdomain(label: string): boolean {
+  return label.length >= 3 && !RESERVED_SUBDOMAINS.has(label);
+}
+
+// Labels: 1-63 chars, alphanumeric or hyphen, no leading/trailing hyphen.
+const HOSTNAME_RE = /^(?!-)[a-z0-9-]{1,63}(?<!-)(\.(?!-)[a-z0-9-]{1,63}(?<!-))+$/;
+
+/**
+ * Validate a customer-supplied custom domain before it is handed to Cloudflare.
+ * Rejects malformed hostnames and any host under a domain we control, which
+ * Cloudflare cannot issue a custom hostname for and which would otherwise let a
+ * tenant squat a platform hostname.
+ */
+export function validateCustomDomain(
+  input: string
+): { ok: true; hostname: string } | { ok: false; error: string } {
+  const hostname = stripPort(input.trim().toLowerCase()).replace(/\.$/, "");
+
+  if (!hostname) {
+    return { ok: false, error: "Custom domain is required" };
+  }
+  if (hostname.length > 253) {
+    return { ok: false, error: "Custom domain is too long" };
+  }
+  if (!HOSTNAME_RE.test(hostname)) {
+    return {
+      ok: false,
+      error: "Enter a valid domain such as demos.mycompany.com (no protocol, path or port)",
+    };
+  }
+
+  const reserved = [...HUB_APEXES, "localhost", "vercel.app"];
+  if (reserved.some((apex) => hostname === apex || hostname.endsWith(`.${apex}`))) {
+    return {
+      ok: false,
+      error: `${hostname} is a Marvedge-managed domain. Use your Marvedge subdomain instead, or enter a domain you own.`,
+    };
+  }
+
+  return { ok: true, hostname };
+}

--- a/docs/branded-demo-hub-deployment.md
+++ b/docs/branded-demo-hub-deployment.md
@@ -1,0 +1,190 @@
+# Branded Demo Hub (BDH) — deployment runbook
+
+The hub code is complete, but custom domains are an infrastructure feature: the
+application cannot provision DNS, buy a Cloudflare add-on, or register hostnames
+with the hosting platform on its own. This is everything that has to exist
+outside the repo before BDH works end to end, in the order it has to happen.
+
+Nothing here is optional for custom domains. Marvedge-subdomain hubs
+(`acme.marvedge.com`) need only steps 1, 2 and 5.
+
+---
+
+## 1. Apply the database migration
+
+The feature adds the `HubSettings` table plus four `Demo` columns. The original
+PR changed `schema.prisma` without generating a migration, so a database built
+from `prisma migrate deploy` has neither.
+
+```bash
+npx prisma migrate deploy
+```
+
+The migration (`20260729000000_add_hub_settings_and_demo_metadata`) is written
+idempotently, so it is safe to run against a database that already has these
+objects from an earlier `prisma db push`.
+
+**Verify:** `SELECT to_regclass('"HubSettings"');` returns non-null, and
+`\d "Demo"` shows `tags`, `integrations`, `userRoles`, `featured`.
+
+---
+
+## 2. Set the domain environment variables
+
+| Variable | Value | Notes |
+| --- | --- | --- |
+| `NEXT_PUBLIC_ROOT_DOMAIN` | `marvedge.com` | Apex the app is served from. **Must match production exactly** — any host that is not this (or a dev/preview host) is treated as a customer hub. |
+| `NEXT_PUBLIC_HUB_ROOT_DOMAIN` | blank, or a separate apex | Leave blank to serve hubs as subdomains of the root domain. |
+| `NEXT_PUBLIC_HUB_CNAME_TARGET` | `hub-ingress.marvedge.io` | What customers point their CNAME at. Shown verbatim in the settings UI. |
+
+> These are `NEXT_PUBLIC_*` and are **inlined at build time**. Changing them
+> requires a redeploy, not just an env update.
+
+---
+
+## 3. Wildcard DNS + hosting platform registration
+
+Two separate things, both required. This is the step most likely to be missed,
+because DNS can look correct while the origin still refuses the request.
+
+**a. DNS.** Add a wildcard record for hub subdomains:
+
+```
+*.marvedge.com    CNAME    <hosting origin>
+```
+
+**b. Register the wildcard with the host.** Vercel serves a request only if the
+hostname is attached to a project — an unregistered `Host` header gets a
+platform 404 that never reaches our middleware. Add `*.marvedge.com` as a domain
+on the Vercel project.
+
+For **customer** domains (`demos.mycompany.com`) the traffic arrives via
+Cloudflare (step 4) with the customer's `Host` header preserved, so the origin
+must accept arbitrary hostnames. Either:
+
+- attach a wildcard domain to the project and let Cloudflare proxy to it, or
+- call the Vercel Domains API to attach each custom hostname when it is
+  registered.
+
+The application currently does **neither** — it registers the hostname with
+Cloudflare only. Whichever route is chosen has to be set up here, and if the
+API route is chosen it also needs building.
+
+**Verify:** `curl -I https://anything.marvedge.com` returns a Marvedge response
+(a hub 404 page is fine — a *platform* 404 is not).
+
+---
+
+## 4. Cloudflare SSL for SaaS
+
+1. **Enable Cloudflare for SaaS** on the zone. It is a paid add-on billed per
+   custom hostname; the feature cannot work until it is on the account.
+2. **Create the ingress record.** `hub-ingress.marvedge.io` must exist and
+   resolve to the origin — it is the CNAME target every customer is told to use.
+3. **Set a fallback origin** on the zone. Without one, verified custom hostnames
+   still will not route.
+4. **Set the API credentials:**
+
+   ```
+   CF_ZONE_ID=...
+   CF_AUTH_EMAIL=...
+   CF_AUTH_KEY=...
+   ```
+
+   Per PRD §4.3 these are the Global API Key headers. That key grants full
+   account access — **recommend migrating to a scoped API token** limited to
+   `Zone → SSL and Certificates → Edit` on this zone alone.
+
+If these are unset, custom domains are mocked in development and **rejected in
+production**. They are never silently faked — an earlier version reported
+domains as active with nothing provisioned.
+
+**Verify:** save a custom domain in Settings → Branding and confirm the hostname
+appears under Cloudflare → SSL/TLS → Custom Hostnames.
+
+---
+
+## 5. Cron for asynchronous verification
+
+PRD §4.3 requires ownership/SSL verification to run as a backend process rather
+than depending on the user refreshing the page. `vercel.json` schedules
+`/api/cron/hub-domains` every 15 minutes to poll pending certificates and sweep
+for orphaned hostnames.
+
+> **Requires a Vercel Pro plan.** Hobby projects are limited to cron jobs that
+> run at most once per day, and the `*/15 * * * *` schedule will not be
+> accepted. On Hobby, either drop to a daily schedule (certificates then take up
+> to a day to flip to active on their own) or trigger the route from an external
+> scheduler with the same `Authorization: Bearer $CRON_SECRET` header.
+
+```
+CRON_SECRET=<random string>
+```
+
+Vercel sends this as `Authorization: Bearer $CRON_SECRET`. **Required in
+production** — the route refuses to run without it rather than exposing an open
+maintenance endpoint.
+
+The orphan sweep is **report-only by default**: it logs hostnames that still
+route to us but have no hub behind them. Deleting from a zone is irreversible,
+so removal is opt-in:
+
+```
+BDH_RECONCILE_DELETE=true
+```
+
+Only enable this once you have confirmed the zone contains nothing but Marvedge
+hub hostnames.
+
+**Verify:** `curl -H "Authorization: Bearer $CRON_SECRET" https://marvedge.com/api/cron/hub-domains`
+returns `{"success":true,...}`.
+
+---
+
+## 6. Kill switches
+
+BDH is opt-**out**, unlike AVS and WTM — it is already serving traffic, so an
+unset variable keeps it enabled.
+
+| Variable | Effect when `"false"` |
+| --- | --- |
+| `BDH_ENABLED` | Hub settings/domain APIs return 404, the cron no-ops, and the public `/hub/...` pages 404 |
+| `NEXT_PUBLIC_BDH_ENABLED` | Middleware stops hub host routing (every host serves the normal app) and the Branding tab is hidden from Settings |
+
+Set **both** to disable the feature completely. `BDH_ENABLED` is server-only and
+takes effect on restart; `NEXT_PUBLIC_BDH_ENABLED` is inlined at build time and
+needs a redeploy.
+
+Use these to disable the feature without a revert if hub routing misbehaves in
+production.
+
+---
+
+## Plan gating
+
+- **The hub and its Marvedge subdomain are free on every plan** — logo, colours,
+  search, and collections included.
+- **Mapping your own domain requires PRO or ENTERPRISE.** It is the white-label
+  half and the only part with a per-hostname cost to us. This mirrors WTM, where
+  capture is free and the customizable watermark is paid.
+
+An existing custom domain keeps working if a user downgrades; only *changing* it
+is gated. Automatic deprovisioning on downgrade is deliberately not implemented
+— pulling a live customer domain is a product decision, not an engineering one.
+
+---
+
+## Known gaps
+
+Not implemented, and each needs a product decision rather than more code:
+
+- **Demo thumbnails.** There is no thumbnail field on the `Demo` model, so every
+  hub card is an identical placeholder. Real thumbnails need a schema column and
+  poster-frame generation in the export pipeline.
+- **Hub curation lives in the editor's Save dialog.** Tags, integrations, roles
+  and "Featured" are edited there (reopening it on a saved demo updates them in
+  place). There is no bulk curation view on the demo list; that is a UI addition,
+  not a blocker.
+- **"Powered by Marvedge" footer** appears on every hub regardless of plan.
+- **Downgrade deprovisioning** — see above.
+- **Vercel hostname registration for custom domains** — see step 3b.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse, NextFetchEvent } from "next/server";
 import { withAuth } from "next-auth/middleware";
+import { classifyHost, mainAppOrigin } from "@/app/lib/hubDomain";
+import { isBdhRoutingEnabled } from "@/app/lib/bdh/flags";
 
 const authMiddleware = withAuth({
   pages: {
@@ -20,32 +22,16 @@ export default async function middleware(req: NextRequest, event: NextFetchEvent
     return NextResponse.next();
   }
 
-  // 2. Subdomain & Custom domain routing
-  // The apex domain the app itself is served from. Anything that is not this
+  // 2. Subdomain & custom domain routing. Anything that is not the app's own
   // domain (or a dev/preview host) is treated as a customer hub.
-  const rootDomain = process.env.NEXT_PUBLIC_ROOT_DOMAIN || "marvedge.com";
-  const devDomain = "localhost:3000";
+  const { kind, domainKey } = classifyHost(hostname);
 
-  const isMainDomain =
-    hostname === rootDomain ||
-    hostname === `www.${rootDomain}` ||
-    hostname === devDomain ||
-    hostname.endsWith(".vercel.app"); // production + preview deployments
-  const isSubdomain =
-    !isMainDomain &&
-    (hostname.endsWith(`.${rootDomain}`) || hostname.endsWith(`.${devDomain}`));
-
-  if (!isMainDomain) {
-    const domainKey = isSubdomain ? hostname.split(".")[0] : hostname.split(":")[0];
-    console.log(
-      `[Middleware] Subdomain/custom domain detected: "${hostname}" (Key: "${domainKey}"). Rewriting path to /hub/${domainKey}${url.pathname}`
-    );
-
-    // Redirect dashboard or auth pages back to the main domain
+  // Kill switch: with hub routing off, every host serves the normal app.
+  if (kind !== "main" && isBdhRoutingEnabled()) {
+    // Send app-only routes back to the main domain rather than 404ing them
+    // inside a hub.
     if (url.pathname.startsWith("/dashboard") || url.pathname.startsWith("/auth")) {
-      const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-      const targetDomain = hostname.endsWith(`.${devDomain}`) ? devDomain : rootDomain;
-      return NextResponse.redirect(`${protocol}://${targetDomain}${url.pathname}${url.search}`);
+      return NextResponse.redirect(`${mainAppOrigin(hostname)}${url.pathname}${url.search}`);
     }
 
     // Rewrite path to /hub/[domainKey]/...

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   experimental: {
     optimizePackageImports: ["@radix-ui/react-slider", "@headlessui/react"],
   },

--- a/prisma/migrations/20260729000000_add_hub_settings_and_demo_metadata/migration.sql
+++ b/prisma/migrations/20260729000000_add_hub_settings_and_demo_metadata/migration.sql
@@ -1,0 +1,45 @@
+-- Branded Demo Hub (BDH): HubSettings table + Demo taxonomy columns.
+--
+-- These models were added to prisma/schema.prisma in the Branded Demo Hub PR but
+-- no migration was generated, so a database built with `prisma migrate deploy`
+-- has neither the "HubSettings" table nor the Demo metadata columns. Every hub
+-- route (/hub/[domain], /api/hub, /api/hub/verify) and the demo save/patch paths
+-- fail at runtime against such a database.
+--
+-- Written idempotently (IF [NOT] EXISTS / drop-then-add) so it applies cleanly
+-- whether the target DB was built from prior migrations, synced with `db push`
+-- while the feature was in development, or is already fully in sync.
+
+-- Demo taxonomy / curation metadata (BDH-4.3, BDH-4.4)
+ALTER TABLE "Demo" ADD COLUMN IF NOT EXISTS "tags" TEXT[] DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "Demo" ADD COLUMN IF NOT EXISTS "integrations" TEXT[] DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "Demo" ADD COLUMN IF NOT EXISTS "userRoles" TEXT[] DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "Demo" ADD COLUMN IF NOT EXISTS "featured" BOOLEAN NOT NULL DEFAULT false;
+
+-- HubSettings (BDH-4.1 branding, BDH-4.2 subdomain / custom domain hosting)
+CREATE TABLE IF NOT EXISTS "HubSettings" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "subdomain" TEXT,
+    "customDomain" TEXT,
+    "sslStatus" TEXT NOT NULL DEFAULT 'pending',
+    "dnsVerification" JSONB,
+    "logoUrl" TEXT,
+    "brandColor" TEXT NOT NULL DEFAULT '#7C5CFC',
+    "textColor" TEXT NOT NULL DEFAULT '#111827',
+    "accentColor" TEXT NOT NULL DEFAULT '#F3F0FC',
+    "hubTitle" TEXT,
+    "hubDescription" TEXT,
+    "cloudflareId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "HubSettings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "HubSettings_userId_key" ON "HubSettings"("userId");
+CREATE UNIQUE INDEX IF NOT EXISTS "HubSettings_subdomain_key" ON "HubSettings"("subdomain");
+CREATE UNIQUE INDEX IF NOT EXISTS "HubSettings_customDomain_key" ON "HubSettings"("customDomain");
+
+ALTER TABLE "HubSettings" DROP CONSTRAINT IF EXISTS "HubSettings_userId_fkey";
+ALTER TABLE "HubSettings" ADD CONSTRAINT "HubSettings_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/hub-domains",
+      "schedule": "*/15 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION

Review of #254 (feat(branding): implement Branded Demo Hub and custom domain setup) against the BDH PRD. The feature's shape was right, but it shipped with defects that broke curation, leaked across tenants, and could report unprovisioned domains as live.

Correctness

- Hub taxonomy was set-once-at-creation. A pre-existing guard in handleSaveDemo bailed out with "This demo has already been saved!" before reaching the PATCH branch the PR added, making it dead code; the Save button was disabled on top of that. Tags, roles and Featured could never be edited after the first save, which defeats BDH-4.3 and BDH-4.4. Existing demos now take a metadata-only PATCH, leaving the autosave loop's ownership of `editing` intact.
- The save modal sends every taxonomy field, but its metadata fetch failed silently, so a failed load blanked the demo's tags. Stale responses are now ignored, HTTP errors surface, and a failed load blocks the save.
- The 409-conflict path PATCHed only title/description, discarding hub metadata.
- Default subdomains collided: `user-${id.substring(0,8)}` on a cuid is "c" plus 7 of 8 base36 timestamp chars, ~36ms of resolution. Two accounts created in the same window generated the same name and the unique index turned the first hub load into an unrecoverable 500. Added probing, create-race handling, and a clear 409 on the upsert.

Tenancy & production safety

- Branded share pages served any tenant's public demo under another customer's logo and colours; the lookup is now scoped to the hub owner.
- Cloudflare was mocked whenever credentials were absent, including in production, reporting domains as SSL-active with nothing provisioned. Mocking is now non-production only; production fails loudly.
- Account deletion ignored Cloudflare failures: deleteCustomDomain returns {success:false} rather than throwing, so the try/catch never fired and PRD §4.4's orphaned-hostname case passed silently.
- tags/integrations/userRoles reached Postgres TEXT[] unvalidated — non-strings 500'd and unbounded lists shipped to every hub visitor. Extracted app/lib/bdh/taxonomy.ts with trimming, dedup and caps.

Infrastructure

- Added the missing Prisma migration; the PR changed schema.prisma without one, so a database built from `migrate deploy` had neither HubSettings nor the Demo columns, and every hub route failed at runtime.
- Restored typecheck and lint during builds, which the PR had disabled.
- Consolidated hostname logic into app/lib/hubDomain.ts (middleware, settings and hub pages had disagreed), with reserved-subdomain and custom-domain validation.
- Added /api/cron/hub-domains for PRD §4.3's asynchronous verification and §4.4's orphan sweep (report-only unless BDH_RECONCILE_DELETE=true).
- Added BDH kill switches, PRO/ENTERPRISE gating for custom domains only, and closed gating holes (/api/hub/verify, the public hub pages, the Branding tab).
- Counted hub views in SQL instead of loading every view row.

Adds 49 unit tests and docs/branded-demo-hub-deployment.md, which records the remaining infrastructure work: custom domains still need Cloudflare for SaaS enabled and hostnames registered with the hosting platform.