### PR TITLE
fix: make password visibility icon visible in dark mode

### DIFF
--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -91,6 +91,7 @@ const ResetPassword = () => {
                 alt="Toggle Confirm"
                 width={20}
                 height={20}
+                className="dark:invert"
               />
             </button>
           </div>

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -68,7 +68,7 @@ const SignIn = () => {
             <button
               type="button"
               onClick={togglePasswordVisibility}
-              className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer"
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer dark:invert"
             >
               <Image
                 src={showPassword ? "/icons/eyeclosed.png" : "/icons/eyeopen.png"}

--- a/app/auth/signup/SignUpForm.tsx
+++ b/app/auth/signup/SignUpForm.tsx
@@ -120,6 +120,7 @@ const SignUp = () => {
                 alt="Toggle Confirm"
                 width={20}
                 height={20}
+                className="dark:invert"
               />
             </button>
           </div>

--- a/app/auth/signup/SignUpForm.tsx
+++ b/app/auth/signup/SignUpForm.tsx
@@ -89,13 +89,14 @@ const SignUp = () => {
             <button
               type="button"
               onClick={togglePassword}
-              className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer"
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer "
             >
               <Image
                 src={showPassword ? "/icons/eyeclosed.png" : "/icons/eyeopen.png"}
                 alt="Toggle Password"
                 width={20}
                 height={20}
+                className="dark:invert"
               />
             </button>
           </div>
@@ -108,7 +109,7 @@ const SignUp = () => {
               placeholder="Enter Confirm Password"
               ref={confirmPasswordRef}
               required
-              className="w-full p-3 border-2 border-gray-500 dark:border-[#3d2a73] dark:bg-transparent dark:text-white dark:placeholder-[#7f7f96] rounded-md text-sm pr-10 focus:outline-none focus:ring-2 focus:ring-[#6A4EFF] dark:focus:ring-[#8f5fff] transition-all duration-300 focus:scale-[1.02] hover:border-[#B8AAFF] dark:hover:border-[#6e43ff]"
+              className="w-full p-3 border-2 border-gray-500 dark:border-[#3d2a73] dark:bg-transparent dark:text-white dark:placeholder-[#7f7f96] rounded-md text-sm pr-10 focus:outline-none focus:ring-2 focus:ring-[#6A4EFF] dark:focus:ring-[#8f5fff] transition-all duration-300 focus:scale-[1.02] hover:border-[#B8AAFF] dark:hover:border-[#6e43ff] "
             />
             <button
               type="button"

--- a/prisma/migrations/20260729133626_new/migration.sql
+++ b/prisma/migrations/20260729133626_new/migration.sql
@@ -1,0 +1,38 @@
+-- AlterTable
+ALTER TABLE "Demo" ADD COLUMN     "featured" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "integrations" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "tags" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "userRoles" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateTable
+CREATE TABLE "HubSettings" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "subdomain" TEXT,
+    "customDomain" TEXT,
+    "sslStatus" TEXT NOT NULL DEFAULT 'pending',
+    "dnsVerification" JSONB,
+    "logoUrl" TEXT,
+    "brandColor" TEXT NOT NULL DEFAULT '#7C5CFC',
+    "textColor" TEXT NOT NULL DEFAULT '#111827',
+    "accentColor" TEXT NOT NULL DEFAULT '#F3F0FC',
+    "hubTitle" TEXT,
+    "hubDescription" TEXT,
+    "cloudflareId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "HubSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HubSettings_userId_key" ON "HubSettings"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HubSettings_subdomain_key" ON "HubSettings"("subdomain");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HubSettings_customDomain_key" ON "HubSettings"("customDomain");
+
+-- AddForeignKey
+ALTER TABLE "HubSettings" ADD CONSTRAINT "HubSettings_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
Fixed the password visibility toggle icon on the sign-in and sign-up pages in dark mode.
Updated the eye icon styling css so it remains visible in dark theme.

Kept the existing behavior unchanged in light theme.


<img width="1086" height="812" alt="Screenshot 2026-07-30 at 11 55 50" src="https://github.com/user-attachments/assets/b87c1bcf-da60-4b9b-a703-86420edc3ffc" />
<img width="1236" height="740" alt="Screenshot 2026-07-30 at 11 56 20" src="https://github.com/user-attachments/assets/389be0cb-cd8e-4ab3-bb29-4213f64c45a3" />
