### PR TITLE
fix: profile image in dark mode

### DIFF
--- a/app/components/signed-header/UserMenu.tsx
+++ b/app/components/signed-header/UserMenu.tsx
@@ -35,21 +35,21 @@ const UserMenu = ({ session, isDark, profileImage }: UserMenuProps) => {
 
   return (
     <div className="relative" ref={dropdownRef}>
-      <button
+        <button
         className={`avatar user-avatar w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-xs sm:text-lg font-bold shadow cursor-pointer hover:scale-105 transition-all overflow-hidden ${
           isDark ? "border-none" : "border-2 sm:border-4 border-white"
         }`}
         onClick={() => setShowDropdown((v) => !v)}
         title={session?.user?.name || session?.user?.email || undefined}
         style={
-          isDark
-            ? { backgroundColor: "#5b3df5", color: "white" }
-            : profileImage
-              ? {}
+          profileImage
+            ? {}
+            : isDark
+              ? { backgroundColor: "#5b3df5", color: "white"}
               : { backgroundColor: "#7C5CFC", color: "white" }
         }
       >
-        {!isDark && profileImage ? (
+        {profileImage ? (
           <Image
             key={profileImage}
             src={profileImage}


### PR DESCRIPTION
Fixes #270.

Updated the user menu profile image behavior so it remains visible and displays correctly in dark mode.


<img width="459" height="229" alt="Image" src="https://github.com/user-attachments/assets/eb8e06d9-a40c-4ad1-b88c-717cda2fffb0" />